### PR TITLE
Add tests for disclaimer fetch logic

### DIFF
--- a/src/components/__tests__/DisclaimerModal.test.tsx
+++ b/src/components/__tests__/DisclaimerModal.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { jest } from '@jest/globals'
+import DisclaimerModal from '../DisclaimerModal'
+
+describe('DisclaimerModal', () => {
+  const originalFetch = global.fetch
+  beforeEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  test('renders fetched text on success', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      text: () => Promise.resolve('loaded text'),
+    } as Response)
+
+    render(<DisclaimerModal open={true} onOpenChange={() => {}} />)
+
+    expect(await screen.findByText('loaded text')).toBeDefined()
+  })
+
+  test('renders fallback text on fetch failure', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('fail'))
+
+    render(<DisclaimerModal open={true} onOpenChange={() => {}} />)
+
+    expect(
+      await screen.findByText('Failed to load disclaimer.')
+    ).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
- test `DisclaimerModal` fetch success and failure cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857f8f1f39c8325a7e24e1908fd9406