### PR TITLE
Add checkbox to disable negative prompts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Then open http://localhost:5173 in your browser.
 ### Features
 
 - Edit prompts and negative prompts with live JSON output
+- Edit prompts and optionally include negative prompts via a checkbox
 - Select model versions and quality presets
 - Adjust dimensions, aspect ratio and output format
 - Configure camera movement, motion strength and video length

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -10,6 +10,7 @@ import { ActionBar } from './ActionBar';
 export interface SoraOptions {
   prompt: string;
   negative_prompt: string;
+  use_negative_prompt: boolean;
   seed: number | null;
   steps: number;
   guidance_scale: number;
@@ -129,6 +130,7 @@ const Dashboard = () => {
   const [options, setOptions] = useState<SoraOptions>({
     prompt: 'A breathtaking cinematic scene of a futuristic city at sunset, flying cars zipping between glass skyscrapers, vibrant colors, ultra-detailed, 8K, masterful lighting, trending on ArtStation',
     negative_prompt: 'blurry, low-res, dark, extra limbs, cropped, watermark, text, signature, logo',
+    use_negative_prompt: true,
     seed: 1337,
     steps: 30,
     guidance_scale: 7.5,
@@ -259,6 +261,10 @@ const Dashboard = () => {
 
     if (!options.use_style_preset) {
       delete cleanOptions.style_preset;
+    }
+
+    if (!options.use_negative_prompt) {
+      delete cleanOptions.negative_prompt;
     }
 
     if (!options.use_material) {
@@ -424,6 +430,7 @@ const Dashboard = () => {
     delete cleanOptions.use_subject_mood;
     delete cleanOptions.use_sword_type;
     delete cleanOptions.use_style_preset;
+    delete cleanOptions.use_negative_prompt;
     delete cleanOptions.use_camera_composition;
     delete (cleanOptions as { image_count?: number }).image_count;
 
@@ -455,6 +462,7 @@ const Dashboard = () => {
     setOptions({
       prompt: 'A breathtaking cinematic scene of a futuristic city at sunset, flying cars zipping between glass skyscrapers, vibrant colors, ultra-detailed, 8K, masterful lighting, trending on ArtStation',
       negative_prompt: 'blurry, low-res, dark, extra limbs, cropped, watermark, text, signature, logo',
+      use_negative_prompt: true,
       seed: 1337,
       steps: 30,
       guidance_scale: 7.5,

--- a/src/components/sections/PromptSection.tsx
+++ b/src/components/sections/PromptSection.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
 import { SoraOptions } from '../Dashboard';
 
 interface PromptSectionProps {
@@ -26,15 +27,25 @@ export const PromptSection: React.FC<PromptSectionProps> = ({ options, updateOpt
       </div>
       
       <div>
-        <Label htmlFor="negative_prompt" className="text-base font-semibold mb-2 block">
-          Negative Prompt
-        </Label>
+        <div className="flex items-center space-x-2 mb-2">
+          <Checkbox
+            id="use_negative_prompt"
+            checked={options.use_negative_prompt}
+            onCheckedChange={(checked) =>
+              updateOptions({ use_negative_prompt: !!checked })
+            }
+          />
+          <Label htmlFor="negative_prompt" className="text-base font-semibold">
+            Negative Prompt
+          </Label>
+        </div>
         <Textarea
           id="negative_prompt"
           value={options.negative_prompt}
           onChange={(e) => updateOptions({ negative_prompt: e.target.value })}
           placeholder="Describe what you want to avoid..."
           className="min-h-[80px] resize-y"
+          disabled={!options.use_negative_prompt}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `use_negative_prompt` flag to options
- update dashboard logic to omit negative prompt when unchecked
- add checkbox to UI for toggling negative prompt
- document optional negative prompt in README

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_6856da7ac9a883258dac129c08e03539