### PR TITLE
Fix history UX and DnD settings

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -100,7 +100,23 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
         options={options}
         updateOptions={updateOptions}
         isEnabled={options.use_dnd_section}
-        onToggle={(enabled) => updateOptions({ use_dnd_section: enabled })}
+        onToggle={(enabled) =>
+          updateOptions({
+            use_dnd_section: enabled,
+            ...(enabled
+              ? {}
+              : {
+                  use_dnd_character_race: false,
+                  use_dnd_character_class: false,
+                  use_dnd_character_background: false,
+                  use_dnd_character_alignment: false,
+                  use_dnd_monster_type: false,
+                  use_dnd_environment: false,
+                  use_dnd_magic_school: false,
+                  use_dnd_item_type: false,
+                })
+          })
+        }
       />
     </div>
   );

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -755,7 +755,82 @@ const Dashboard = () => {
   const editHistoryEntry = (json: string) => {
     try {
       const obj = JSON.parse(json);
-      setOptions(prev => ({ ...prev, ...obj }));
+      const enableMap: Record<string, keyof SoraOptions> = {
+        negative_prompt: 'use_negative_prompt',
+        width: 'use_dimensions_format',
+        height: 'use_dimensions_format',
+        aspect_ratio: 'use_dimensions_format',
+        output_format: 'use_dimensions_format',
+        dynamic_range: 'use_dimensions_format',
+        style_preset: 'use_style_preset',
+        made_out_of: 'use_material',
+        secondary_material: 'use_secondary_material',
+        lighting: 'use_lighting',
+        color_grade: 'use_color_grading',
+        environment: 'use_environment',
+        location: 'use_location',
+        year: 'use_settings_location',
+        season: 'use_season',
+        atmosphere_mood: 'use_atmosphere_mood',
+        subject_mood: 'use_subject_mood',
+        sword_type: 'use_sword_type',
+        sword_vibe: 'use_sword_type',
+        upscale: 'use_upscale_factor',
+        safety_filter: 'use_safety_filter',
+        quality_booster: 'use_quality_booster',
+        prevent_deformities: 'use_enhancement_safety',
+        keep_typography_details: 'use_enhancement_safety',
+        enhance_object_reflections: 'use_enhancement_safety',
+        keep_key_details: 'use_enhancement_safety',
+        add_same_face: 'use_face_enhancements',
+        dont_change_face: 'use_face_enhancements',
+        subject_gender: 'use_subject_gender',
+        makeup_style: 'use_makeup_style',
+        character_mood: 'use_character_mood',
+        black_and_white_preset: 'use_black_and_white',
+        special_effects: 'use_special_effects',
+        lut_preset: 'use_lut_preset',
+        dnd_character_race: 'use_dnd_character_race',
+        dnd_character_class: 'use_dnd_character_class',
+        dnd_character_background: 'use_dnd_character_background',
+        dnd_character_alignment: 'use_dnd_character_alignment',
+        dnd_monster_type: 'use_dnd_monster_type',
+        dnd_environment: 'use_dnd_environment',
+        dnd_magic_school: 'use_dnd_magic_school',
+        dnd_item_type: 'use_dnd_item_type',
+        camera_angle: 'use_camera_composition',
+        shot_type: 'use_camera_composition',
+        subject_focus: 'use_camera_composition',
+        composition_rules: 'use_camera_composition',
+        camera_type: 'use_camera_composition',
+        lens_type: 'use_lens_type',
+        aperture: 'use_aperture',
+        depth_of_field: 'use_dof',
+        blur_style: 'use_blur_style',
+        motion_strength: 'use_motion_animation',
+        camera_motion: 'use_motion_animation',
+        motion_direction: 'use_motion_animation',
+        fps: 'use_motion_animation',
+        frame_interpolation: 'use_motion_animation',
+        duration_seconds: 'use_duration',
+        seed: 'use_core_settings',
+        steps: 'use_core_settings',
+        guidance_scale: 'use_core_settings',
+        temperature: 'use_core_settings',
+        cfg_rescale: 'use_core_settings',
+        quality: 'use_core_settings',
+        signature: 'use_signature',
+      };
+
+      const flagUpdates: Partial<SoraOptions> = {};
+      Object.keys(obj).forEach(key => {
+        const flag = enableMap[key as keyof typeof enableMap];
+        if (flag) (flagUpdates as Record<string, unknown>)[flag] = true;
+        if (key.startsWith('dnd_')) flagUpdates.use_dnd_section = true;
+        if (key === 'width' || key === 'height') flagUpdates.use_dimensions = true;
+      });
+      setJsonString('{}');
+      setOptions(prev => ({ ...prev, ...obj, ...flagUpdates }));
       document
         .getElementById('generated-json')
         ?.scrollIntoView({ behavior: 'smooth' });

--- a/src/components/sections/DnDSection.tsx
+++ b/src/components/sections/DnDSection.tsx
@@ -81,101 +81,101 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
       <div className="grid grid-cols-1 gap-4">
         <div className="flex items-center space-x-2">
           <Checkbox
-            id="use_character_race"
-            checked={options.use_character_race}
-            onCheckedChange={(checked) => updateOptions({ use_character_race: !!checked })}
+            id="use_dnd_character_race"
+            checked={options.use_dnd_character_race}
+            onCheckedChange={(checked) => updateOptions({ use_dnd_character_race: !!checked })}
           />
-          <Label htmlFor="use_character_race">Use Character Race</Label>
+          <Label htmlFor="use_dnd_character_race">Use Character Race</Label>
         </div>
 
         <div>
           <Label>Character Race</Label>
           <SearchableDropdown
             options={characterRaceOptions}
-            value={options.character_race || 'human'}
-            onValueChange={(value) => updateOptions({ character_race: value })}
+            value={options.dnd_character_race || 'human'}
+            onValueChange={(value) => updateOptions({ dnd_character_race: value })}
             label="Character Race Options"
-            disabled={!options.use_character_race}
+            disabled={!options.use_dnd_character_race}
           />
         </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
-            id="use_character_class"
-            checked={options.use_character_class}
-            onCheckedChange={(checked) => updateOptions({ use_character_class: !!checked })}
+            id="use_dnd_character_class"
+            checked={options.use_dnd_character_class}
+            onCheckedChange={(checked) => updateOptions({ use_dnd_character_class: !!checked })}
           />
-          <Label htmlFor="use_character_class">Use Character Class</Label>
+          <Label htmlFor="use_dnd_character_class">Use Character Class</Label>
         </div>
 
         <div>
           <Label>Character Class</Label>
           <SearchableDropdown
             options={characterClassOptions}
-            value={options.character_class || 'fighter'}
-            onValueChange={(value) => updateOptions({ character_class: value })}
+            value={options.dnd_character_class || 'fighter'}
+            onValueChange={(value) => updateOptions({ dnd_character_class: value })}
             label="Character Class Options"
-            disabled={!options.use_character_class}
+            disabled={!options.use_dnd_character_class}
           />
         </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
-            id="use_character_background"
-            checked={options.use_character_background}
-            onCheckedChange={(checked) => updateOptions({ use_character_background: !!checked })}
+            id="use_dnd_character_background"
+            checked={options.use_dnd_character_background}
+            onCheckedChange={(checked) => updateOptions({ use_dnd_character_background: !!checked })}
           />
-          <Label htmlFor="use_character_background">Use Character Background</Label>
+          <Label htmlFor="use_dnd_character_background">Use Character Background</Label>
         </div>
 
         <div>
           <Label>Character Background</Label>
           <SearchableDropdown
             options={characterBackgroundOptions}
-            value={options.character_background || 'soldier'}
-            onValueChange={(value) => updateOptions({ character_background: value })}
+            value={options.dnd_character_background || 'soldier'}
+            onValueChange={(value) => updateOptions({ dnd_character_background: value })}
             label="Character Background Options"
-            disabled={!options.use_character_background}
+            disabled={!options.use_dnd_character_background}
           />
         </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
-            id="use_character_alignment"
-            checked={options.use_character_alignment}
-            onCheckedChange={(checked) => updateOptions({ use_character_alignment: !!checked })}
+            id="use_dnd_character_alignment"
+            checked={options.use_dnd_character_alignment}
+            onCheckedChange={(checked) => updateOptions({ use_dnd_character_alignment: !!checked })}
           />
-          <Label htmlFor="use_character_alignment">Use Character Alignment</Label>
+          <Label htmlFor="use_dnd_character_alignment">Use Character Alignment</Label>
         </div>
 
         <div>
           <Label>Character Alignment</Label>
           <SearchableDropdown
             options={characterAlignmentOptions}
-            value={options.character_alignment || 'lawful good'}
-            onValueChange={(value) => updateOptions({ character_alignment: value })}
+            value={options.dnd_character_alignment || 'lawful good'}
+            onValueChange={(value) => updateOptions({ dnd_character_alignment: value })}
             label="Character Alignment Options"
-            disabled={!options.use_character_alignment}
+            disabled={!options.use_dnd_character_alignment}
           />
         </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
-            id="use_monster_type"
-            checked={options.use_monster_type}
-            onCheckedChange={(checked) => updateOptions({ use_monster_type: !!checked })}
+            id="use_dnd_monster_type"
+            checked={options.use_dnd_monster_type}
+            onCheckedChange={(checked) => updateOptions({ use_dnd_monster_type: !!checked })}
           />
-          <Label htmlFor="use_monster_type">Use Monster Type</Label>
+          <Label htmlFor="use_dnd_monster_type">Use Monster Type</Label>
         </div>
 
         <div>
           <Label>Monster Type</Label>
           <SearchableDropdown
             options={monsterTypeOptions}
-            value={options.monster_type || 'dragon'}
-            onValueChange={(value) => updateOptions({ monster_type: value })}
+            value={options.dnd_monster_type || 'dragon'}
+            onValueChange={(value) => updateOptions({ dnd_monster_type: value })}
             label="Monster Type Options"
-            disabled={!options.use_monster_type}
+            disabled={!options.use_dnd_monster_type}
           />
         </div>
 
@@ -201,41 +201,41 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
 
         <div className="flex items-center space-x-2">
           <Checkbox
-            id="use_magic_school"
-            checked={options.use_magic_school}
-            onCheckedChange={(checked) => updateOptions({ use_magic_school: !!checked })}
+            id="use_dnd_magic_school"
+            checked={options.use_dnd_magic_school}
+            onCheckedChange={(checked) => updateOptions({ use_dnd_magic_school: !!checked })}
           />
-          <Label htmlFor="use_magic_school">Use Magic School</Label>
+          <Label htmlFor="use_dnd_magic_school">Use Magic School</Label>
         </div>
 
         <div>
           <Label>Magic School</Label>
           <SearchableDropdown
             options={magicSchoolOptions}
-            value={options.magic_school || 'evocation'}
-            onValueChange={(value) => updateOptions({ magic_school: value })}
+            value={options.dnd_magic_school || 'evocation'}
+            onValueChange={(value) => updateOptions({ dnd_magic_school: value })}
             label="Magic School Options"
-            disabled={!options.use_magic_school}
+            disabled={!options.use_dnd_magic_school}
           />
         </div>
 
         <div className="flex items-center space-x-2">
           <Checkbox
-            id="use_item_type"
-            checked={options.use_item_type}
-            onCheckedChange={(checked) => updateOptions({ use_item_type: !!checked })}
+            id="use_dnd_item_type"
+            checked={options.use_dnd_item_type}
+            onCheckedChange={(checked) => updateOptions({ use_dnd_item_type: !!checked })}
           />
-          <Label htmlFor="use_item_type">Use Item Type</Label>
+          <Label htmlFor="use_dnd_item_type">Use Item Type</Label>
         </div>
 
         <div>
           <Label>Item Type</Label>
           <SearchableDropdown
             options={itemTypeOptions}
-            value={options.item_type || 'magic sword'}
-            onValueChange={(value) => updateOptions({ item_type: value })}
+            value={options.dnd_item_type || 'magic sword'}
+            onValueChange={(value) => updateOptions({ dnd_item_type: value })}
             label="Item Type Options"
-            disabled={!options.use_item_type}
+            disabled={!options.use_dnd_item_type}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add state to confirm clearing latest actions
- add confirmation button for each latest action deletion
- rename latest actions clear button
- enable nested DnD options and fix naming
- enable sections when applying history entries

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857b38c03388325a08af5f1eabc696f