### PR TITLE
Fix quality type casts

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -410,7 +410,9 @@ const Dashboard = () => {
       seed: Math.floor(Math.random() * 10000),
       steps: Math.floor(Math.random() * 31) + 20,
       guidance_scale: Math.random() * 12 + 3,
-      quality: ['defective', 'poor', 'moderate', 'high', 'excellent'][Math.floor(Math.random() * 5)] as any,
+      quality: ['defective', 'poor', 'moderate', 'high', 'excellent'][
+        Math.floor(Math.random() * 5)
+      ] as SoraOptions['quality'],
       temperature: Math.random() * 0.5 + 0.8,
       chaos: Math.random(),
       motion_strength: Math.random(),

--- a/src/components/sections/CoreSettingsSection.tsx
+++ b/src/components/sections/CoreSettingsSection.tsx
@@ -47,7 +47,7 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
         
         <div>
           <Label htmlFor="quality">Quality</Label>
-          <Select value={options.quality} onValueChange={(value) => updateOptions({ quality: value as any })}>
+          <Select value={options.quality} onValueChange={(value) => updateOptions({ quality: value as SoraOptions['quality'] })}>
             <SelectTrigger>
               <SelectValue />
             </SelectTrigger>

--- a/src/components/sections/DimensionsFormatSection.tsx
+++ b/src/components/sections/DimensionsFormatSection.tsx
@@ -78,7 +78,7 @@ export const DimensionsFormatSection: React.FC<DimensionsFormatSectionProps> = (
           <Label htmlFor="quality">Quality</Label>
           <Select
             value={options.quality}
-            onValueChange={(value) => updateOptions({ quality: value as any })}
+            onValueChange={(value) => updateOptions({ quality: value as SoraOptions['quality'] })}
           >
             <SelectTrigger>
               <SelectValue />


### PR DESCRIPTION
## Summary
- cast quality dropdown values to `SoraOptions['quality']`
- typecast randomized quality in `Dashboard` to `SoraOptions['quality']`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856b82020b0832597a66e374f9d2d87