### PR TITLE
fix: preserve JSON after reload

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -31,6 +31,8 @@ const Dashboard = () => {
     }
   });
 
+  const firstLoadRef = React.useRef(true)
+
   const [copied, setCopied] = useState(false);
   const [jsonString, setJsonString] = useState(() => {
     try {
@@ -133,10 +135,14 @@ const Dashboard = () => {
   }, [jsonString]);
 
   useEffect(() => {
+    if (firstLoadRef.current) {
+      firstLoadRef.current = false;
+      return;
+    }
     try {
-      const json = generateJson(options)
-      setJsonString(json)
-      localStorage.setItem('currentJson', json)
+      const json = generateJson(options);
+      setJsonString(json);
+      localStorage.setItem('currentJson', json);
     } catch (error) {
       console.error('Error generating JSON:', error);
       setJsonString('{}');


### PR DESCRIPTION
## Summary
- don't overwrite stored JSON when Dashboard mounts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857ed5a100c8325b3f42e7ee2bdc2bc