### PR TITLE
Implement json highlight and dark mode logo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
+        "diff": "^5.2.0",
         "embla-carousel-react": "^8.3.0",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
@@ -3861,6 +3862,15 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
+    "diff": "^5.2.0",
     "embla-carousel-react": "^8.3.0",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -81,12 +81,22 @@ export default {
                                 rainbow: {
                                         '0%': { filter: 'hue-rotate(0deg)' },
                                         '100%': { filter: 'hue-rotate(360deg)' }
+                                },
+                                'rainbow-dark': {
+                                        '0%': { filter: 'invert(100%) brightness(70%) hue-rotate(0deg)' },
+                                        '100%': { filter: 'invert(100%) brightness(70%) hue-rotate(360deg)' }
+                                },
+                                highlight: {
+                                        '0%': { backgroundColor: 'rgba(253, 224, 71, 0.4)' },
+                                        '100%': { backgroundColor: 'transparent' }
                                 }
                         },
                         animation: {
                                 'accordion-down': 'accordion-down 0.2s ease-out',
                                 'accordion-up': 'accordion-up 0.2s ease-out',
-                                rainbow: 'rainbow 10s linear infinite'
+                                rainbow: 'rainbow 10s linear infinite',
+                                'rainbow-dark': 'rainbow-dark 10s linear infinite',
+                                highlight: 'highlight 2s ease-in-out'
                         }
                 }
         },


### PR DESCRIPTION
## Summary
- animate only new JSON with `diff` and highlight animation
- keep logo animation visible in dark mode
- define new `rainbow-dark` and `highlight` animations
- add `diff` to dependencies

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857399a0ee08325a9ca7ce0a9542b7b