### PR TITLE
Replace old product name in dashboard header

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -593,7 +593,7 @@ const Dashboard = () => {
         <div className="mb-8">
           <h1 className="text-4xl font-bold mb-2 flex items-center gap-3">
             <Sparkles className="w-10 h-10 text-purple-500" />
-            Sora Prompt Generator
+            Sora JSON Prompt Crafter
           </h1>
           <p className="text-muted-foreground">Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.</p>
         </div>


### PR DESCRIPTION
## Summary
- rename "Sora Prompt Generator" heading to "Sora JSON Prompt Crafter" in Dashboard

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856d15b25348325995c0494b1233919