### PR TITLE
Fix linter errors in mobile hook tests

### DIFF
--- a/src/hooks/__tests__/use-mobile.test.tsx
+++ b/src/hooks/__tests__/use-mobile.test.tsx
@@ -13,7 +13,7 @@ describe('useIsMobile', () => {
     window.matchMedia = jest.fn().mockReturnValue({
       addEventListener: add,
       removeEventListener: remove,
-    }) as any
+    }) as unknown as typeof window.matchMedia
   })
 
   afterEach(() => {
@@ -49,7 +49,7 @@ describe('useIsSingleColumn', () => {
     window.matchMedia = jest.fn().mockReturnValue({
       addEventListener: add,
       removeEventListener: remove,
-    }) as any
+    }) as unknown as typeof window.matchMedia
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- fix `matchMedia` mocks to avoid `any` type

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857fafad1388325bedfe4d77f2989c2