### PR TITLE
Fix toast dismissal delay

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -6,7 +6,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- reduce toast removal delay from 1000000ms to 5000ms so notifications disappear promptly

## Testing
- `npm ci`
- `npm run lint` *(fails: Unexpected any, no-empty-object-type, only-export-components, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_6855c85afae883258a04eb8bca0d069b