### PR TITLE
Export toast state type

### DIFF
--- a/src/hooks/__tests__/use-toast.test.ts
+++ b/src/hooks/__tests__/use-toast.test.ts
@@ -1,5 +1,6 @@
 
 import { reducer } from '../use-toast'
+import type { State } from '../use-toast'
 
 const baseToast = {
   id: '1',
@@ -23,7 +24,7 @@ describe('use-toast reducer', () => {
   })
 
   test('DISMISS_TOAST closes toast and REMOVE_TOAST removes it', () => {
-    let state = { toasts: [baseToast] }
+    let state: State = { toasts: [baseToast] }
     state = reducer(state, { type: 'DISMISS_TOAST', toastId: '1' })
     expect(state.toasts[0]?.open).toBe(false)
     state = reducer(state, { type: 'REMOVE_TOAST', toastId: '1' })

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -49,7 +49,7 @@ type Action =
       toastId?: ToasterToast["id"]
     }
 
-interface State {
+export interface State {
   toasts: ToasterToast[]
 }
 


### PR DESCRIPTION
## Summary
- export `State` interface from `use-toast`
- update tests to import `State` type and annotate reducer state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857e9b1a07c832594950421085c81c2