### PR TITLE
Make camera and composition section optional

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -44,7 +44,12 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
       
       <StyleSection options={options} updateNestedOptions={updateNestedOptions} />
       
-      <CameraCompositionSection options={options} updateOptions={updateOptions} />
+      <CameraCompositionSection
+        options={options}
+        updateOptions={updateOptions}
+        isEnabled={options.use_camera_composition}
+        onToggle={(enabled) => updateOptions({ use_camera_composition: enabled })}
+      />
       
       <VideoMotionSection 
         options={options} 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -124,6 +124,7 @@ export interface SoraOptions {
   use_aperture: boolean;
   use_dof: boolean;
   use_blur_style: boolean;
+  use_camera_composition: boolean;
   extended_motion_strength: boolean;
   extended_fps: boolean;
   use_duration: boolean;
@@ -220,6 +221,7 @@ const Dashboard = () => {
     use_dnd_environment: false,
     use_dnd_magic_school: false,
     use_dnd_item_type: false,
+    use_camera_composition: true,
     use_camera_angle: false,
     use_lens_type: false,
     use_aperture: false,
@@ -270,6 +272,13 @@ const Dashboard = () => {
       delete cleanOptions.secondary_material;
     } else if (!options.use_secondary_material) {
       delete cleanOptions.secondary_material;
+    }
+
+    if (!options.use_camera_composition) {
+      delete cleanOptions.camera_angle;
+      delete cleanOptions.shot_type;
+      delete cleanOptions.subject_focus;
+      delete cleanOptions.composition_rules;
     }
 
     if (!options.use_motion_animation) {
@@ -362,6 +371,7 @@ const Dashboard = () => {
     delete cleanOptions.use_atmosphere_mood;
     delete cleanOptions.use_subject_mood;
     delete cleanOptions.use_sword_type;
+    delete cleanOptions.use_camera_composition;
     
     setJsonString(JSON.stringify(cleanOptions, null, 2));
   }, [options]);
@@ -478,6 +488,7 @@ const Dashboard = () => {
       use_dnd_environment: false,
       use_dnd_magic_school: false,
       use_dnd_item_type: false,
+      use_camera_composition: true,
       use_camera_angle: false,
       use_lens_type: false,
       use_aperture: false,

--- a/src/components/sections/CameraCompositionSection.tsx
+++ b/src/components/sections/CameraCompositionSection.tsx
@@ -11,6 +11,8 @@ import { SoraOptions } from '../Dashboard';
 interface CameraCompositionSectionProps {
   options: SoraOptions;
   updateOptions: (updates: Partial<SoraOptions>) => void;
+  isEnabled: boolean;
+  onToggle: (enabled: boolean) => void;
 }
 
 const shotTypeOptions = [
@@ -55,14 +57,21 @@ const compositionRulesOptions = [
 
 export const CameraCompositionSection: React.FC<CameraCompositionSectionProps> = ({
   options,
-  updateOptions
+  updateOptions,
+  isEnabled,
+  onToggle
 }) => {
   const handleCompositionRulesChange = (selectedRules: string[]) => {
     updateOptions({ composition_rules: selectedRules });
   };
 
   return (
-    <CollapsibleSection title="Camera & Composition">
+    <CollapsibleSection
+      title="Camera & Composition"
+      isOptional={true}
+      isEnabled={isEnabled}
+      onToggle={onToggle}
+    >
       <div className="grid grid-cols-1 gap-4">
         <div>
           <Label>Shot Type</Label>


### PR DESCRIPTION
## Summary
- add a `use_camera_composition` flag to `SoraOptions`
- allow toggling the Camera & Composition section
- drop camera fields from JSON when disabled

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856c67c8a1483259ee43ceada788cea