### PR TITLE
Fix lint error in ResizeObserver test

### DIFF
--- a/src/hooks/__tests__/use-resize-tracker.test.ts
+++ b/src/hooks/__tests__/use-resize-tracker.test.ts
@@ -38,7 +38,11 @@ function Test() {
 describe('useResizeTracker', () => {
   beforeEach(() => {
     ;(trackEvent as jest.Mock).mockClear()
-    ;(global as any).ResizeObserver = MockResizeObserver
+    ;(
+      global as unknown as {
+        ResizeObserver: typeof ResizeObserver
+      }
+    ).ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
     jest.useFakeTimers()
     jest.setSystemTime(0)
   })


### PR DESCRIPTION
## Summary
- remove explicit `any` cast for `global.ResizeObserver`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f959b5f083259bbc037359b21ddd