### PR TITLE
Fix lint warning in resize tracker test

### DIFF
--- a/src/hooks/__tests__/use-resize-tracker.test.ts
+++ b/src/hooks/__tests__/use-resize-tracker.test.ts
@@ -38,7 +38,8 @@ function Test() {
 describe('useResizeTracker', () => {
   beforeEach(() => {
     ;(trackEvent as jest.Mock).mockClear()
-    ;(global as any).ResizeObserver = MockResizeObserver
+    ;(global as unknown as { ResizeObserver: typeof MockResizeObserver }).ResizeObserver =
+      MockResizeObserver
     jest.useFakeTimers()
     jest.setSystemTime(0)
   })


### PR DESCRIPTION
## Summary
- type cast global ResizeObserver without using `any`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f959b5f083259bbc037359b21ddd