### PR TITLE
Add analytics tracking tests

### DIFF
--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -1,9 +1,12 @@
-import { trackEvent } from '../analytics'
+let trackEvent: typeof import('../analytics').trackEvent
 
 describe('trackEvent', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    jest.resetModules()
+    ;({ trackEvent } = await import('../analytics'))
     localStorage.clear()
     jest.restoreAllMocks()
+    ;(window as any).gtag = jest.fn()
   })
 
   test('does nothing when tracking disabled', () => {
@@ -15,10 +18,27 @@ describe('trackEvent', () => {
 
   test('updates localStorage and dispatches event when enabled', () => {
     const dispatchSpy = jest.spyOn(window, 'dispatchEvent')
-    ;(window as any).gtag = jest.fn()
     trackEvent(true, 'scroll_bottom')
     const stored = JSON.parse(localStorage.getItem('trackingHistory') || '[]')
     expect(stored[0].action).toBe('scroll_bottom')
     expect(dispatchSpy).toHaveBeenCalled()
+  })
+
+  test('calls gtag with correct parameters when enabled', () => {
+    trackEvent(true, 'event')
+    expect((window as any).gtag).toHaveBeenCalledWith('event', 'page_action', {
+      send_to: 'G-RVR9TSBQL7',
+      action: 'event',
+    })
+  })
+
+  test('stops calling gtag after 5 failures', () => {
+    ;(window as any).gtag = jest.fn(() => {
+      throw new Error('fail')
+    })
+    for (let i = 0; i < 6; i++) {
+      trackEvent(true, 'fail')
+    }
+    expect((window as any).gtag).toHaveBeenCalledTimes(5)
   })
 })

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -46,9 +46,11 @@ export function trackEvent(
     if (trackingFailures <= 5) {
       console.error('Tracking Analytics: There was an error.')
     }
-    if (!trackingDead) {
+    if (trackingFailures >= 5 && !trackingDead) {
       trackingDead = true
-      console.error('Tracking Analytics: Too many errors, tracking permanently failed.')
+      console.error(
+        'Tracking Analytics: Too many errors, tracking permanently failed.'
+      )
     }
   }
 }


### PR DESCRIPTION
## Summary
- mock `gtag` globally in analytics tests and add thorough assertions
- fail-safe analytics after 5 errors instead of one

## Testing
- `npx jest --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6857defb16b083259b41802ddcb73f62