### PR TITLE
Make style preset optional

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -42,7 +42,11 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
         onToggle={(enabled) => updateOptions({ use_dimensions_format: enabled })}
       />
       
-      <StyleSection options={options} updateNestedOptions={updateNestedOptions} />
+      <StyleSection
+        options={options}
+        updateNestedOptions={updateNestedOptions}
+        updateOptions={updateOptions}
+      />
       
       <CameraCompositionSection
         options={options}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -22,6 +22,7 @@ export interface SoraOptions {
     category: string;
     style: string;
   };
+  use_style_preset: boolean;
   quality: 'defective' | 'unacceptable' | 'poor' | 'bad' | 'below standard' | 'minimum' | 'moderate' | 'medium' | 'draft' | 'standard' | 'good' | 'high' | 'excellent' | 'ultra' | 'maximum' | 'low';
   temperature: number;
   dynamic_range: 'SDR' | 'HDR';
@@ -140,6 +141,7 @@ const Dashboard = () => {
       category: 'Photography & Cinematic',
       style: 'cinematic'
     },
+    use_style_preset: false,
     quality: 'high',
     temperature: 1.1,
     dynamic_range: 'HDR',
@@ -253,6 +255,10 @@ const Dashboard = () => {
     } else if (!options.use_dimensions) {
       delete cleanOptions.width;
       delete cleanOptions.height;
+    }
+
+    if (!options.use_style_preset) {
+      delete cleanOptions.style_preset;
     }
 
     if (!options.use_material) {
@@ -409,6 +415,7 @@ const Dashboard = () => {
     delete cleanOptions.use_atmosphere_mood;
     delete cleanOptions.use_subject_mood;
     delete cleanOptions.use_sword_type;
+    delete cleanOptions.use_style_preset;
     delete cleanOptions.use_camera_composition;
     delete (cleanOptions as { image_count?: number }).image_count;
 
@@ -452,6 +459,7 @@ const Dashboard = () => {
         category: 'Photography & Cinematic',
         style: 'cinematic'
       },
+      use_style_preset: false,
       quality: 'high',
       temperature: 1.1,
       dynamic_range: 'HDR',

--- a/src/components/sections/StyleSection.tsx
+++ b/src/components/sections/StyleSection.tsx
@@ -8,6 +8,7 @@ import { SoraOptions } from '../Dashboard';
 interface StyleSectionProps {
   options: SoraOptions;
   updateNestedOptions: (path: string, value: unknown) => void;
+  updateOptions: (updates: Partial<SoraOptions>) => void;
 }
 
 const stylePresets = {
@@ -79,7 +80,8 @@ const stylePresets = {
 
 export const StyleSection: React.FC<StyleSectionProps> = ({
   options,
-  updateNestedOptions
+  updateNestedOptions,
+  updateOptions
 }) => {
   const formatLabel = (value: string) => {
     return value.split(' ').map(word => 
@@ -88,7 +90,12 @@ export const StyleSection: React.FC<StyleSectionProps> = ({
   };
 
   return (
-    <CollapsibleSection title="Style Preset">
+    <CollapsibleSection
+      title="Style Preset"
+      isOptional={true}
+      isEnabled={options.use_style_preset}
+      onToggle={(enabled) => updateOptions({ use_style_preset: enabled })}
+    >
       <div className="grid grid-cols-1 gap-4">
         <div>
           <Label htmlFor="style_category">Style Category</Label>


### PR DESCRIPTION
## Summary
- allow disabling the Style Preset section
- clean style_preset from the output when disabled

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856d8351d888325b2b1c44677998fc9