### PR TITLE
Add analytics tracking toggle

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -10,6 +10,8 @@ import {
   RotateCcw,
   RefreshCw,
   Shuffle,
+  Eye,
+  EyeOff,
   Trash2,
   ChevronDown,
   ChevronUp,
@@ -24,6 +26,8 @@ interface ActionBarProps {
   onReset: () => void;
   onRegenerate: () => void;
   onRandomize: () => void;
+  trackingEnabled: boolean;
+  onToggleTracking: () => void;
   copied: boolean;
 }
 
@@ -36,6 +40,8 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   onReset,
   onRegenerate,
   onRandomize,
+  trackingEnabled,
+  onToggleTracking,
   copied,
 }) => {
   const [minimized, setMinimized] = useState(false);
@@ -83,6 +89,17 @@ export const ActionBar: React.FC<ActionBarProps> = ({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={onRandomize} className="gap-2">
             <Shuffle className="w-4 h-4" /> Randomize
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onToggleTracking} className="gap-2">
+            {trackingEnabled ? (
+              <>
+                <EyeOff className="w-4 h-4" /> Disable Tracking
+              </>
+            ) : (
+              <>
+                <Eye className="w-4 h-4" /> Enable Tracking
+              </>
+            )}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -13,6 +13,7 @@ import Footer from './Footer';
 import DisclaimerModal from './DisclaimerModal';
 import { useIsSingleColumn } from '@/hooks/use-single-column';
 import { useDarkMode } from '@/hooks/use-dark-mode';
+import { useTracking } from '@/hooks/use-tracking';
 
 export interface SoraOptions {
   prompt: string;
@@ -251,8 +252,10 @@ const Dashboard = () => {
     }
   });
   const jsonRef = React.useRef<HTMLDivElement>(null);
+  const jsonContainerRef = React.useRef<HTMLDivElement>(null);
   const isSingleColumn = useIsSingleColumn();
   const [darkMode, setDarkMode] = useDarkMode();
+  const [trackingEnabled, setTrackingEnabled] = useTracking();
 
   useEffect(() => {
     localStorage.setItem('jsonHistory', JSON.stringify(history));
@@ -260,6 +263,18 @@ const Dashboard = () => {
 
   useEffect(() => {
     localStorage.setItem('currentJson', jsonString);
+  }, [jsonString]);
+
+  useEffect(() => {
+    const container = jsonContainerRef.current;
+    if (!container) return;
+    const atBottom = Math.abs(container.scrollHeight - container.scrollTop - container.clientHeight) < 5;
+    const atTop = container.scrollTop === 0;
+    if (atBottom) {
+      container.scrollTop = container.scrollHeight;
+    } else if (atTop) {
+      container.scrollTop = 0;
+    }
   }, [jsonString]);
 
   useEffect(() => {
@@ -695,8 +710,8 @@ const Dashboard = () => {
   };
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto p-6">
+    <div className="min-h-screen flex flex-col bg-background">
+      <div className="container mx-auto p-6 flex flex-col flex-1">
         <div className="mb-8 flex items-start justify-between">
           <div>
             <h1 className="text-4xl font-bold mb-2 flex items-center gap-3 select-none">
@@ -707,10 +722,11 @@ const Dashboard = () => {
             <div className="flex items-center gap-2 mt-2">
               <a
                 className="github-button"
-                href="https://github.com/supermarsx"
+                href="https://github.com/sponsors/supermarsx"
                 data-icon="octicon-heart"
                 data-size="large"
                 aria-label="Sponsor supermarsx"
+                data-color-scheme={darkMode ? 'dark_high_contrast' : 'light_high_contrast'}
               >
                 Sponsor
               </a>
@@ -721,6 +737,7 @@ const Dashboard = () => {
                 data-show-count="true"
                 data-size="large"
                 aria-label="Star supermarsx/sora-json-prompt-crafter on GitHub"
+                data-color-scheme={darkMode ? 'dark_high_contrast' : 'light_high_contrast'}
               >
                 Star
               </a>
@@ -742,7 +759,7 @@ const Dashboard = () => {
           </Button>
         </div>
         
-        <div className="grid lg:grid-cols-2 gap-6 h-[calc(100vh-12rem)]">
+        <div className="grid lg:grid-cols-2 gap-6 flex-1">
           <Card className="flex flex-col" ref={jsonRef}>
             <CardHeader className="border-b">
               <CardTitle className="flex items-center gap-2">
@@ -769,7 +786,7 @@ const Dashboard = () => {
               </CardTitle>
             </CardHeader>
             <CardContent className="flex-1 p-0 overflow-hidden">
-              <div className="h-full overflow-y-auto">
+              <div className="h-full overflow-y-auto" ref={jsonContainerRef}>
                 <pre className="p-6 text-sm font-mono whitespace-pre-wrap break-words leading-relaxed">
                   <code>{jsonString}</code>
                 </pre>
@@ -798,6 +815,8 @@ const Dashboard = () => {
         onReset={resetJson}
         onRegenerate={regenerateJson}
         onRandomize={randomizeJson}
+        trackingEnabled={trackingEnabled}
+        onToggleTracking={() => setTrackingEnabled(!trackingEnabled)}
         copied={copied}
       />
       <ShareModal

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,19 +1,38 @@
 import React from 'react';
+import { useTracking } from '@/hooks/use-tracking';
 
-const Footer = () => (
-  <footer className="py-6 text-center text-sm text-muted-foreground">
-    <p>
-      I ♥ Open-Source software @ 2025 –{' '}
-      <a
-        href="https://github.com/supermarsx/sora-json-prompt-crafter"
-        className="underline"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        GitHub Source
-      </a>
-    </p>
-  </footer>
-);
+const Footer = () => {
+  const [trackingEnabled] = useTracking();
+
+  return (
+    <footer className="py-6 text-center text-sm text-muted-foreground">
+      <p>
+        I ♥ Open-Source software @ 2025 –{' '}
+        <a
+          href="https://github.com/supermarsx/sora-json-prompt-crafter"
+          className="underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GitHub Source
+        </a>
+      </p>
+      {trackingEnabled && (
+        <>
+          {/* Google tag (gtag.js) */}
+          <script async src="https://www.googletagmanager.com/gtag/js?id=G-RVR9TSBQL7"></script>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'G-RVR9TSBQL7');`,
+            }}
+          />
+        </>
+      )}
+    </footer>
+  );
+};
 
 export default Footer;

--- a/src/hooks/use-tracking.ts
+++ b/src/hooks/use-tracking.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+export function useTracking() {
+  const [enabled, setEnabled] = useState(() => {
+    try {
+      const stored = localStorage.getItem('trackingEnabled')
+      return stored ? JSON.parse(stored) : true
+    } catch {
+      return true
+    }
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('trackingEnabled', JSON.stringify(enabled))
+    } catch {
+      /* ignore */
+    }
+  }, [enabled])
+
+  return [enabled, setEnabled] as const
+}


### PR DESCRIPTION
## Summary
- include Google Analytics tag in footer when tracking enabled
- persist analytics tracking state with `useTracking`
- toggle tracking from Manage menu in action bar
- adjust hero to fill page so footer stays at bottom
- update Github buttons to respect theme and new sponsor link
- keep JSON viewer scrolled to top/bottom on changes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68572019fdb48325a36e310689bcf623