### PR TITLE
Modify history panel, manage button, upscale slider

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -13,6 +13,7 @@ import {
   Eye,
   EyeOff,
   Trash2,
+  Cog,
   ChevronDown,
   ChevronUp,
 } from 'lucide-react';
@@ -74,7 +75,7 @@ export const ActionBar: React.FC<ActionBarProps> = ({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="outline" size="sm" className="gap-2">
-            <Import className="w-4 h-4" /> Manage
+            <Cog className="w-4 h-4" /> Manage
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -26,6 +26,7 @@ import {
   Import as ImportIcon,
   Download,
 } from 'lucide-react'
+import { toast } from 'sonner'
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -86,6 +87,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
   const exportClipboard = async () => {
     try {
       await navigator.clipboard.writeText(JSON.stringify(history, null, 2))
+      toast.success('Copied all history to clipboard!')
     } catch {
       /* ignore */
     }
@@ -96,8 +98,25 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
     const blob = new Blob([data], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
+    const now = new Date()
+    const datetime = `${now.getFullYear()}${(now.getMonth() + 1)
+      .toString()
+      .padStart(2, '0')}${now
+      .getDate()
+      .toString()
+      .padStart(2, '0')}-${now
+      .getHours()
+      .toString()
+      .padStart(2, '0')}${now
+      .getMinutes()
+      .toString()
+      .padStart(2, '0')}${now
+      .getSeconds()
+      .toString()
+      .padStart(2, '0')}`
+    const rand = Math.random().toString(16).slice(2, 8)
     a.href = url
-    a.download = 'history.json'
+    a.download = `history-${datetime}-${rand}.json`
     a.click()
     URL.revokeObjectURL(url)
   }

--- a/src/components/sections/EnhancementsSection.tsx
+++ b/src/components/sections/EnhancementsSection.tsx
@@ -66,19 +66,18 @@ export const EnhancementsSection: React.FC<EnhancementsSectionProps> = ({
           <Label htmlFor="use_upscale_factor">Use Upscale Factor</Label>
         </div>
 
-        {options.use_upscale_factor && (
-          <div>
-            <Label htmlFor="upscale">Upscale Factor: {options.upscale}</Label>
-            <Slider
-              value={[options.upscale]}
-              onValueChange={(value) => updateOptions({ upscale: value[0] })}
-              min={1}
-              max={4}
-              step={0.1}
-              className="mt-2"
-            />
-          </div>
-        )}
+        <div>
+          <Label htmlFor="upscale">Upscale Factor: {options.upscale}</Label>
+          <Slider
+            value={[options.upscale]}
+            onValueChange={(value) => updateOptions({ upscale: value[0] })}
+            min={1}
+            max={4}
+            step={0.1}
+            className="mt-2"
+            disabled={!options.use_upscale_factor}
+          />
+        </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox


### PR DESCRIPTION
## Summary
- keep upscale factor slider visible and disabled when not used
- show toast when copying all history to clipboard
- generate dated filename for exported history JSON
- change manage button icon to a cog

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68572afac37c8325a1c0a409d98589ad