### PR TITLE
Fix share modal title

### DIFF
--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -57,7 +57,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({ isOpen, onClose, jsonCon
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Share Your Sora Configuration</DialogTitle>
+          <DialogTitle>Share your JSON prompt</DialogTitle>
         </DialogHeader>
         <div className="grid grid-cols-2 gap-4 py-4">
           <Button onClick={shareToFacebook} variant="outline" className="gap-2">


### PR DESCRIPTION
## Summary
- update the share dialog title to say "Share your JSON prompt"

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856bd3c4b888325b1670426e81d415a