### PR TITLE
Add Upscale Factor slider

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -263,6 +263,9 @@ const Dashboard = () => {
       delete cleanOptions.sword_type;
       delete cleanOptions.sword_vibe;
     }
+    if (!options.use_upscale_factor) {
+      delete cleanOptions.upscale;
+    }
     
     // Remove control flags from final JSON
     delete cleanOptions.use_dimensions;

--- a/src/components/sections/EnhancementsSection.tsx
+++ b/src/components/sections/EnhancementsSection.tsx
@@ -4,6 +4,7 @@ import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { SearchableDropdown } from '../SearchableDropdown';
 import { CollapsibleSection } from '../CollapsibleSection';
+import { Slider } from '@/components/ui/slider';
 import { SoraOptions } from '../Dashboard';
 
 interface EnhancementsSectionProps {
@@ -64,6 +65,20 @@ export const EnhancementsSection: React.FC<EnhancementsSectionProps> = ({
           />
           <Label htmlFor="use_upscale_factor">Use Upscale Factor</Label>
         </div>
+
+        {options.use_upscale_factor && (
+          <div>
+            <Label htmlFor="upscale">Upscale Factor: {options.upscale}</Label>
+            <Slider
+              value={[options.upscale]}
+              onValueChange={(value) => updateOptions({ upscale: value[0] })}
+              min={1}
+              max={4}
+              step={0.1}
+              className="mt-2"
+            />
+          </div>
+        )}
 
         <div className="flex items-center space-x-2">
           <Checkbox


### PR DESCRIPTION
## Summary
- show slider when enabling `Use Upscale Factor`
- omit `upscale` from the JSON output when the feature is disabled

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856bc9d5d1083258f29edd05e0beba5