### PR TITLE
Add NotFound page test

### DIFF
--- a/src/pages/__tests__/NotFound.test.tsx
+++ b/src/pages/__tests__/NotFound.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react'
+import { jest } from '@jest/globals'
+import NotFound from '@/pages/NotFound'
+
+// Mock useLocation from react-router-dom to return a specific path
+jest.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: '/missing-page' })
+}))
+
+describe('NotFound page', () => {
+  test('logs error with the attempted path', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<NotFound />)
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '404 Error: User attempted to access non-existent route:',
+      '/missing-page'
+    )
+
+    errorSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- add test for NotFound page verifying the error log contains the attempted path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f80339248325a21152f43ed636de