### PR TITLE
Add Jest component export tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,8 +1,14 @@
 import type { Config } from 'jest'
 
 const config: Config = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',
+  setupFiles: ['./jest.setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.app.json',
+    },
+  },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,2 @@
+Object.defineProperty(globalThis, 'import', { value: {} });
+Object.defineProperty(globalThis.import, 'meta', { value: { env: {} } });

--- a/src/components/__tests__/components.test.ts
+++ b/src/components/__tests__/components.test.ts
@@ -1,0 +1,57 @@
+import BulkFileImportModal from '../BulkFileImportModal'
+import ClipboardImportModal from '../ClipboardImportModal'
+import DisclaimerModal from '../DisclaimerModal'
+
+import HistoryPanelDefault, { HistoryPanel } from '../HistoryPanel'
+import ImportModalDefault, { ImportModal } from '../ImportModal'
+
+import { ActionBar } from '../ActionBar'
+import { CollapsibleSection } from '../CollapsibleSection'
+import { ControlPanel } from '../ControlPanel'
+import { MultiSelectDropdown } from '../MultiSelectDropdown'
+import { ProgressBar } from '../ProgressBar'
+import { SearchableDropdown } from '../SearchableDropdown'
+import { ShareModal } from '../ShareModal'
+
+describe('component export tests', () => {
+  const defaultOnly = {
+    BulkFileImportModal,
+    ClipboardImportModal,
+    DisclaimerModal,
+  }
+
+  const namedOnly = {
+    ActionBar,
+    CollapsibleSection,
+    ControlPanel,
+    MultiSelectDropdown,
+    ProgressBar,
+    SearchableDropdown,
+    ShareModal,
+  }
+
+  const both = {
+    HistoryPanel: [HistoryPanelDefault, HistoryPanel],
+    ImportModal: [ImportModalDefault, ImportModal],
+  }
+
+  for (const [name, component] of Object.entries(defaultOnly)) {
+    test(`${name} default export is defined`, () => {
+      expect(component).toBeDefined()
+    })
+  }
+
+  for (const [name, component] of Object.entries(namedOnly)) {
+    test(`${name} named export is defined`, () => {
+      expect(component).toBeDefined()
+    })
+  }
+
+  for (const [name, [def, named]] of Object.entries(both) as any) {
+    test(`${name} default equals named export`, () => {
+      expect(def).toBeDefined()
+      expect(named).toBeDefined()
+      expect(def).toBe(named)
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- add tests verifying component exports
- support ESM in Jest using ts-jest/presets/default-esm

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857df47ee388325abe5cb011e661f63