### PR TITLE
Fix history display and DnD toggle

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -103,18 +103,6 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
         onToggle={(enabled) =>
           updateOptions({
             use_dnd_section: enabled,
-            ...(enabled
-              ? {}
-              : {
-                  use_dnd_character_race: false,
-                  use_dnd_character_class: false,
-                  use_dnd_character_background: false,
-                  use_dnd_character_alignment: false,
-                  use_dnd_monster_type: false,
-                  use_dnd_environment: false,
-                  use_dnd_magic_school: false,
-                  use_dnd_item_type: false,
-                })
           })
         }
       />

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -292,28 +292,9 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
                   {(() => {
                     try {
                       const obj = JSON.parse(entry.json)
-                      const { prompt, ...rest } = obj
-                      const flatten = (o: Record<string, unknown>, p = ''): Record<string, unknown> => {
-                        return Object.keys(o).reduce((acc, k) => {
-                          const v = o[k]
-                          const key = p ? `${p}.${k}` : k
-                          if (v && typeof v === 'object' && !Array.isArray(v)) {
-                            Object.assign(acc, flatten(v, key))
-                          } else {
-                            acc[key] = v
-                          }
-                          return acc
-                        }, {} as Record<string, unknown>)
-                      }
-                      const flat = flatten(rest)
-                      const keys = Object.keys(flat)
-                      const sample = keys.sort(() => 0.5 - Math.random()).slice(0, 3)
                       return (
                         <div className="space-y-1 text-xs text-muted-foreground">
-                          <div className="font-medium break-words">{prompt}</div>
-                          <div>
-                            {sample.map(key => `${key}: ${String(flat[key])}`).join(', ')}
-                          </div>
+                          <div className="font-medium break-words">{obj.prompt}</div>
                         </div>
                       )
                     } catch {
@@ -501,7 +482,8 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
               <pre className="whitespace-pre-wrap text-xs p-2">
                 {(() => {
                   try {
-                    return JSON.stringify(JSON.parse(preview.json), null, 2)
+                    const obj = JSON.parse(preview.json)
+                    return JSON.stringify({ prompt: obj.prompt }, null, 2)
                   } catch {
                     return preview.json
                   }


### PR DESCRIPTION
## Summary
- clean up history item preview and make JSON preview only show the prompt
- don't reset all DnD flags when disabling the section

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857b7a2b25c8325805f2404f0f3148d