### PR TITLE
fix sonner toast export

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Button } from '@/components/ui/button'
-import { toast } from 'sonner'
+import { toast } from '@/components/ui/sonner-toast'
 import { trackEvent } from '@/lib/analytics'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import {

--- a/src/components/BulkFileImportModal.tsx
+++ b/src/components/BulkFileImportModal.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { toast } from 'sonner';
+import { toast } from '@/components/ui/sonner-toast';
 
 interface BulkFileImportModalProps {
   open: boolean;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -3,7 +3,7 @@ import { diffChars, Change } from 'diff';
 import { Sun, Moon, Heart, Github, Star, GitFork, Bug } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { toast } from 'sonner';
+import { toast } from '@/components/ui/sonner-toast';
 import { ControlPanel } from './ControlPanel';
 import { ShareModal } from './ShareModal';
 import { ProgressBar } from './ProgressBar';

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -26,7 +26,7 @@ import {
   Download,
   Check,
 } from 'lucide-react'
-import { toast } from 'sonner'
+import { toast } from '@/components/ui/sonner-toast'
 import {
   DropdownMenu,
   DropdownMenuTrigger,

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Facebook, Twitter, Instagram, MessageCircle, Send, Copy, Check } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/components/ui/sonner-toast';
 
 interface ShareModalProps {
   isOpen: boolean;

--- a/src/components/ui/sonner-toast.ts
+++ b/src/components/ui/sonner-toast.ts
@@ -1,0 +1,1 @@
+export { toast } from "sonner"

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from "next-themes"
-import { Toaster as Sonner, toast } from "sonner"
+import { Toaster as Sonner } from "sonner"
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
@@ -27,4 +27,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
   )
 }
 
-export { Toaster, toast }
+export { Toaster }


### PR DESCRIPTION
## Summary
- add `sonner-toast` module to re-export toast
- clean up exports in `sonner` component
- update toast imports to use the new module

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6857f712e0448325b72cb686d0adbd28