### PR TITLE
Improve disclaimer fetch handling

### DIFF
--- a/src/components/DisclaimerModal.tsx
+++ b/src/components/DisclaimerModal.tsx
@@ -18,7 +18,12 @@ const DisclaimerModal: React.FC<DisclaimerModalProps> = ({ open, onOpenChange })
 
   useEffect(() => {
     fetch('/disclaimer.txt')
-      .then((res) => res.text())
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error('Failed to fetch disclaimer');
+        }
+        return res.text();
+      })
       .then(setText)
       .catch(() => {
         setText('Failed to load disclaimer.');

--- a/src/components/__tests__/DisclaimerModal.test.tsx
+++ b/src/components/__tests__/DisclaimerModal.test.tsx
@@ -14,6 +14,7 @@ describe('DisclaimerModal', () => {
 
   test('renders fetched text on success', async () => {
     global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
       text: () => Promise.resolve('loaded text'),
     } as Response)
 
@@ -24,6 +25,19 @@ describe('DisclaimerModal', () => {
 
   test('renders fallback text on fetch failure', async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error('fail'))
+
+    render(<DisclaimerModal open={true} onOpenChange={() => {}} />)
+
+    expect(
+      await screen.findByText('Failed to load disclaimer.')
+    ).toBeDefined()
+  })
+
+  test('renders fallback text when response not ok', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      text: () => Promise.resolve('loaded text'),
+    } as Response)
 
     render(<DisclaimerModal open={true} onOpenChange={() => {}} />)
 


### PR DESCRIPTION
## Summary
- error when fetching `disclaimer.txt` if response is not OK
- show fallback text when fetch fails or response not OK
- add unit test for the non-ok response case

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857fd20ac8483258d0c5506b848bf57