### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm install
+      - run: npm run lint
+      - run: npm run build

--- a/readme.md
+++ b/readme.md
@@ -168,3 +168,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## CI Status
+
+[![CI](https://github.com/supermarsx/sora-json-prompt-crafter/actions/workflows/ci.yml/badge.svg)](https://github.com/supermarsx/sora-json-prompt-crafter/actions/workflows/ci.yml)


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run lint and build
- document CI status badge in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857dab069848325b1959e565d857ac8