### PR TITLE
Fix updateNestedOptions types

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -16,7 +16,7 @@ import { DnDSection } from './sections/DnDSection';
 interface ControlPanelProps {
   options: SoraOptions;
   updateOptions: (updates: Partial<SoraOptions>) => void;
-  updateNestedOptions: (path: string, value: any) => void;
+  updateNestedOptions: (path: string, value: unknown) => void;
 }
 
 export const ControlPanel: React.FC<ControlPanelProps> = ({

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -424,11 +424,11 @@ const Dashboard = () => {
     setOptions(prev => ({ ...prev, ...updates }));
   };
 
-  const updateNestedOptions = (path: string, value: any) => {
+  const updateNestedOptions = (path: string, value: unknown) => {
     setOptions(prev => {
       const newOptions = { ...prev };
       const keys = path.split('.');
-      let current: any = newOptions;
+      let current: Record<string, unknown> = newOptions as Record<string, unknown>;
       
       for (let i = 0; i < keys.length - 1; i++) {
         current[keys[i]] = { ...current[keys[i]] };

--- a/src/components/sections/StyleSection.tsx
+++ b/src/components/sections/StyleSection.tsx
@@ -7,7 +7,7 @@ import { SoraOptions } from '../Dashboard';
 
 interface StyleSectionProps {
   options: SoraOptions;
-  updateNestedOptions: (path: string, value: any) => void;
+  updateNestedOptions: (path: string, value: unknown) => void;
 }
 
 const stylePresets = {


### PR DESCRIPTION
## Summary
- update `updateNestedOptions` prop to accept `unknown`
- adjust `Dashboard.updateNestedOptions` type and variable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856b8151c608325aab5f50e913bfff6