### PR TITLE
Add tracking toggle and fix layout

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { Switch } from '@/components/ui/switch';
 import {
   Copy,
   Check,
@@ -25,6 +26,8 @@ interface ActionBarProps {
   onRegenerate: () => void;
   onRandomize: () => void;
   copied: boolean;
+  trackingEnabled: boolean;
+  onToggleTracking: (enabled: boolean) => void;
 }
 
 export const ActionBar: React.FC<ActionBarProps> = ({
@@ -37,6 +40,8 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   onRegenerate,
   onRandomize,
   copied,
+  trackingEnabled,
+  onToggleTracking,
 }) => {
   const [minimized, setMinimized] = useState(false);
 
@@ -83,6 +88,13 @@ export const ActionBar: React.FC<ActionBarProps> = ({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={onRandomize} className="gap-2">
             <Shuffle className="w-4 h-4" /> Randomize
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={(e) => e.preventDefault()} className="gap-2">
+            <span className="mr-2">Tracking</span>
+            <Switch
+              checked={trackingEnabled}
+              onCheckedChange={onToggleTracking}
+            />
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -13,6 +13,7 @@ import Footer from './Footer';
 import DisclaimerModal from './DisclaimerModal';
 import { useIsSingleColumn } from '@/hooks/use-single-column';
 import { useDarkMode } from '@/hooks/use-dark-mode';
+import { useTracking } from '@/hooks/use-tracking';
 
 export interface SoraOptions {
   prompt: string;
@@ -253,6 +254,7 @@ const Dashboard = () => {
   const jsonRef = React.useRef<HTMLDivElement>(null);
   const isSingleColumn = useIsSingleColumn();
   const [darkMode, setDarkMode] = useDarkMode();
+  const [trackingEnabled, setTrackingEnabled] = useTracking();
 
   useEffect(() => {
     localStorage.setItem('jsonHistory', JSON.stringify(history));
@@ -695,8 +697,8 @@ const Dashboard = () => {
   };
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto p-6">
+    <div className="min-h-screen flex flex-col bg-background">
+      <div className="container mx-auto p-6 flex-1 flex flex-col">
         <div className="mb-8 flex items-start justify-between">
           <div>
             <h1 className="text-4xl font-bold mb-2 flex items-center gap-3 select-none">
@@ -742,7 +744,7 @@ const Dashboard = () => {
           </Button>
         </div>
         
-        <div className="grid lg:grid-cols-2 gap-6 h-[calc(100vh-12rem)]">
+        <div className="grid lg:grid-cols-2 gap-6 flex-1">
           <Card className="flex flex-col" ref={jsonRef}>
             <CardHeader className="border-b">
               <CardTitle className="flex items-center gap-2">
@@ -799,6 +801,8 @@ const Dashboard = () => {
         onRegenerate={regenerateJson}
         onRandomize={randomizeJson}
         copied={copied}
+        trackingEnabled={trackingEnabled}
+        onToggleTracking={setTrackingEnabled}
       />
       <ShareModal
         isOpen={showShareModal}
@@ -821,7 +825,7 @@ const Dashboard = () => {
         onImport={importJson}
       />
       <DisclaimerModal open={showDisclaimer} onOpenChange={setShowDisclaimer} />
-      <Footer />
+      <Footer trackingEnabled={trackingEnabled} />
       <ProgressBar />
     </div>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,19 +1,46 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
-const Footer = () => (
-  <footer className="py-6 text-center text-sm text-muted-foreground">
-    <p>
-      I ♥ Open-Source software @ 2025 –{' '}
-      <a
-        href="https://github.com/supermarsx/sora-json-prompt-crafter"
-        className="underline"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        GitHub Source
-      </a>
-    </p>
-  </footer>
-);
+interface FooterProps {
+  trackingEnabled: boolean;
+}
+
+const GA_ID = 'G-RVR9TSBQL7';
+
+const Footer: React.FC<FooterProps> = ({ trackingEnabled }) => {
+  useEffect(() => {
+    const win = window as Window & Record<string, unknown>;
+    if (!trackingEnabled) {
+      win[`ga-disable-${GA_ID}`] = true;
+      return;
+    }
+    win[`ga-disable-${GA_ID}`] = false;
+    if (document.getElementById('ga-script')) return;
+    const script = document.createElement('script');
+    script.id = 'ga-script';
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
+    document.body.appendChild(script);
+
+    const inline = document.createElement('script');
+    inline.innerHTML = `window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', '${GA_ID}');`;
+    document.body.appendChild(inline);
+  }, [trackingEnabled]);
+
+  return (
+    <footer className="py-6 text-center text-sm text-muted-foreground">
+      <p>
+        I ♥ Open-Source software @ 2025 –{' '}
+        <a
+          href="https://github.com/supermarsx/sora-json-prompt-crafter"
+          className="underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GitHub Source
+        </a>
+      </p>
+    </footer>
+  );
+};
 
 export default Footer;

--- a/src/hooks/use-tracking.ts
+++ b/src/hooks/use-tracking.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react'
+
+export function useTracking() {
+  const [enabled, setEnabled] = useState(() => {
+    try {
+      const stored = localStorage.getItem('trackingEnabled')
+      return stored ? JSON.parse(stored) : true
+    } catch {
+      return true
+    }
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('trackingEnabled', JSON.stringify(enabled))
+    } catch {
+      /* ignore */
+    }
+  }, [enabled])
+
+  return [enabled, setEnabled] as const
+}


### PR DESCRIPTION
## Summary
- integrate Google Analytics in the footer
- add tracking toggle inside the Manage dropdown
- persist tracking setting in localStorage
- ensure footer sticks to bottom with flexible layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685711eb836083259e8b9b049895b83b