### PR TITLE
Order quality options by quality level

### DIFF
--- a/src/components/sections/CoreSettingsSection.tsx
+++ b/src/components/sections/CoreSettingsSection.tsx
@@ -15,10 +15,10 @@ interface CoreSettingsSectionProps {
 }
 
 const qualityOptions = [
-  'defective', 'unacceptable', 'poor', 'bad', 'below standard', 
-  'minimum', 'moderate', 'medium', 'draft', 'standard', 
-  'good', 'high', 'excellent', 'ultra', 'maximum', 'low'
-].sort();
+  'maximum', 'ultra', 'excellent', 'high', 'good', 'standard',
+  'draft', 'medium', 'moderate', 'minimum', 'low',
+  'below standard', 'bad', 'poor', 'unacceptable', 'defective'
+];
 
 export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
   options,

--- a/src/components/sections/DimensionsFormatSection.tsx
+++ b/src/components/sections/DimensionsFormatSection.tsx
@@ -21,23 +21,23 @@ export const DimensionsFormatSection: React.FC<DimensionsFormatSectionProps> = (
   onToggle
 }) => {
   const qualityOptions = [
-    'defective',
-    'unacceptable', 
-    'poor',
-    'bad',
-    'below standard',
-    'minimum',
-    'moderate',
-    'medium',
-    'draft',
-    'standard',
-    'good',
-    'high',
-    'excellent',
-    'ultra',
     'maximum',
-    'low'
-  ].sort();
+    'ultra',
+    'excellent',
+    'high',
+    'good',
+    'standard',
+    'draft',
+    'medium',
+    'moderate',
+    'minimum',
+    'low',
+    'below standard',
+    'bad',
+    'poor',
+    'unacceptable',
+    'defective'
+  ];
 
   const formatLabel = (value: string) => {
     return value.split(' ').map(word => 


### PR DESCRIPTION
## Summary
- arrange quality options from best to worst instead of alphabetically

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856c6600100832582d21de840b61302