### PR TITLE
Fix lint error in analytics test

### DIFF
--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -15,7 +15,11 @@ describe('trackEvent', () => {
 
   test('updates localStorage and dispatches event when enabled', () => {
     const dispatchSpy = jest.spyOn(window, 'dispatchEvent')
-    ;(window as any).gtag = jest.fn()
+    ;(
+      window as unknown as {
+        gtag?: jest.Mock
+      }
+    ).gtag = jest.fn()
     trackEvent(true, 'scroll_bottom')
     const stored = JSON.parse(localStorage.getItem('trackingHistory') || '[]')
     expect(stored[0].action).toBe('scroll_bottom')


### PR DESCRIPTION
## Summary
- fix lint error by replacing `any` with typed cast in analytics tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857dea5116c832585363c315450c402