### PR TITLE
Add optional lighting dropdown

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -8,6 +8,7 @@ import { StyleSection } from './sections/StyleSection';
 import { CameraCompositionSection } from './sections/CameraCompositionSection';
 import { VideoMotionSection } from './sections/VideoMotionSection';
 import { MaterialSection } from './sections/MaterialSection';
+import { LightingSection } from './sections/LightingSection';
 import { ColorGradingSection } from './sections/ColorGradingSection';
 import { SettingsLocationSection } from './sections/SettingsLocationSection';
 import { FaceSection } from './sections/FaceSection';
@@ -64,6 +65,11 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
       />
       
       <MaterialSection
+        options={options}
+        updateOptions={updateOptions}
+      />
+
+      <LightingSection
         options={options}
         updateOptions={updateOptions}
       />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -303,6 +303,10 @@ const Dashboard = () => {
       delete cleanOptions.color_grade;
     }
 
+    if (!options.use_lighting) {
+      delete cleanOptions.lighting;
+    }
+
     if (!options.use_motion_animation) {
       delete cleanOptions.duration_seconds;
       delete cleanOptions.fps;

--- a/src/components/sections/LightingSection.tsx
+++ b/src/components/sections/LightingSection.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { Label } from '@/components/ui/label';
+import { SearchableDropdown } from '../SearchableDropdown';
+import { CollapsibleSection } from '../CollapsibleSection';
+import { SoraOptions } from '../Dashboard';
+
+interface LightingSectionProps {
+  options: SoraOptions;
+  updateOptions: (updates: Partial<SoraOptions>) => void;
+}
+
+const lightingOptions = [
+  "default (auto lighting)",
+  "not defined",
+  "natural light",
+  "direct sunlight",
+  "diffused sunlight",
+  "soft natural",
+  "hard natural",
+  "window light",
+  "overcast",
+  "golden hour",
+  "blue hour",
+  "sunrise",
+  "sunset",
+  "dappled sunlight",
+  "moonlight",
+  "twilight",
+  "dawn",
+  "backlight",
+  "rim light",
+  "edge light",
+  "side light",
+  "split light",
+  "top light",
+  "bottom light",
+  "underlight",
+  "uplighting",
+  "downlighting",
+  "ambient light",
+  "soft ambient",
+  "studio light",
+  "three-point lighting",
+  "butterfly lighting",
+  "Rembrandt lighting",
+  "loop lighting",
+  "broad lighting",
+  "short lighting",
+  "clamshell lighting",
+  "ring light",
+  "beauty dish",
+  "softbox",
+  "octabox",
+  "hard light",
+  "soft light",
+  "spotlight",
+  "key light",
+  "fill light",
+  "hair light",
+  "catchlight",
+  "practical lighting",
+  "motivated lighting",
+  "cinematic lighting",
+  "dramatic lighting",
+  "moody lighting",
+  "high-key lighting",
+  "low-key lighting",
+  "harsh lighting",
+  "diffused lighting",
+  "glowing",
+  "glare",
+  "lens flare",
+  "bokeh lights",
+  "colored light",
+  "RGB lighting",
+  "neon lighting",
+  "fluorescent lighting",
+  "incandescent lighting",
+  "tungsten lighting",
+  "LED lighting",
+  "candlelight",
+  "torchlight",
+  "firelight",
+  "lantern light",
+  "streetlight",
+  "headlights",
+  "car lights",
+  "spotlights",
+  "searchlights",
+  "stage lighting",
+  "concert lighting",
+  "strobe lighting",
+  "light painting",
+  "chiaroscuro",
+  "silhouette",
+  "shadow play",
+  "patterned light",
+  "projected light",
+  "reflected light",
+  "bounce lighting",
+  "underwater lighting",
+  "volumetric lighting",
+  "god rays",
+  "crepuscular rays",
+  "foggy light",
+  "hazy light",
+  "misty light",
+  "storm lighting",
+  "lightning",
+  "bioluminescence",
+  "glow in the dark",
+  "magic light",
+  "fairy lights",
+  "crystal lighting",
+  "laser lighting",
+  "fiber optic lighting",
+  "psychedelic lighting"
+];
+
+export const LightingSection: React.FC<LightingSectionProps> = ({ options, updateOptions }) => {
+  return (
+    <CollapsibleSection
+      title="Lighting"
+      isOptional={true}
+      isEnabled={options.use_lighting}
+      onToggle={(enabled) => updateOptions({ use_lighting: enabled })}
+    >
+      <div className="space-y-4">
+        <div>
+          <Label>Lighting</Label>
+          <SearchableDropdown
+            options={lightingOptions}
+            value={options.lighting || 'default (auto lighting)'}
+            onValueChange={(value) => updateOptions({ lighting: value })}
+            label="Lighting Options"
+            disabled={!options.use_lighting}
+          />
+        </div>
+      </div>
+    </CollapsibleSection>
+  );
+};


### PR DESCRIPTION
## Summary
- add LightingSection with extensive presets
- hook new section into ControlPanel
- omit lighting from generated JSON unless enabled

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856dc3a754083259421e2469300d622