### PR TITLE
Remove face enhancement flag from JSON output

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -44,7 +44,6 @@ export interface SoraOptions {
   depth_of_field: string;
   lens: string;
   frame_interpolation: 'smooth' | 'realistic' | 'sharp';
-  face_enhance: boolean;
   upscale: number;
   safety_filter: 'strict' | 'moderate' | 'off';
   nsfw: boolean;
@@ -169,7 +168,6 @@ const Dashboard = () => {
     depth_of_field: 'shallow',
     lens: 'anamorphic',
     frame_interpolation: 'smooth',
-    face_enhance: false,
     upscale: 2,
     safety_filter: 'moderate',
     nsfw: false,
@@ -482,7 +480,6 @@ const Dashboard = () => {
       depth_of_field: 'shallow',
       lens: 'anamorphic',
       frame_interpolation: 'smooth',
-      face_enhance: false,
       upscale: 2,
       safety_filter: 'moderate',
       nsfw: false,


### PR DESCRIPTION
## Summary
- drop `face_enhance` from `SoraOptions`
- update default and reset options accordingly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856d3e005188325a2777ade23a41272