### PR TITLE
Improve interface and theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,8 +12,9 @@ const queryClient = new QueryClient();
 
 const App = () => {
   useEffect(() => {
-    // Enable dark mode by default
-    document.documentElement.classList.add('dark');
+    if (localStorage.getItem('darkMode') === null) {
+      document.documentElement.classList.add('dark');
+    }
   }, []);
 
   return (

--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import {
   Copy,
   Check,
@@ -64,25 +65,30 @@ export const ActionBar: React.FC<ActionBarProps> = ({
         <Share className="w-4 h-4" />
         Share
       </Button>
-      <Button onClick={onImport} variant="outline" size="sm" className="gap-2">
-        <Import className="w-4 h-4" />
-        Import
-      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" className="gap-2">
+            <Import className="w-4 h-4" /> Manage
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem onSelect={onImport} className="gap-2">
+            <Import className="w-4 h-4" /> Import
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onReset} className="gap-2">
+            <RotateCcw className="w-4 h-4" /> Reset
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onRegenerate} className="gap-2">
+            <RefreshCw className="w-4 h-4" /> Regenerate
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onRandomize} className="gap-2">
+            <Shuffle className="w-4 h-4" /> Randomize
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <Button onClick={onHistory} variant="outline" size="sm" className="gap-2">
         <History className="w-4 h-4" />
         History
-      </Button>
-      <Button onClick={onReset} variant="outline" size="sm" className="gap-2">
-        <RotateCcw className="w-4 h-4" />
-        Reset
-      </Button>
-      <Button onClick={onRegenerate} variant="outline" size="sm" className="gap-2">
-        <RefreshCw className="w-4 h-4" />
-        Regenerate
-      </Button>
-      <Button onClick={onRandomize} variant="outline" size="sm" className="gap-2">
-        <Shuffle className="w-4 h-4" />
-        Randomize
       </Button>
       <Button onClick={() => setMinimized(true)} variant="ghost" size="icon" className="ml-auto">
         <ChevronDown className="w-4 h-4" />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Sparkles } from 'lucide-react';
+import { Sparkles, Sun, Moon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { toast } from 'sonner';
@@ -10,6 +10,7 @@ import { ActionBar } from './ActionBar';
 import HistoryPanel, { HistoryEntry } from './HistoryPanel';
 import ImportModal from './ImportModal';
 import { useIsSingleColumn } from '@/hooks/use-single-column';
+import { useDarkMode } from '@/hooks/use-dark-mode';
 
 export interface SoraOptions {
   prompt: string;
@@ -160,8 +161,8 @@ const Dashboard = () => {
     camera_angle: 'low',
     shot_type: 'wide',
     subject_focus: 'center',
-    composition_rules: ['rule_of_thirds', 'leading_lines'],
-    lighting: 'golden_hour',
+    composition_rules: [],
+    lighting: '',
     color_grade: 'default (no specific color grading)',
     depth_of_field: 'shallow',
     lens_type: 'default',
@@ -248,6 +249,7 @@ const Dashboard = () => {
   });
   const jsonRef = React.useRef<HTMLDivElement>(null);
   const isSingleColumn = useIsSingleColumn();
+  const [darkMode, setDarkMode] = useDarkMode();
 
   useEffect(() => {
     localStorage.setItem('jsonHistory', JSON.stringify(history));
@@ -540,8 +542,8 @@ const Dashboard = () => {
       camera_angle: 'low',
       shot_type: 'wide',
       subject_focus: 'center',
-      composition_rules: ['rule_of_thirds', 'leading_lines'],
-      lighting: 'golden_hour',
+      composition_rules: [],
+      lighting: '',
       color_grade: 'default (no specific color grading)',
       depth_of_field: 'shallow',
       lens_type: 'default',
@@ -692,12 +694,22 @@ const Dashboard = () => {
   return (
     <div className="min-h-screen bg-background">
       <div className="container mx-auto p-6">
-        <div className="mb-8">
-          <h1 className="text-4xl font-bold mb-2 flex items-center gap-3">
-            <Sparkles className="w-10 h-10 text-purple-500" />
-            Sora JSON Prompt Crafter
-          </h1>
-          <p className="text-muted-foreground">Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.</p>
+        <div className="mb-8 flex items-start justify-between">
+          <div>
+            <h1 className="text-4xl font-bold mb-2 flex items-center gap-3 select-none">
+              <Sparkles className="w-10 h-10 text-purple-500 animate-rainbow" />
+              Sora JSON Prompt Crafter
+            </h1>
+            <p className="text-muted-foreground select-none">Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.</p>
+          </div>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => setDarkMode(!darkMode)}
+            aria-label="Toggle dark mode"
+          >
+            {darkMode ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+          </Button>
         </div>
         
         <div className="grid lg:grid-cols-2 gap-6 h-[calc(100vh-12rem)]">
@@ -719,7 +731,7 @@ const Dashboard = () => {
             </CardContent>
           </Card>
 
-          <Card className="flex flex-col">
+          <Card className="flex flex-col lg:sticky lg:top-24">
             <CardHeader className="border-b">
               <CardTitle className="flex items-center gap-2">
                 <div className="w-2 h-2 bg-green-500 rounded-full"></div>

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -195,13 +195,26 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
                     try {
                       const obj = JSON.parse(entry.json)
                       const { prompt, ...rest } = obj
-                      const keys = Object.keys(rest)
+                      const flatten = (o: Record<string, unknown>, p = ''): Record<string, unknown> => {
+                        return Object.keys(o).reduce((acc, k) => {
+                          const v = o[k]
+                          const key = p ? `${p}.${k}` : k
+                          if (v && typeof v === 'object' && !Array.isArray(v)) {
+                            Object.assign(acc, flatten(v, key))
+                          } else {
+                            acc[key] = v
+                          }
+                          return acc
+                        }, {} as Record<string, unknown>)
+                      }
+                      const flat = flatten(rest)
+                      const keys = Object.keys(flat)
                       const sample = keys.sort(() => 0.5 - Math.random()).slice(0, 3)
                       return (
                         <div className="space-y-1 text-xs text-muted-foreground">
                           <div className="font-medium break-words">{prompt}</div>
                           <div>
-                            {sample.map(key => `${key}: ${String(rest[key])}`).join(', ')}
+                            {sample.map(key => `${key}: ${String(flat[key])}`).join(', ')}
                           </div>
                         </div>
                       )

--- a/src/components/SearchableDropdown.tsx
+++ b/src/components/SearchableDropdown.tsx
@@ -72,7 +72,7 @@ export const SearchableDropdown: React.FC<SearchableDropdownProps> = ({
           className="w-full justify-between"
           disabled={disabled}
         >
-          <span className="truncate">{formatLabel(value)}</span>
+          <span className="truncate">{value ? formatLabel(value) : placeholder}</span>
           <ChevronDown className="w-4 h-4 ml-2 flex-shrink-0" />
         </Button>
       </DialogTrigger>

--- a/src/components/sections/LightingSection.tsx
+++ b/src/components/sections/LightingSection.tsx
@@ -130,9 +130,10 @@ export const LightingSection: React.FC<LightingSectionProps> = ({ options, updat
           <Label>Lighting</Label>
           <SearchableDropdown
             options={lightingOptions}
-            value={options.lighting || 'default (auto lighting)'}
+            value={options.lighting || ''}
             onValueChange={(value) => updateOptions({ lighting: value })}
             label="Lighting Options"
+            placeholder="Select lighting..."
             disabled={!options.use_lighting}
           />
         </div>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -36,7 +36,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
+      "text-2xl font-semibold leading-none tracking-tight select-none",
       className
     )}
     {...props}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 select-none"
 )
 
 const Label = React.forwardRef<

--- a/src/hooks/use-dark-mode.ts
+++ b/src/hooks/use-dark-mode.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+
+export function useDarkMode() {
+  const [isDark, setIsDark] = useState(() => {
+    try {
+      const stored = localStorage.getItem('darkMode')
+      return stored ? JSON.parse(stored) : true
+    } catch {
+      return true
+    }
+  })
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (isDark) root.classList.add('dark')
+    else root.classList.remove('dark')
+    try {
+      localStorage.setItem('darkMode', JSON.stringify(isDark))
+    } catch {
+      /* ignore */
+    }
+  }, [isDark])
+
+  return [isDark, setIsDark] as const
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -69,29 +69,26 @@ export default {
 				md: 'calc(var(--radius) - 2px)',
 				sm: 'calc(var(--radius) - 4px)'
 			},
-			keyframes: {
-				'accordion-down': {
-					from: {
-						height: '0'
-					},
-					to: {
-						height: 'var(--radix-accordion-content-height)'
-					}
-				},
-				'accordion-up': {
-					from: {
-						height: 'var(--radix-accordion-content-height)'
-					},
-					to: {
-						height: '0'
-					}
-				}
-			},
-			animation: {
-				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out'
-			}
-		}
-	},
+                        keyframes: {
+                                'accordion-down': {
+                                        from: { height: '0' },
+                                        to: { height: 'var(--radix-accordion-content-height)' }
+                                },
+                                'accordion-up': {
+                                        from: { height: 'var(--radix-accordion-content-height)' },
+                                        to: { height: '0' }
+                                },
+                                rainbow: {
+                                        '0%': { filter: 'hue-rotate(0deg)' },
+                                        '100%': { filter: 'hue-rotate(360deg)' }
+                                }
+                        },
+                        animation: {
+                                'accordion-down': 'accordion-down 0.2s ease-out',
+                                'accordion-up': 'accordion-up 0.2s ease-out',
+                                rainbow: 'rainbow 10s linear infinite'
+                        }
+                }
+        },
        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add dark mode hook and toggle in dashboard header
- animate app icon in rainbow colors
- ensure JSON panel stays visible on large screens
- group management actions in dropdown
- prevent text selection in labels and headers
- tweak lighting and composition defaults
- support placeholder in searchable dropdown
- flatten nested objects in history panel
- add rainbow animation to Tailwind config

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685709337bcc8325a167d15e94d05c5d