### PR TITLE
Fix heading for generated JSON

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -619,7 +619,7 @@ const Dashboard = () => {
             <CardHeader className="border-b">
               <CardTitle className="flex items-center gap-2">
                 <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-                Sora JSON Prompt
+                Generated JSON Prompt
               </CardTitle>
             </CardHeader>
             <CardContent className="flex-1 p-0 overflow-hidden">


### PR DESCRIPTION
## Summary
- update UI heading to clarify the generated prompt name

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856d6c5a4b083259953a6d4883fc6eb