### PR TITLE
Add tracking confirmation and throttling

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -4,6 +4,16 @@ import { toast } from 'sonner'
 import { trackEvent } from '@/lib/analytics'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
   Copy,
   Check,
   Share,
@@ -54,6 +64,8 @@ export const ActionBar: React.FC<ActionBarProps> = ({
 }) => {
   const [minimized, setMinimized] = useState(false);
   const [clearing, setClearing] = useState(false);
+  const [confirmDisableTracking, setConfirmDisableTracking] = useState(false);
+  const [confirmEnableTracking, setConfirmEnableTracking] = useState(false);
 
   if (minimized) {
     return (
@@ -118,10 +130,11 @@ export const ActionBar: React.FC<ActionBarProps> = ({
           </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => {
-              onToggleTracking()
-              const newStatus = !trackingEnabled
-              toast.success(newStatus ? 'Tracking enabled' : 'Tracking disabled')
-              trackEvent(trackingEnabled, 'toggle_tracking', { enabled: newStatus })
+              if (trackingEnabled) {
+                setConfirmDisableTracking(true)
+              } else {
+                setConfirmEnableTracking(true)
+              }
             }}
             className="gap-2"
           >
@@ -166,6 +179,56 @@ export const ActionBar: React.FC<ActionBarProps> = ({
       >
         <ChevronDown className="w-4 h-4" />
       </Button>
+
+      <AlertDialog open={confirmDisableTracking} onOpenChange={setConfirmDisableTracking}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Disable tracking?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will stop sending anonymous usage data.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                onToggleTracking()
+                toast.success('Tracking disabled')
+                trackEvent(true, 'disable_tracking_confirm')
+                trackEvent(true, 'toggle_tracking', { enabled: false })
+                setConfirmDisableTracking(false)
+              }}
+            >
+              Disable
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={confirmEnableTracking} onOpenChange={setConfirmEnableTracking}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Enable tracking?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This allows sending anonymous usage data to help improve the app.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                onToggleTracking()
+                toast.success('Tracking enabled')
+                trackEvent(true, 'enable_tracking_confirm')
+                trackEvent(true, 'toggle_tracking', { enabled: true })
+                setConfirmEnableTracking(false)
+              }}
+            >
+              Enable
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };

--- a/src/hooks/use-resize-tracker.ts
+++ b/src/hooks/use-resize-tracker.ts
@@ -11,13 +11,18 @@ export function useResizeTracker(
     if (!el || typeof ResizeObserver === 'undefined') return
     let prevWidth = el.offsetWidth
     let prevHeight = el.offsetHeight
+    let lastTracked = 0
     const observer = new ResizeObserver(entries => {
       for (const entry of entries) {
         const { width, height } = entry.contentRect
         if (width !== prevWidth || height !== prevHeight) {
           prevWidth = width
           prevHeight = height
-          trackEvent(trackingEnabled, event)
+          const now = Date.now()
+          if (now - lastTracked > 1000) {
+            lastTracked = now
+            trackEvent(trackingEnabled, event)
+          }
         }
       }
     })

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,3 +1,5 @@
+const MEASUREMENT_ID = 'G-RVR9TSBQL7'
+
 export function trackEvent(
   enabled: boolean,
   event: string,
@@ -27,6 +29,6 @@ export function trackEvent(
     }
   ).gtag
   if (typeof gtag === 'function') {
-    gtag('event', event, params)
+    gtag('event', event, { send_to: MEASUREMENT_ID, ...params })
   }
 }


### PR DESCRIPTION
## Summary
- throttle resize tracking to once per second
- send events directly to GA measurement ID
- require confirmation before enabling/disabling tracking

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857c93879b08325a68b7b42d3c0bf5c