### PR TITLE
Fix bulk import for prompt history

### DIFF
--- a/src/components/BulkFileImportModal.tsx
+++ b/src/components/BulkFileImportModal.tsx
@@ -35,8 +35,18 @@ const BulkFileImportModal: React.FC<BulkFileImportModalProps> = ({
       const text = await file.text();
       const parsed = JSON.parse(text);
       const jsons = Array.isArray(parsed)
-        ? parsed.map(j => (typeof j === 'string' ? j : JSON.stringify(j)))
-        : [typeof parsed === 'string' ? parsed : JSON.stringify(parsed)];
+        ? parsed.map(j => {
+            if (typeof j === 'string') return j;
+            if (j && typeof j === 'object' && 'json' in j) return j.json as string;
+            return JSON.stringify(j);
+          })
+        : [
+            typeof parsed === 'string'
+              ? parsed
+              : parsed && typeof parsed === 'object' && 'json' in parsed
+                ? (parsed as { json: string }).json
+                : JSON.stringify(parsed),
+          ];
       onImport(jsons);
       toast.success('File imported!');
       trackEvent(trackingEnabled, 'history_import', { type: 'bulk_file' })

--- a/src/components/ClipboardImportModal.tsx
+++ b/src/components/ClipboardImportModal.tsx
@@ -42,10 +42,20 @@ const ClipboardImportModal: React.FC<ClipboardImportModalProps> = ({
     try {
       const parsed = JSON.parse(text)
       if (Array.isArray(parsed)) {
-        const strings = parsed.map(j => (typeof j === 'string' ? j : JSON.stringify(j)))
+        const strings = parsed.map(j => {
+          if (typeof j === 'string') return j
+          if (j && typeof j === 'object' && 'json' in j) return j.json as string
+          return JSON.stringify(j)
+        })
         onImport(strings)
       } else {
-        onImport([typeof parsed === 'string' ? parsed : JSON.stringify(parsed)])
+        onImport([
+          typeof parsed === 'string'
+            ? parsed
+            : parsed && typeof parsed === 'object' && 'json' in parsed
+              ? (parsed as { json: string }).json
+              : JSON.stringify(parsed)
+        ])
       }
     } catch {
       onImport([text])


### PR DESCRIPTION
## Summary
- keep imported JSON clean of history metadata when bulk importing from clipboard or file

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857bc7e160c83259499e8c74dbb8fd2