### PR TITLE
Add hook tests for responsive utilities

### DIFF
--- a/src/hooks/__tests__/use-mobile.test.tsx
+++ b/src/hooks/__tests__/use-mobile.test.tsx
@@ -1,0 +1,75 @@
+import { renderHook, act } from '@testing-library/react'
+import { useIsMobile } from '../use-mobile'
+import { useIsSingleColumn } from '../use-single-column'
+
+describe('useIsMobile', () => {
+  const originalMatchMedia = window.matchMedia
+  let add: jest.Mock
+  let remove: jest.Mock
+
+  beforeEach(() => {
+    add = jest.fn()
+    remove = jest.fn()
+    window.matchMedia = jest.fn().mockReturnValue({
+      addEventListener: add,
+      removeEventListener: remove,
+    }) as any
+  })
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia
+  })
+
+  test('updates state on change and cleans up', () => {
+    window.innerWidth = 500
+    const { result, unmount } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(true)
+
+    window.innerWidth = 800
+    act(() => {
+      const handler = add.mock.calls[0][1]
+      handler()
+    })
+    expect(result.current).toBe(false)
+
+    const handler = add.mock.calls[0][1]
+    unmount()
+    expect(remove).toHaveBeenCalledWith('change', handler)
+  })
+})
+
+describe('useIsSingleColumn', () => {
+  const originalMatchMedia = window.matchMedia
+  let add: jest.Mock
+  let remove: jest.Mock
+
+  beforeEach(() => {
+    add = jest.fn()
+    remove = jest.fn()
+    window.matchMedia = jest.fn().mockReturnValue({
+      addEventListener: add,
+      removeEventListener: remove,
+    }) as any
+  })
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia
+  })
+
+  test('updates state on change and cleans up', () => {
+    window.innerWidth = 900
+    const { result, unmount } = renderHook(() => useIsSingleColumn())
+    expect(result.current).toBe(true)
+
+    window.innerWidth = 1100
+    act(() => {
+      const handler = add.mock.calls[0][1]
+      handler()
+    })
+    expect(result.current).toBe(false)
+
+    const handler = add.mock.calls[0][1]
+    unmount()
+    expect(remove).toHaveBeenCalledWith('change', handler)
+  })
+})


### PR DESCRIPTION
## Summary
- test `useIsMobile` and `useIsSingleColumn`
- ensure state updates when width changes and listeners clean up

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857f8d2174c832590f121f0d99d865f