### PR TITLE
Add analytics error handling tests

### DIFF
--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -1,9 +1,11 @@
-import { trackEvent } from '../analytics'
+let trackEvent: typeof import('../analytics').trackEvent
 
 describe('trackEvent', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     localStorage.clear()
     jest.restoreAllMocks()
+    jest.resetModules()
+    ;({ trackEvent } = await import('../analytics'))
   })
 
   test('does nothing when tracking disabled', () => {
@@ -24,5 +26,47 @@ describe('trackEvent', () => {
     const stored = JSON.parse(localStorage.getItem('trackingHistory') || '[]')
     expect(stored[0].action).toBe('scroll_bottom')
     expect(dispatchSpy).toHaveBeenCalled()
+  })
+
+  test('continues when localStorage.setItem throws', () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const gtagMock = jest.fn()
+    ;(window as unknown as { gtag?: jest.Mock }).gtag = gtagMock
+    jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('fail')
+      })
+
+    trackEvent(true, 'foo')
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Tracking History: There was an error.'
+    )
+    expect(gtagMock).toHaveBeenCalled()
+  })
+
+  test('gtag errors stop further tracking', () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const gtagMock = jest.fn(() => {
+      throw new Error('gtag fail')
+    })
+    ;(window as unknown as { gtag?: jest.Mock }).gtag = gtagMock
+
+    trackEvent(true, 'a1')
+    trackEvent(true, 'a2')
+
+    expect(gtagMock).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Tracking Analytics: There was an error.'
+    )
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Tracking Analytics: Too many errors, tracking permanently failed.'
+    )
+    expect(errorSpy).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
## Summary
- improve `trackEvent` test coverage
- verify logging and behavior when `localStorage` or `gtag` throw errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857f7450c9c83259fbdcaafd270087e