### PR TITLE
Add toggle for DnD section

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -75,9 +75,11 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
         onToggle={(enabled) => updateOptions({ use_enhancement_safety: enabled })}
       />
       
-      <DnDSection 
-        options={options} 
+      <DnDSection
+        options={options}
         updateOptions={updateOptions}
+        isEnabled={options.use_dnd_section}
+        onToggle={(enabled) => updateOptions({ use_dnd_section: enabled })}
       />
     </div>
   );

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -102,6 +102,7 @@ export interface SoraOptions {
   special_effects?: string[];
   use_lut_preset: boolean;
   lut_preset?: string;
+  use_dnd_section: boolean;
   use_dnd_character_race: boolean;
   dnd_character_race?: string;
   use_dnd_character_class: boolean;
@@ -210,6 +211,7 @@ const Dashboard = () => {
     use_location: false,
     use_special_effects: false,
     use_lut_preset: false,
+    use_dnd_section: false,
     use_dnd_character_race: false,
     use_dnd_character_class: false,
     use_dnd_character_background: false,
@@ -263,6 +265,16 @@ const Dashboard = () => {
       delete cleanOptions.sword_type;
       delete cleanOptions.sword_vibe;
     }
+    if (!options.use_dnd_section) {
+      delete cleanOptions.dnd_character_race;
+      delete cleanOptions.dnd_character_class;
+      delete cleanOptions.dnd_character_background;
+      delete cleanOptions.dnd_character_alignment;
+      delete cleanOptions.dnd_monster_type;
+      delete cleanOptions.dnd_environment;
+      delete cleanOptions.dnd_magic_school;
+      delete cleanOptions.dnd_item_type;
+    }
     
     // Remove control flags from final JSON
     delete cleanOptions.use_dimensions;
@@ -273,6 +285,7 @@ const Dashboard = () => {
     delete cleanOptions.use_atmosphere_mood;
     delete cleanOptions.use_subject_mood;
     delete cleanOptions.use_sword_type;
+    delete cleanOptions.use_dnd_section;
     
     setJsonString(JSON.stringify(cleanOptions, null, 2));
   }, [options]);
@@ -380,6 +393,7 @@ const Dashboard = () => {
       use_location: false,
       use_special_effects: false,
       use_lut_preset: false,
+      use_dnd_section: false,
       use_dnd_character_race: false,
       use_dnd_character_class: false,
       use_dnd_character_background: false,

--- a/src/components/sections/DnDSection.tsx
+++ b/src/components/sections/DnDSection.tsx
@@ -9,6 +9,8 @@ import { SoraOptions } from '../Dashboard';
 interface DnDSectionProps {
   options: SoraOptions;
   updateOptions: (updates: Partial<SoraOptions>) => void;
+  isEnabled: boolean;
+  onToggle: (enabled: boolean) => void;
 }
 
 const characterRaceOptions = [
@@ -65,10 +67,17 @@ const itemTypeOptions = [
 
 export const DnDSection: React.FC<DnDSectionProps> = ({
   options,
-  updateOptions
+  updateOptions,
+  isEnabled,
+  onToggle
 }) => {
   return (
-    <CollapsibleSection title="Dungeons & Dragons">
+    <CollapsibleSection
+      title="Dungeons & Dragons"
+      isOptional={true}
+      isEnabled={isEnabled}
+      onToggle={onToggle}
+    >
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="flex items-center space-x-2">
           <Checkbox


### PR DESCRIPTION
## Summary
- make the Dungeons & Dragons section optional via checkbox
- support new `use_dnd_section` flag in dashboard state
- clean up DnD fields when the section is disabled

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856bce4dbc48325b36bfd04a7be8d04