### PR TITLE
Remove clip skip from JSON generation

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -25,7 +25,6 @@ export interface SoraOptions {
   };
   quality: 'defective' | 'unacceptable' | 'poor' | 'bad' | 'below standard' | 'minimum' | 'moderate' | 'medium' | 'draft' | 'standard' | 'good' | 'high' | 'excellent' | 'ultra' | 'maximum' | 'low';
   temperature: number;
-  clip_skip: number;
   batch_size: number;
   image_count: number;
   dynamic_range: 'SDR' | 'HDR';
@@ -150,7 +149,6 @@ const Dashboard = () => {
     },
     quality: 'high',
     temperature: 1.1,
-    clip_skip: 2,
     batch_size: 1,
     image_count: 4,
     dynamic_range: 'HDR',
@@ -463,7 +461,6 @@ const Dashboard = () => {
       },
       quality: 'high',
       temperature: 1.1,
-      clip_skip: 2,
       batch_size: 1,
       image_count: 4,
       dynamic_range: 'HDR',


### PR DESCRIPTION
## Summary
- eliminate `clip_skip` from `SoraOptions`
- drop references in default and reset option objects

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856d3a15e188325bbf50f6dc5af8599