### PR TITLE
Fix header wrapping on mobile

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -884,7 +884,7 @@ const Dashboard = () => {
               Sora JSON Prompt Crafter
             </h1>
             <p className="text-muted-foreground select-none">Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.</p>
-            <div className="flex items-center gap-2 mt-2">
+            <div className="flex flex-wrap items-center gap-2 mt-2">
               <Button asChild variant="outline" size="sm" className="gap-1">
                 <a
                   href="https://github.com/sponsors/supermarsx"


### PR DESCRIPTION
## Summary
- allow header buttons to wrap on small screens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857cb18be488325a31bf7f124b90597