### PR TITLE
Remove chaos and nsfw fields

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -43,8 +43,6 @@ export interface SoraOptions {
   frame_interpolation: 'smooth' | 'realistic' | 'sharp';
   upscale: number;
   safety_filter: 'strict' | 'moderate' | 'off';
-  nsfw: boolean;
-  chaos: number;
   made_out_of: string;
   environment: string;
   use_signature: boolean;
@@ -130,7 +128,7 @@ export interface SoraOptions {
 const Dashboard = () => {
   const [options, setOptions] = useState<SoraOptions>({
     prompt: 'A breathtaking cinematic scene of a futuristic city at sunset, flying cars zipping between glass skyscrapers, vibrant colors, ultra-detailed, 8K, masterful lighting, trending on ArtStation',
-    negative_prompt: 'blurry, low-res, dark, extra limbs, cropped, watermark, text, signature, logo, nsfw',
+    negative_prompt: 'blurry, low-res, dark, extra limbs, cropped, watermark, text, signature, logo',
     seed: 1337,
     steps: 30,
     guidance_scale: 7.5,
@@ -164,8 +162,6 @@ const Dashboard = () => {
     frame_interpolation: 'smooth',
     upscale: 2,
     safety_filter: 'moderate',
-    nsfw: false,
-    chaos: 0.1,
     made_out_of: 'default',
     environment: 'default',
     use_signature: false,
@@ -445,7 +441,7 @@ const Dashboard = () => {
     // Reset to default options
     setOptions({
       prompt: 'A breathtaking cinematic scene of a futuristic city at sunset, flying cars zipping between glass skyscrapers, vibrant colors, ultra-detailed, 8K, masterful lighting, trending on ArtStation',
-      negative_prompt: 'blurry, low-res, dark, extra limbs, cropped, watermark, text, signature, logo, nsfw',
+      negative_prompt: 'blurry, low-res, dark, extra limbs, cropped, watermark, text, signature, logo',
       seed: 1337,
       steps: 30,
       guidance_scale: 7.5,
@@ -479,8 +475,6 @@ const Dashboard = () => {
       frame_interpolation: 'smooth',
       upscale: 2,
       safety_filter: 'moderate',
-      nsfw: false,
-      chaos: 0.1,
       made_out_of: 'default',
       environment: 'default',
       use_signature: false,
@@ -557,7 +551,6 @@ const Dashboard = () => {
         Math.floor(Math.random() * 5)
       ] as SoraOptions['quality'],
       temperature: Math.random() * 0.5 + 0.8,
-      chaos: Math.random(),
       motion_strength: Math.random(),
     };
     


### PR DESCRIPTION
## Summary
- simplify `SoraOptions` by dropping `chaos` and `nsfw`
- update default and reset options to omit the removed fields

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856d668a9988325af789e074f4610b0