### PR TITLE
Ensure toggles grey out inputs

### DIFF
--- a/src/components/SearchableDropdown.tsx
+++ b/src/components/SearchableDropdown.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -18,6 +18,7 @@ interface SearchableDropdownProps {
   onValueChange: (value: string) => void;
   placeholder?: string;
   label?: string;
+  disabled?: boolean;
 }
 
 export const SearchableDropdown: React.FC<SearchableDropdownProps> = ({
@@ -25,10 +26,17 @@ export const SearchableDropdown: React.FC<SearchableDropdownProps> = ({
   value,
   onValueChange,
   placeholder = "Select option...",
-  label = "Options"
+  label = "Options",
+  disabled = false
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+
+  useEffect(() => {
+    if (disabled) {
+      setIsOpen(false);
+    }
+  }, [disabled]);
 
   const sortedOptions = useMemo(() => {
     const priorityOptions = ['default', 'as is', 'not defined', 'keep original'];
@@ -57,9 +65,13 @@ export const SearchableDropdown: React.FC<SearchableDropdownProps> = ({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+    <Dialog open={isOpen} onOpenChange={(open) => !disabled && setIsOpen(open)}>
       <DialogTrigger asChild>
-        <Button variant="outline" className="w-full justify-between">
+        <Button
+          variant="outline"
+          className="w-full justify-between"
+          disabled={disabled}
+        >
           <span className="truncate">{formatLabel(value)}</span>
           <ChevronDown className="w-4 h-4 ml-2 flex-shrink-0" />
         </Button>
@@ -76,6 +88,7 @@ export const SearchableDropdown: React.FC<SearchableDropdownProps> = ({
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="pl-10"
+              disabled={disabled}
             />
           </div>
           <ScrollArea className="h-[300px]">
@@ -86,6 +99,7 @@ export const SearchableDropdown: React.FC<SearchableDropdownProps> = ({
                   variant={value === option ? "default" : "ghost"}
                   className="w-full justify-start text-left h-auto py-2 px-3"
                   onClick={() => handleSelect(option)}
+                  disabled={disabled}
                 >
                   <span className="break-words">{formatLabel(option)}</span>
                 </Button>

--- a/src/components/sections/CameraCompositionSection.tsx
+++ b/src/components/sections/CameraCompositionSection.tsx
@@ -82,17 +82,16 @@ export const CameraCompositionSection: React.FC<CameraCompositionSectionProps> =
           <Label htmlFor="use_camera_angle">Use Camera Angle</Label>
         </div>
 
-        {options.use_camera_angle && (
-          <div>
-            <Label>Camera Angle</Label>
-            <SearchableDropdown
-              options={cameraAngleOptions}
-              value={options.camera_angle}
-              onValueChange={(value) => updateOptions({ camera_angle: value })}
-              label="Camera Angle"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Camera Angle</Label>
+          <SearchableDropdown
+            options={cameraAngleOptions}
+            value={options.camera_angle}
+            onValueChange={(value) => updateOptions({ camera_angle: value })}
+            label="Camera Angle"
+            disabled={!options.use_camera_angle}
+          />
+        </div>
 
         <div>
           <Label htmlFor="subject_focus">Subject Focus</Label>

--- a/src/components/sections/DimensionsFormatSection.tsx
+++ b/src/components/sections/DimensionsFormatSection.tsx
@@ -102,28 +102,28 @@ export const DimensionsFormatSection: React.FC<DimensionsFormatSectionProps> = (
           <Label htmlFor="use_dimensions">Use Custom Dimensions</Label>
         </div>
 
-        {options.use_dimensions && (
-          <>
-            <div>
-              <Label htmlFor="width">Width</Label>
-              <Input
-                id="width"
-                type="number"
-                value={options.width || 1024}
-                onChange={(e) => updateOptions({ width: parseInt(e.target.value) })}
-              />
-            </div>
-            <div>
-              <Label htmlFor="height">Height</Label>
-              <Input
-                id="height"
-                type="number"
-                value={options.height || 576}
-                onChange={(e) => updateOptions({ height: parseInt(e.target.value) })}
-              />
-            </div>
-          </>
-        )}
+        <>
+          <div>
+            <Label htmlFor="width">Width</Label>
+            <Input
+              id="width"
+              type="number"
+              value={options.width || 1024}
+              onChange={(e) => updateOptions({ width: parseInt(e.target.value) })}
+              disabled={!options.use_dimensions}
+            />
+          </div>
+          <div>
+            <Label htmlFor="height">Height</Label>
+            <Input
+              id="height"
+              type="number"
+              value={options.height || 576}
+              onChange={(e) => updateOptions({ height: parseInt(e.target.value) })}
+              disabled={!options.use_dimensions}
+            />
+          </div>
+        </>
 
         <div>
           <Label htmlFor="output_format">Output Format</Label>

--- a/src/components/sections/DnDSection.tsx
+++ b/src/components/sections/DnDSection.tsx
@@ -79,17 +79,16 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <Label htmlFor="use_character_race">Use Character Race</Label>
         </div>
 
-        {options.use_character_race && (
-          <div>
-            <Label>Character Race</Label>
-            <SearchableDropdown
-              options={characterRaceOptions}
-              value={options.character_race || 'human'}
-              onValueChange={(value) => updateOptions({ character_race: value })}
-              label="Character Race Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Character Race</Label>
+          <SearchableDropdown
+            options={characterRaceOptions}
+            value={options.character_race || 'human'}
+            onValueChange={(value) => updateOptions({ character_race: value })}
+            label="Character Race Options"
+            disabled={!options.use_character_race}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -100,17 +99,16 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <Label htmlFor="use_character_class">Use Character Class</Label>
         </div>
 
-        {options.use_character_class && (
-          <div>
-            <Label>Character Class</Label>
-            <SearchableDropdown
-              options={characterClassOptions}
-              value={options.character_class || 'fighter'}
-              onValueChange={(value) => updateOptions({ character_class: value })}
-              label="Character Class Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Character Class</Label>
+          <SearchableDropdown
+            options={characterClassOptions}
+            value={options.character_class || 'fighter'}
+            onValueChange={(value) => updateOptions({ character_class: value })}
+            label="Character Class Options"
+            disabled={!options.use_character_class}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -121,17 +119,16 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <Label htmlFor="use_character_background">Use Character Background</Label>
         </div>
 
-        {options.use_character_background && (
-          <div>
-            <Label>Character Background</Label>
-            <SearchableDropdown
-              options={characterBackgroundOptions}
-              value={options.character_background || 'soldier'}
-              onValueChange={(value) => updateOptions({ character_background: value })}
-              label="Character Background Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Character Background</Label>
+          <SearchableDropdown
+            options={characterBackgroundOptions}
+            value={options.character_background || 'soldier'}
+            onValueChange={(value) => updateOptions({ character_background: value })}
+            label="Character Background Options"
+            disabled={!options.use_character_background}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -142,17 +139,16 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <Label htmlFor="use_character_alignment">Use Character Alignment</Label>
         </div>
 
-        {options.use_character_alignment && (
-          <div>
-            <Label>Character Alignment</Label>
-            <SearchableDropdown
-              options={characterAlignmentOptions}
-              value={options.character_alignment || 'lawful good'}
-              onValueChange={(value) => updateOptions({ character_alignment: value })}
-              label="Character Alignment Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Character Alignment</Label>
+          <SearchableDropdown
+            options={characterAlignmentOptions}
+            value={options.character_alignment || 'lawful good'}
+            onValueChange={(value) => updateOptions({ character_alignment: value })}
+            label="Character Alignment Options"
+            disabled={!options.use_character_alignment}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -163,17 +159,16 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <Label htmlFor="use_monster_type">Use Monster Type</Label>
         </div>
 
-        {options.use_monster_type && (
-          <div>
-            <Label>Monster Type</Label>
-            <SearchableDropdown
-              options={monsterTypeOptions}
-              value={options.monster_type || 'dragon'}
-              onValueChange={(value) => updateOptions({ monster_type: value })}
-              label="Monster Type Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Monster Type</Label>
+          <SearchableDropdown
+            options={monsterTypeOptions}
+            value={options.monster_type || 'dragon'}
+            onValueChange={(value) => updateOptions({ monster_type: value })}
+            label="Monster Type Options"
+            disabled={!options.use_monster_type}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -184,17 +179,16 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <Label htmlFor="use_dnd_environment">Use D&D Environment</Label>
         </div>
 
-        {options.use_dnd_environment && (
-          <div>
-            <Label>D&D Environment</Label>
-            <SearchableDropdown
-              options={dndEnvironmentOptions}
-              value={options.dnd_environment || 'dungeon'}
-              onValueChange={(value) => updateOptions({ dnd_environment: value })}
-              label="D&D Environment Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>D&D Environment</Label>
+          <SearchableDropdown
+            options={dndEnvironmentOptions}
+            value={options.dnd_environment || 'dungeon'}
+            onValueChange={(value) => updateOptions({ dnd_environment: value })}
+            label="D&D Environment Options"
+            disabled={!options.use_dnd_environment}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -205,17 +199,16 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <Label htmlFor="use_magic_school">Use Magic School</Label>
         </div>
 
-        {options.use_magic_school && (
-          <div>
-            <Label>Magic School</Label>
-            <SearchableDropdown
-              options={magicSchoolOptions}
-              value={options.magic_school || 'evocation'}
-              onValueChange={(value) => updateOptions({ magic_school: value })}
-              label="Magic School Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Magic School</Label>
+          <SearchableDropdown
+            options={magicSchoolOptions}
+            value={options.magic_school || 'evocation'}
+            onValueChange={(value) => updateOptions({ magic_school: value })}
+            label="Magic School Options"
+            disabled={!options.use_magic_school}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -226,17 +219,16 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <Label htmlFor="use_item_type">Use Item Type</Label>
         </div>
 
-        {options.use_item_type && (
-          <div>
-            <Label>Item Type</Label>
-            <SearchableDropdown
-              options={itemTypeOptions}
-              value={options.item_type || 'magic sword'}
-              onValueChange={(value) => updateOptions({ item_type: value })}
-              label="Item Type Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Item Type</Label>
+          <SearchableDropdown
+            options={itemTypeOptions}
+            value={options.item_type || 'magic sword'}
+            onValueChange={(value) => updateOptions({ item_type: value })}
+            label="Item Type Options"
+            disabled={!options.use_item_type}
+          />
+        </div>
       </div>
     </CollapsibleSection>
   );

--- a/src/components/sections/EnhancementsSection.tsx
+++ b/src/components/sections/EnhancementsSection.tsx
@@ -74,17 +74,16 @@ export const EnhancementsSection: React.FC<EnhancementsSectionProps> = ({
           <Label htmlFor="use_safety_filter">Use Safety Filter</Label>
         </div>
 
-        {options.use_safety_filter && (
-          <div>
-            <Label>Safety Filter</Label>
-            <SearchableDropdown
-              options={safetyFilterOptions}
-              value={options.safety_filter || 'default (auto safety level)'}
-              onValueChange={(value) => updateOptions({ safety_filter: value })}
-              label="Safety Filter Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Safety Filter</Label>
+          <SearchableDropdown
+            options={safetyFilterOptions}
+            value={options.safety_filter || 'default (auto safety level)'}
+            onValueChange={(value) => updateOptions({ safety_filter: value })}
+            label="Safety Filter Options"
+            disabled={!options.use_safety_filter}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -104,17 +103,16 @@ export const EnhancementsSection: React.FC<EnhancementsSectionProps> = ({
           <Label htmlFor="use_quality_booster">Use Quality Booster</Label>
         </div>
 
-        {options.use_quality_booster && (
-          <div>
-            <Label>Quality Booster</Label>
-            <SearchableDropdown
-              options={qualityBoosterOptions}
-              value={options.quality_booster || 'default (standard quality)'}
-              onValueChange={(value) => updateOptions({ quality_booster: value })}
-              label="Quality Booster Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Quality Booster</Label>
+          <SearchableDropdown
+            options={qualityBoosterOptions}
+            value={options.quality_booster || 'default (standard quality)'}
+            onValueChange={(value) => updateOptions({ quality_booster: value })}
+            label="Quality Booster Options"
+            disabled={!options.use_quality_booster}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox

--- a/src/components/sections/FaceSection.tsx
+++ b/src/components/sections/FaceSection.tsx
@@ -93,17 +93,16 @@ export const FaceSection: React.FC<FaceSectionProps> = ({
           <Label htmlFor="use_subject_gender">Use Subject Gender</Label>
         </div>
 
-        {options.use_subject_gender && (
-          <div>
-            <Label>Subject Gender</Label>
-            <SearchableDropdown
-              options={subjectGenderOptions}
-              value={options.subject_gender || 'default (auto/inferred gender)'}
-              onValueChange={(value) => updateOptions({ subject_gender: value })}
-              label="Subject Gender Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Subject Gender</Label>
+          <SearchableDropdown
+            options={subjectGenderOptions}
+            value={options.subject_gender || 'default (auto/inferred gender)'}
+            onValueChange={(value) => updateOptions({ subject_gender: value })}
+            label="Subject Gender Options"
+            disabled={!options.use_subject_gender}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -114,17 +113,16 @@ export const FaceSection: React.FC<FaceSectionProps> = ({
           <Label htmlFor="use_makeup_style">Use Makeup Style</Label>
         </div>
 
-        {options.use_makeup_style && (
-          <div>
-            <Label>Makeup Style</Label>
-            <SearchableDropdown
-              options={makeupStyleOptions}
-              value={options.makeup_style || 'default (no specific makeup)'}
-              onValueChange={(value) => updateOptions({ makeup_style: value })}
-              label="Makeup Style Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Makeup Style</Label>
+          <SearchableDropdown
+            options={makeupStyleOptions}
+            value={options.makeup_style || 'default (no specific makeup)'}
+            onValueChange={(value) => updateOptions({ makeup_style: value })}
+            label="Makeup Style Options"
+            disabled={!options.use_makeup_style}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -135,17 +133,16 @@ export const FaceSection: React.FC<FaceSectionProps> = ({
           <Label htmlFor="use_character_mood">Use Character Mood</Label>
         </div>
 
-        {options.use_character_mood && (
-          <div>
-            <Label>Character Mood</Label>
-            <SearchableDropdown
-              options={characterMoodOptions}
-              value={options.character_mood || 'default (neutral mood)'}
-              onValueChange={(value) => updateOptions({ character_mood: value })}
-              label="Character Mood Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Character Mood</Label>
+          <SearchableDropdown
+            options={characterMoodOptions}
+            value={options.character_mood || 'default (neutral mood)'}
+            onValueChange={(value) => updateOptions({ character_mood: value })}
+            label="Character Mood Options"
+            disabled={!options.use_character_mood}
+          />
+        </div>
       </div>
     </CollapsibleSection>
   );

--- a/src/components/sections/MaterialSection.tsx
+++ b/src/components/sections/MaterialSection.tsx
@@ -78,17 +78,16 @@ export const MaterialSection: React.FC<MaterialSectionProps> = ({
           <Label htmlFor="use_secondary_material">Use Secondary Material</Label>
         </div>
 
-        {options.use_secondary_material && (
-          <div>
-            <Label>Secondary Material</Label>
-            <SearchableDropdown
-              options={materialOptions}
-              value={options.secondary_material || 'default'}
-              onValueChange={(value) => updateOptions({ secondary_material: value })}
-              label="Secondary Material Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Secondary Material</Label>
+          <SearchableDropdown
+            options={materialOptions}
+            value={options.secondary_material || 'default'}
+            onValueChange={(value) => updateOptions({ secondary_material: value })}
+            label="Secondary Material Options"
+            disabled={!options.use_secondary_material}
+          />
+        </div>
       </div>
     </CollapsibleSection>
   );

--- a/src/components/sections/SettingsLocationSection.tsx
+++ b/src/components/sections/SettingsLocationSection.tsx
@@ -147,17 +147,16 @@ export const SettingsLocationSection: React.FC<SettingsLocationSectionProps> = (
           <Label htmlFor="use_environment">Use Environment</Label>
         </div>
 
-        {options.use_environment && (
-          <div className="md:col-span-2">
-            <Label>Environment</Label>
-            <SearchableDropdown
-              options={environmentOptions}
-              value={options.environment}
-              onValueChange={(value) => updateOptions({ environment: value })}
-              label="Environment Options"
-            />
-          </div>
-        )}
+        <div className="md:col-span-2">
+          <Label>Environment</Label>
+          <SearchableDropdown
+            options={environmentOptions}
+            value={options.environment}
+            onValueChange={(value) => updateOptions({ environment: value })}
+            label="Environment Options"
+            disabled={!options.use_environment}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -168,17 +167,16 @@ export const SettingsLocationSection: React.FC<SettingsLocationSectionProps> = (
           <Label htmlFor="use_location">Use Location</Label>
         </div>
 
-        {options.use_location && (
-          <div className="md:col-span-2">
-            <Label>Location</Label>
-            <SearchableDropdown
-              options={locationOptions}
-              value={options.location || 'Berlin, Germany'}
-              onValueChange={(value) => updateOptions({ location: value })}
-              label="Location Options"
-            />
-          </div>
-        )}
+        <div className="md:col-span-2">
+          <Label>Location</Label>
+          <SearchableDropdown
+            options={locationOptions}
+            value={options.location || 'Berlin, Germany'}
+            onValueChange={(value) => updateOptions({ location: value })}
+            label="Location Options"
+            disabled={!options.use_location}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -189,17 +187,16 @@ export const SettingsLocationSection: React.FC<SettingsLocationSectionProps> = (
           <Label htmlFor="use_season">Use Season</Label>
         </div>
 
-        {options.use_season && (
-          <div>
-            <Label>Season</Label>
-            <SearchableDropdown
-              options={seasonOptions}
-              value={options.season || 'default (any season)'}
-              onValueChange={(value) => updateOptions({ season: value })}
-              label="Season Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Season</Label>
+          <SearchableDropdown
+            options={seasonOptions}
+            value={options.season || 'default (any season)'}
+            onValueChange={(value) => updateOptions({ season: value })}
+            label="Season Options"
+            disabled={!options.use_season}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -210,17 +207,16 @@ export const SettingsLocationSection: React.FC<SettingsLocationSectionProps> = (
           <Label htmlFor="use_atmosphere_mood">Use Atmosphere Mood</Label>
         </div>
 
-        {options.use_atmosphere_mood && (
-          <div>
-            <Label>Atmosphere Mood</Label>
-            <SearchableDropdown
-              options={atmosphereMoodOptions}
-              value={options.atmosphere_mood || 'default (neutral mood)'}
-              onValueChange={(value) => updateOptions({ atmosphere_mood: value })}
-              label="Atmosphere Mood Options"
-            />
-          </div>
-        )}
+        <div>
+          <Label>Atmosphere Mood</Label>
+          <SearchableDropdown
+            options={atmosphereMoodOptions}
+            value={options.atmosphere_mood || 'default (neutral mood)'}
+            onValueChange={(value) => updateOptions({ atmosphere_mood: value })}
+            label="Atmosphere Mood Options"
+            disabled={!options.use_atmosphere_mood}
+          />
+        </div>
       </div>
     </CollapsibleSection>
   );

--- a/src/components/sections/VideoMotionSection.tsx
+++ b/src/components/sections/VideoMotionSection.tsx
@@ -38,19 +38,18 @@ export const VideoMotionSection: React.FC<VideoMotionSectionProps> = ({
           <Label htmlFor="use_duration">Use Duration</Label>
         </div>
 
-        {options.use_duration && (
-          <div>
-            <Label htmlFor="duration_seconds">Duration (seconds)</Label>
-            <Input
-              id="duration_seconds"
-              type="number"
-              value={options.duration_seconds}
-              onChange={(e) => updateOptions({ duration_seconds: parseInt(e.target.value) })}
-              min="1"
-              max="30"
-            />
-          </div>
-        )}
+        <div>
+          <Label htmlFor="duration_seconds">Duration (seconds)</Label>
+          <Input
+            id="duration_seconds"
+            type="number"
+            value={options.duration_seconds}
+            onChange={(e) => updateOptions({ duration_seconds: parseInt(e.target.value) })}
+            min="1"
+            max="30"
+            disabled={!options.use_duration}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox


### PR DESCRIPTION
## Summary
- add a `disabled` prop to `SearchableDropdown`
- keep dropdowns/inputs visible but disabled when feature flags are off
- close dropdown when disabled

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856bc01b1f483259dcdeccc77652ea6