### PR TITLE
Fix lint warnings in tests

### DIFF
--- a/src/hooks/__tests__/use-mobile.test.tsx
+++ b/src/hooks/__tests__/use-mobile.test.tsx
@@ -10,10 +10,12 @@ describe('useIsMobile', () => {
   beforeEach(() => {
     add = jest.fn()
     remove = jest.fn()
-    window.matchMedia = jest.fn().mockReturnValue({
-      addEventListener: add,
-      removeEventListener: remove,
-    }) as any
+    window.matchMedia = jest
+      .fn()
+      .mockReturnValue({
+        addEventListener: add,
+        removeEventListener: remove,
+      } as unknown as MediaQueryList)
   })
 
   afterEach(() => {
@@ -46,10 +48,12 @@ describe('useIsSingleColumn', () => {
   beforeEach(() => {
     add = jest.fn()
     remove = jest.fn()
-    window.matchMedia = jest.fn().mockReturnValue({
-      addEventListener: add,
-      removeEventListener: remove,
-    }) as any
+    window.matchMedia = jest
+      .fn()
+      .mockReturnValue({
+        addEventListener: add,
+        removeEventListener: remove,
+      } as unknown as MediaQueryList)
   })
 
   afterEach(() => {

--- a/src/hooks/__tests__/use-resize-tracker.test.ts
+++ b/src/hooks/__tests__/use-resize-tracker.test.ts
@@ -38,7 +38,8 @@ function Test() {
 describe('useResizeTracker', () => {
   beforeEach(() => {
     ;(trackEvent as jest.Mock).mockClear()
-    ;(global as any).ResizeObserver = MockResizeObserver
+    ;(global as unknown as Record<string, unknown>).ResizeObserver =
+      MockResizeObserver
     jest.useFakeTimers()
     jest.setSystemTime(0)
   })


### PR DESCRIPTION
## Summary
- remove `any` casts from `use-mobile.test.tsx`
- avoid `any` in resize tracker test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f9d310888325a1bfa3ce3f486d03