### PR TITLE
Add analytics toggle and fix footer

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { Switch } from '@/components/ui/switch';
 import {
   Copy,
   Check,
@@ -25,6 +26,8 @@ interface ActionBarProps {
   onRegenerate: () => void;
   onRandomize: () => void;
   copied: boolean;
+  trackingEnabled: boolean;
+  onTrackingChange: (enabled: boolean) => void;
 }
 
 export const ActionBar: React.FC<ActionBarProps> = ({
@@ -37,6 +40,8 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   onRegenerate,
   onRandomize,
   copied,
+  trackingEnabled,
+  onTrackingChange,
 }) => {
   const [minimized, setMinimized] = useState(false);
 
@@ -83,6 +88,15 @@ export const ActionBar: React.FC<ActionBarProps> = ({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={onRandomize} className="gap-2">
             <Shuffle className="w-4 h-4" /> Randomize
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={e => e.preventDefault()} className="gap-2">
+            <div className="flex items-center justify-between w-full">
+              <span>Tracking</span>
+              <Switch
+                checked={trackingEnabled}
+                onCheckedChange={onTrackingChange}
+              />
+            </div>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -253,6 +253,27 @@ const Dashboard = () => {
   const jsonRef = React.useRef<HTMLDivElement>(null);
   const isSingleColumn = useIsSingleColumn();
   const [darkMode, setDarkMode] = useDarkMode();
+  const [trackingEnabled, setTrackingEnabled] = useState(() => {
+    try {
+      const stored = localStorage.getItem('trackingEnabled');
+      return stored ? JSON.parse(stored) : true;
+    } catch {
+      return true;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('trackingEnabled', JSON.stringify(trackingEnabled));
+    } catch {
+      /* ignore */
+    }
+    (
+      window as unknown as {
+        'ga-disable-G-RVR9TSBQL7': boolean
+      }
+    )['ga-disable-G-RVR9TSBQL7'] = !trackingEnabled;
+  }, [trackingEnabled]);
 
   useEffect(() => {
     localStorage.setItem('jsonHistory', JSON.stringify(history));
@@ -695,8 +716,8 @@ const Dashboard = () => {
   };
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto p-6">
+    <div className="min-h-screen bg-background flex flex-col">
+      <div className="container mx-auto p-6 flex-grow">
         <div className="mb-8 flex items-start justify-between">
           <div>
             <h1 className="text-4xl font-bold mb-2 flex items-center gap-3 select-none">
@@ -742,7 +763,7 @@ const Dashboard = () => {
           </Button>
         </div>
         
-        <div className="grid lg:grid-cols-2 gap-6 h-[calc(100vh-12rem)]">
+        <div className="grid lg:grid-cols-2 gap-6 min-h-[calc(100vh-12rem)]">
           <Card className="flex flex-col" ref={jsonRef}>
             <CardHeader className="border-b">
               <CardTitle className="flex items-center gap-2">
@@ -799,6 +820,8 @@ const Dashboard = () => {
         onRegenerate={regenerateJson}
         onRandomize={randomizeJson}
         copied={copied}
+        trackingEnabled={trackingEnabled}
+        onTrackingChange={setTrackingEnabled}
       />
       <ShareModal
         isOpen={showShareModal}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,19 +1,36 @@
 import React from 'react';
 
 const Footer = () => (
-  <footer className="py-6 text-center text-sm text-muted-foreground">
-    <p>
-      I ♥ Open-Source software @ 2025 –{' '}
-      <a
-        href="https://github.com/supermarsx/sora-json-prompt-crafter"
-        className="underline"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        GitHub Source
-      </a>
-    </p>
-  </footer>
+  <>
+    <footer className="py-6 text-center text-sm text-muted-foreground">
+      <p>
+        I ♥ Open-Source software @ 2025 –{' '}
+        <a
+          href="https://github.com/supermarsx/sora-json-prompt-crafter"
+          className="underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GitHub Source
+        </a>
+      </p>
+    </footer>
+    {/* Google tag (gtag.js) */}
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-RVR9TSBQL7"></script>
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          if (localStorage.getItem('trackingEnabled') === 'false') {
+            window['ga-disable-G-RVR9TSBQL7'] = true;
+          }
+          gtag('js', new Date());
+          gtag('config', 'G-RVR9TSBQL7');
+        `,
+      }}
+    />
+  </>
 );
 
 export default Footer;


### PR DESCRIPTION
## Summary
- include Google Analytics tag in `Footer`
- make hero container flex so footer is pinned to bottom
- add tracking toggle to manage dropdown and persist to `localStorage`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685711eb836083259e8b9b049895b83b