### PR TITLE
Display git version in footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,6 +5,8 @@ interface FooterProps {
 }
 
 const Footer: React.FC<FooterProps> = ({ onShowDisclaimer }) => {
+  const commit = import.meta.env.VITE_COMMIT_HASH
+  const date = import.meta.env.VITE_COMMIT_DATE
   return (
     <footer className="py-6 text-center text-sm text-muted-foreground">
       <p>
@@ -21,6 +23,7 @@ const Footer: React.FC<FooterProps> = ({ onShowDisclaimer }) => {
           Disclaimer
         </button>
       </p>
+      <p className="mt-2 text-xs">Version {commit} ({date})</p>
       {/* Tracking scripts moved to index.html */}
     </footer>
   );

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_COMMIT_HASH: string
+  readonly VITE_COMMIT_DATE: string
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
+import { execSync } from "child_process";
+
+const commitHash = execSync("git rev-parse --short HEAD").toString().trim();
+const commitDate = execSync(
+  "git show -s --date=format:%y%m%d --format=%cd"
+).toString().trim();
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -18,5 +24,9 @@ export default defineConfig(({ mode }) => ({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
+  },
+  define: {
+    "import.meta.env.VITE_COMMIT_HASH": JSON.stringify(commitHash),
+    "import.meta.env.VITE_COMMIT_DATE": JSON.stringify(commitDate),
   },
 }));


### PR DESCRIPTION
## Summary
- inject commit info from git into Vite build
- expose `VITE_COMMIT_HASH` and `VITE_COMMIT_DATE` variables
- show the build version in the footer

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857dd52def0832582f55d702094d621