### PR TITLE
Remove batch size option

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -26,7 +26,6 @@ export interface SoraOptions {
   quality: 'defective' | 'unacceptable' | 'poor' | 'bad' | 'below standard' | 'minimum' | 'moderate' | 'medium' | 'draft' | 'standard' | 'good' | 'high' | 'excellent' | 'ultra' | 'maximum' | 'low';
   temperature: number;
   clip_skip: number;
-  batch_size: number;
   image_count: number;
   dynamic_range: 'SDR' | 'HDR';
   output_format: 'png' | 'jpg' | 'webp';
@@ -151,7 +150,6 @@ const Dashboard = () => {
     quality: 'high',
     temperature: 1.1,
     clip_skip: 2,
-    batch_size: 1,
     image_count: 4,
     dynamic_range: 'HDR',
     output_format: 'png',
@@ -464,7 +462,6 @@ const Dashboard = () => {
       quality: 'high',
       temperature: 1.1,
       clip_skip: 2,
-      batch_size: 1,
       image_count: 4,
       dynamic_range: 'HDR',
       output_format: 'png',


### PR DESCRIPTION
## Summary
- remove unused batch size property from Sora options

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856d39081a8832585298b8cca919f21