### PR TITLE
Add optional color grading section

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -8,6 +8,7 @@ import { StyleSection } from './sections/StyleSection';
 import { CameraCompositionSection } from './sections/CameraCompositionSection';
 import { VideoMotionSection } from './sections/VideoMotionSection';
 import { MaterialSection } from './sections/MaterialSection';
+import { ColorGradingSection } from './sections/ColorGradingSection';
 import { SettingsLocationSection } from './sections/SettingsLocationSection';
 import { FaceSection } from './sections/FaceSection';
 import { EnhancementsSection } from './sections/EnhancementsSection';
@@ -58,13 +59,18 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
         onToggle={(enabled) => updateOptions({ use_motion_animation: enabled })}
       />
       
-      <MaterialSection 
-        options={options} 
+      <MaterialSection
+        options={options}
         updateOptions={updateOptions}
       />
-      
-      <SettingsLocationSection 
-        options={options} 
+
+      <ColorGradingSection
+        options={options}
+        updateOptions={updateOptions}
+      />
+
+      <SettingsLocationSection
+        options={options}
         updateOptions={updateOptions}
       />
       

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -154,7 +154,7 @@ const Dashboard = () => {
     subject_focus: 'center',
     composition_rules: ['rule_of_thirds', 'leading_lines'],
     lighting: 'golden_hour',
-    color_grade: 'teal_and_orange',
+    color_grade: 'default (no specific color grading)',
     depth_of_field: 'shallow',
     lens_type: 'default',
     frame_interpolation: 'smooth',
@@ -281,6 +281,10 @@ const Dashboard = () => {
 
     if (!options.use_blur_style) {
       delete cleanOptions.blur_style;
+    }
+
+    if (!options.use_color_grading) {
+      delete cleanOptions.color_grade;
     }
 
     if (!options.use_motion_animation) {
@@ -466,7 +470,7 @@ const Dashboard = () => {
       subject_focus: 'center',
       composition_rules: ['rule_of_thirds', 'leading_lines'],
       lighting: 'golden_hour',
-      color_grade: 'teal_and_orange',
+      color_grade: 'default (no specific color grading)',
       depth_of_field: 'shallow',
       lens_type: 'default',
       frame_interpolation: 'smooth',

--- a/src/components/sections/ColorGradingSection.tsx
+++ b/src/components/sections/ColorGradingSection.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { Label } from '@/components/ui/label';
+import { SearchableDropdown } from '../SearchableDropdown';
+import { CollapsibleSection } from '../CollapsibleSection';
+import { SoraOptions } from '../Dashboard';
+
+interface ColorGradingSectionProps {
+  options: SoraOptions;
+  updateOptions: (updates: Partial<SoraOptions>) => void;
+}
+
+const colorGradingOptions = [
+  "default (no specific color grading)",
+  "not defined",
+  "cinematic",
+  "cinematic teal-orange",
+  "cinematic blue",
+  "cinematic green",
+  "blockbuster",
+  "vintage film",
+  "old Hollywood",
+  "technicolor",
+  "sepia",
+  "classic sepia",
+  "monochrome",
+  "black and white",
+  "high contrast black and white",
+  "low contrast black and white",
+  "bleach bypass",
+  "cross-processed",
+  "retro",
+  "pastel",
+  "pastel neon",
+  "muted",
+  "muted vintage",
+  "faded",
+  "washed out",
+  "matte",
+  "ultra-vivid",
+  "vivid",
+  "vivid pop",
+  "desaturated",
+  "de-saturated blues",
+  "cool tones",
+  "warm tones",
+  "cool shadows, warm highlights",
+  "warm highlights, cool shadows",
+  "teal and orange",
+  "orange and teal",
+  "golden hour",
+  "blue hour",
+  "sunset glow",
+  "night blue",
+  "autumn tones",
+  "spring bloom",
+  "earthy",
+  "rustic",
+  "icy blue",
+  "emerald green",
+  "magenta dream",
+  "purple haze",
+  "cyan tint",
+  "neon",
+  "neon glow",
+  "duotone",
+  "tritone",
+  "yellow and blue",
+  "red and cyan",
+  "split toning",
+  "film noir",
+  "giallo",
+  "moody",
+  "dramatic",
+  "dreamy",
+  "ethereal",
+  "infrared",
+  "ultraviolet",
+  "infrared false color",
+  "xpro",
+  "cinema verité",
+  "HDR",
+  "SDR",
+  "washed film",
+  "cool matte",
+  "warm matte",
+  "lush greens",
+  "icy whites",
+  "day for night",
+  "Lomo",
+  "Kodachrome",
+  "Fuji Velvia",
+  "Fuji Provia",
+  "Fuji Classic Chrome",
+  "Portra 400",
+  "Portra 800",
+  "Ektar 100",
+  "Kodak 2383",
+  "Fujifilm Eterna",
+  "Agfa Ultra",
+  "Rec709",
+  "Rec2020",
+  "Polaroid",
+  "Instax",
+  "film grain"
+];
+
+export const ColorGradingSection: React.FC<ColorGradingSectionProps> = ({
+  options,
+  updateOptions
+}) => {
+  return (
+    <CollapsibleSection
+      title="Color Grading"
+      isOptional={true}
+      isEnabled={options.use_color_grading}
+      onToggle={(enabled) => updateOptions({ use_color_grading: enabled })}
+    >
+      <div className="space-y-4">
+        <div>
+          <Label>Color Grade</Label>
+          <SearchableDropdown
+            options={colorGradingOptions}
+            value={options.color_grade || 'default (no specific color grading)'}
+            onValueChange={(value) => updateOptions({ color_grade: value })}
+            label="Color Grade Options"
+            disabled={!options.use_color_grading}
+          />
+        </div>
+      </div>
+    </CollapsibleSection>
+  );
+};


### PR DESCRIPTION
## Summary
- add `ColorGradingSection` with many grading presets
- include section in control panel
- set default color grade to "default (no specific color grading)"
- omit `color_grade` from JSON when not enabled

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856d90dbebc8325b83bcba88839755f