### PR TITLE
Add tracking improvements and issue link

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -19,16 +19,22 @@ interface ControlPanelProps {
   options: SoraOptions;
   updateOptions: (updates: Partial<SoraOptions>) => void;
   updateNestedOptions: (path: string, value: unknown) => void;
+  trackingEnabled: boolean;
 }
 
 export const ControlPanel: React.FC<ControlPanelProps> = ({
   options,
   updateOptions,
   updateNestedOptions,
+  trackingEnabled,
 }) => {
   return (
     <div className="space-y-6 p-6">
-      <PromptSection options={options} updateOptions={updateOptions} />
+      <PromptSection
+        options={options}
+        updateOptions={updateOptions}
+        trackingEnabled={trackingEnabled}
+      />
       
       <CoreSettingsSection 
         options={options} 

--- a/src/components/sections/PromptSection.tsx
+++ b/src/components/sections/PromptSection.tsx
@@ -4,13 +4,19 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Checkbox } from '@/components/ui/checkbox';
 import { SoraOptions } from '../Dashboard';
+import { useResizeTracker } from '@/hooks/use-resize-tracker';
 
 interface PromptSectionProps {
   options: SoraOptions;
   updateOptions: (updates: Partial<SoraOptions>) => void;
+  trackingEnabled: boolean;
 }
 
-export const PromptSection: React.FC<PromptSectionProps> = ({ options, updateOptions }) => {
+export const PromptSection: React.FC<PromptSectionProps> = ({ options, updateOptions, trackingEnabled }) => {
+  const promptRef = React.useRef<HTMLTextAreaElement>(null)
+  const negativeRef = React.useRef<HTMLTextAreaElement>(null)
+  useResizeTracker(promptRef, trackingEnabled, 'prompt_resize')
+  useResizeTracker(negativeRef, trackingEnabled, 'negative_prompt_resize')
   return (
     <div className="space-y-4">
       <div>
@@ -23,9 +29,10 @@ export const PromptSection: React.FC<PromptSectionProps> = ({ options, updateOpt
           onChange={(e) => updateOptions({ prompt: e.target.value })}
           placeholder="Describe what you want to generate..."
           className="min-h-[100px] resize-y"
+          ref={promptRef}
         />
       </div>
-      
+
       <div>
         <div className="flex items-center space-x-2 mb-2">
           <Checkbox
@@ -46,6 +53,7 @@ export const PromptSection: React.FC<PromptSectionProps> = ({ options, updateOpt
           placeholder="Describe what you want to avoid..."
           className="min-h-[80px] resize-y"
           disabled={!options.use_negative_prompt}
+          ref={negativeRef}
         />
       </div>
     </div>

--- a/src/hooks/use-resize-tracker.ts
+++ b/src/hooks/use-resize-tracker.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+import { trackEvent } from '@/lib/analytics'
+
+export function useResizeTracker(
+  ref: React.RefObject<HTMLElement>,
+  trackingEnabled: boolean,
+  event: string
+) {
+  useEffect(() => {
+    const el = ref.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+    let prevWidth = el.offsetWidth
+    let prevHeight = el.offsetHeight
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect
+        if (width !== prevWidth || height !== prevHeight) {
+          prevWidth = width
+          prevHeight = height
+          trackEvent(trackingEnabled, event)
+        }
+      }
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [ref, trackingEnabled, event])
+}


### PR DESCRIPTION
## Summary
- add resize tracking hook and apply to prompt textareas
- track prompt, negative prompt, and generic input changes
- strip false boolean flags in generated JSON
- expose tracking flag to control panel
- add link to GitHub issues with bug icon

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6857bfdae95c83259736002d994d1002