### PR TITLE
Add JSON history and mobile improvements

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -16,6 +16,7 @@ interface ActionBarProps {
   onCopy: () => void;
   onClear: () => void;
   onShare: () => void;
+  onHistory: () => void;
   onReset: () => void;
   onRegenerate: () => void;
   onRandomize: () => void;
@@ -26,6 +27,7 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   onCopy,
   onClear,
   onShare,
+  onHistory,
   onReset,
   onRegenerate,
   onRandomize,
@@ -57,6 +59,9 @@ export const ActionBar: React.FC<ActionBarProps> = ({
       <Button onClick={onShare} variant="outline" size="sm" className="gap-2">
         <Share className="w-4 h-4" />
         Share
+      </Button>
+      <Button onClick={onHistory} variant="outline" size="sm" className="gap-2">
+        History
       </Button>
       <Button onClick={onReset} variant="outline" size="sm" className="gap-2">
         <RotateCcw className="w-4 h-4" />

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Clipboard, Trash2, Edit, Eye } from 'lucide-react'
+
+export interface HistoryEntry {
+  id: number
+  date: string
+  json: string
+}
+
+interface HistoryPanelProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  history: HistoryEntry[]
+  onDelete: (id: number) => void
+  onClear: () => void
+  onCopy: (json: string) => void
+  onEdit: (json: string) => void
+}
+
+export const HistoryPanel: React.FC<HistoryPanelProps> = ({
+  open,
+  onOpenChange,
+  history,
+  onDelete,
+  onClear,
+  onCopy,
+  onEdit,
+}) => {
+  const [preview, setPreview] = useState<HistoryEntry | null>(null)
+  const [confirmClear, setConfirmClear] = useState(false)
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>History</DialogTitle>
+          </DialogHeader>
+          <div className="mb-4 text-right">
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setConfirmClear(true)}
+            >
+              Clear History
+            </Button>
+          </div>
+          <ScrollArea className="h-[60vh]">
+            <div className="space-y-4 pb-2">
+              {history.map((entry) => (
+                <div key={entry.id} className="border p-3 rounded-md space-y-2">
+                  <div className="text-xs text-muted-foreground flex justify-between">
+                    <span>{entry.date}</span>
+                    <span className="truncate max-w-[50%]">
+                      {entry.json.slice(0, 40)}...
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => onEdit(entry.json)}
+                      className="gap-1"
+                    >
+                      <Edit className="w-4 h-4" /> Edit
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => onCopy(entry.json)}
+                      className="gap-1"
+                    >
+                      <Clipboard className="w-4 h-4" /> Copy
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setPreview(entry)}
+                      className="gap-1"
+                    >
+                      <Eye className="w-4 h-4" /> Preview
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      onClick={() => onDelete(entry.id)}
+                      className="gap-1"
+                    >
+                      <Trash2 className="w-4 h-4" /> Delete
+                    </Button>
+                  </div>
+                </div>
+              ))}
+              {history.length === 0 && (
+                <p className="text-center text-sm text-muted-foreground">
+                  No history yet.
+                </p>
+              )}
+            </div>
+          </ScrollArea>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={confirmClear} onOpenChange={setConfirmClear}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clear history?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove all entries permanently.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                onClear()
+                setConfirmClear(false)
+              }}
+            >
+              Clear
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <Dialog open={!!preview} onOpenChange={() => setPreview(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>JSON Preview</DialogTitle>
+          </DialogHeader>
+          {preview && (
+            <ScrollArea className="h-[60vh]">
+              <pre className="whitespace-pre-wrap text-xs p-2">
+                {preview.json}
+              </pre>
+            </ScrollArea>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+export default HistoryPanel

--- a/src/hooks/use-single-column.tsx
+++ b/src/hooks/use-single-column.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+
+const BREAKPOINT = 1024
+
+export function useIsSingleColumn() {
+  const [isSingle, setIsSingle] = React.useState(false)
+
+  React.useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${BREAKPOINT - 1}px)`)
+    const handler = () => setIsSingle(window.innerWidth < BREAKPOINT)
+    mq.addEventListener('change', handler)
+    handler()
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  return isSingle
+}


### PR DESCRIPTION
## Summary
- add hook to detect single-column layout
- create history panel for previously copied JSON
- extend ActionBar with History button
- store JSON and history in localStorage
- add jump-to-JSON button on small screens

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_6856fe6ce570832585547d2eca2b97b6