### PR TITLE
Add path alias test and update ts config

### DIFF
--- a/src/__tests__/importPaths.test.ts
+++ b/src/__tests__/importPaths.test.ts
@@ -1,0 +1,16 @@
+import { ActionBar } from '@/components/ActionBar'
+import ImportModal from '@/components/ImportModal'
+import { useDarkMode } from '@/hooks/use-dark-mode'
+import { useIsMobile } from '@/hooks/use-mobile'
+
+describe('path alias resolution', () => {
+  test('components import via @ alias', () => {
+    expect(ActionBar).toBeDefined()
+    expect(ImportModal).toBeDefined()
+  })
+
+  test('hooks import via @ alias', () => {
+    expect(typeof useDarkMode).toBe('function')
+    expect(typeof useIsMobile).toBe('function')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
     "skipLibCheck": true,
     "allowJs": true,
     "noUnusedLocals": false,
-    "strictNullChecks": false
+    "strictNullChecks": false,
+    "jsx": "react-jsx",
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
## Summary
- add importPaths.test.ts to verify `@/` alias resolution
- revert jest config changes from previous commit
- set `jsx` and `esModuleInterop` in tsconfig so ts-jest can compile TSX

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857df3b04e0832595d8f2ca93c30388