### PR TITLE
Improve gtag guard

### DIFF
--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -4,6 +4,7 @@ describe('trackEvent', () => {
   beforeEach(async () => {
     localStorage.clear()
     jest.restoreAllMocks()
+    delete (window as unknown as { gtag?: unknown }).gtag
     jest.resetModules()
     ;({ trackEvent } = await import('../analytics'))
   })
@@ -46,6 +47,20 @@ describe('trackEvent', () => {
       'Tracking History: There was an error.'
     )
     expect(gtagMock).toHaveBeenCalled()
+  })
+
+  test('does not call gtag when missing', () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    trackEvent(true, 'foo')
+    trackEvent(true, 'bar')
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Tracking Analytics: gtag function missing.'
+    )
+    expect(errorSpy).toHaveBeenCalledTimes(1)
   })
 
   test('gtag errors stop further tracking', () => {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -2,6 +2,7 @@ const MEASUREMENT_ID = 'G-RVR9TSBQL7'
 
 let trackingFailures = 0
 let trackingDead = false
+let gtagMissingLogged = false
 
 export function trackEvent(
   enabled: boolean,
@@ -34,8 +35,15 @@ export function trackEvent(
     }
   ).gtag
 
+  if (typeof gtag !== 'function') {
+    if (!gtagMissingLogged) {
+      console.error('Tracking Analytics: gtag function missing.')
+      gtagMissingLogged = true
+    }
+    return
+  }
+
   try {
-    if (typeof gtag !== 'function') console.error('Tracking Analytics: gtag function missing.')
     gtag('event', 'page_action', {
       send_to: MEASUREMENT_ID,
       action: event,


### PR DESCRIPTION
## Summary
- guard against missing `gtag`
- test that `gtag` isn't used when absent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857fd0e9ba08325a000638ed3b8a31b