### PR TITLE
Improve history UX

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -4,6 +4,8 @@ import {
   Copy,
   Check,
   Share,
+  Import,
+  History,
   RotateCcw,
   RefreshCw,
   Shuffle,
@@ -16,6 +18,7 @@ interface ActionBarProps {
   onCopy: () => void;
   onClear: () => void;
   onShare: () => void;
+  onImport: () => void;
   onHistory: () => void;
   onReset: () => void;
   onRegenerate: () => void;
@@ -27,6 +30,7 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   onCopy,
   onClear,
   onShare,
+  onImport,
   onHistory,
   onReset,
   onRegenerate,
@@ -60,7 +64,12 @@ export const ActionBar: React.FC<ActionBarProps> = ({
         <Share className="w-4 h-4" />
         Share
       </Button>
+      <Button onClick={onImport} variant="outline" size="sm" className="gap-2">
+        <Import className="w-4 h-4" />
+        Import
+      </Button>
       <Button onClick={onHistory} variant="outline" size="sm" className="gap-2">
+        <History className="w-4 h-4" />
         History
       </Button>
       <Button onClick={onReset} variant="outline" size="sm" className="gap-2">

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -17,7 +18,20 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { Clipboard, Trash2, Edit, Eye } from 'lucide-react'
+import {
+  Clipboard,
+  Trash2,
+  Edit,
+  Eye,
+  Import as ImportIcon,
+  Download,
+} from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu'
 
 export interface HistoryEntry {
   id: number
@@ -33,6 +47,7 @@ interface HistoryPanelProps {
   onClear: () => void
   onCopy: (json: string) => void
   onEdit: (json: string) => void
+  onImport: (jsons: string[]) => void
 }
 
 export const HistoryPanel: React.FC<HistoryPanelProps> = ({
@@ -43,9 +58,69 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
   onClear,
   onCopy,
   onEdit,
+  onImport,
 }) => {
   const [preview, setPreview] = useState<HistoryEntry | null>(null)
   const [confirmClear, setConfirmClear] = useState(false)
+
+  const handleSingleClipboardImport = async () => {
+    try {
+      const text = await navigator.clipboard.readText()
+      JSON.parse(text)
+      onImport([text])
+    } catch {
+      /* ignore invalid */
+    }
+  }
+
+  const handleBulkClipboardImport = async () => {
+    try {
+      const text = await navigator.clipboard.readText()
+      const arr = JSON.parse(text)
+      if (Array.isArray(arr)) {
+        const strings = arr.map(j => (typeof j === 'string' ? j : JSON.stringify(j)))
+        onImport(strings)
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const handleFileImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const text = await file.text()
+    try {
+      const parsed = JSON.parse(text)
+      if (Array.isArray(parsed)) {
+        const strings = parsed.map(j => (typeof j === 'string' ? j : JSON.stringify(j)))
+        onImport(strings)
+      } else {
+        onImport([JSON.stringify(parsed)])
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const exportClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(history, null, 2))
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const exportFile = () => {
+    const data = JSON.stringify(history, null, 2)
+    const blob = new Blob([data], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'history.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
 
   return (
     <>
@@ -53,8 +128,54 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
         <DialogContent className="max-w-2xl">
           <DialogHeader>
             <DialogTitle>History</DialogTitle>
+            <DialogDescription>
+              This is your clipboard copied prompt history, every copied prompt goes here. You can review them, export them or delete them when you don't need them any longer
+            </DialogDescription>
           </DialogHeader>
-          <div className="mb-4 text-right">
+          <div className="mb-4 flex justify-between items-center gap-2">
+            <div className="flex gap-2">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="sm" className="gap-1">
+                    <ImportIcon className="w-4 h-4" /> Import
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem onSelect={handleSingleClipboardImport}>
+                    Paste from clipboard
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={handleBulkClipboardImport}>
+                    Bulk paste from clipboard
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <label className="w-full cursor-pointer">
+                      Bulk file import
+                      <input
+                        type="file"
+                        accept=".json"
+                        onChange={handleFileImport}
+                        className="hidden"
+                      />
+                    </label>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="sm" className="gap-1">
+                    <Download className="w-4 h-4" /> Export
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem onSelect={exportClipboard}>
+                    Copy all to clipboard
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={exportFile}>
+                    Download JSON
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
             <Button
               variant="destructive"
               size="sm"
@@ -69,10 +190,25 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
                 <div key={entry.id} className="border p-3 rounded-md space-y-2">
                   <div className="text-xs text-muted-foreground flex justify-between">
                     <span>{entry.date}</span>
-                    <span className="truncate max-w-[50%]">
-                      {entry.json.slice(0, 40)}...
-                    </span>
                   </div>
+                  {(() => {
+                    try {
+                      const obj = JSON.parse(entry.json)
+                      const { prompt, ...rest } = obj
+                      const keys = Object.keys(rest)
+                      const sample = keys.sort(() => 0.5 - Math.random()).slice(0, 3)
+                      return (
+                        <div className="space-y-1 text-xs text-muted-foreground">
+                          <div className="font-medium break-words">{prompt}</div>
+                          <div>
+                            {sample.map(key => `${key}: ${String(rest[key])}`).join(', ')}
+                          </div>
+                        </div>
+                      )
+                    } catch {
+                      return null
+                    }
+                  })()}
                   <div className="flex flex-wrap gap-2">
                     <Button
                       size="sm"
@@ -111,7 +247,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
               ))}
               {history.length === 0 && (
                 <p className="text-center text-sm text-muted-foreground">
-                  No history yet.
+                  We're lonely here, please generate some prompts and copy them 🥺
                 </p>
               )}
             </div>

--- a/src/components/ImportModal.tsx
+++ b/src/components/ImportModal.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+
+interface ImportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onImport: (json: string) => void;
+}
+
+export const ImportModal: React.FC<ImportModalProps> = ({ isOpen, onClose, onImport }) => {
+  const [text, setText] = useState('');
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = ev => setText(ev.target?.result as string);
+    reader.readAsText(file);
+  };
+
+  const handleImport = () => {
+    onImport(text);
+    setText('');
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Import JSON</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-2 py-4">
+          <Textarea
+            value={text}
+            onChange={e => setText(e.target.value)}
+            placeholder="Paste JSON here"
+          />
+          <Input type="file" accept=".json" onChange={handleFile} />
+        </div>
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleImport}>Import</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ImportModal;


### PR DESCRIPTION
## Summary
- keep JSON prompt when reloading the page
- add Import button and History icon to the action bar
- allow importing JSON via modal dialog
- enhance history panel with description, import/export options, nicer excerpts and empty state text

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685702fca6b483258f59d27a869f1f4a