### PR TITLE
fix reload json

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -132,14 +132,20 @@ const Dashboard = () => {
     }
   }, [jsonString]);
 
+  const firstLoadRef = React.useRef(true)
   useEffect(() => {
+    if (firstLoadRef.current) {
+      firstLoadRef.current = false
+      const stored = localStorage.getItem('currentJson')
+      if (stored) return
+    }
     try {
       const json = generateJson(options)
       setJsonString(json)
       localStorage.setItem('currentJson', json)
     } catch (error) {
-      console.error('Error generating JSON:', error);
-      setJsonString('{}');
+      console.error('Error generating JSON:', error)
+      setJsonString('{}')
     }
   }, [options])
 


### PR DESCRIPTION
## Summary
- keep generated JSON when reloading the page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857ed5a100c8325b3f42e7ee2bdc2bc