### PR TITLE
Add catch-all redirect to home

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, Navigate } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -11,17 +11,7 @@ const NotFound = () => {
     );
   }, [location.pathname]);
 
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
-      </div>
-    </div>
-  );
+  return <Navigate to="/" replace />;
 };
 
 export default NotFound;

--- a/src/pages/__tests__/NotFound.test.tsx
+++ b/src/pages/__tests__/NotFound.test.tsx
@@ -4,7 +4,8 @@ import NotFound from '@/pages/NotFound'
 
 // Mock useLocation from react-router-dom to return a specific path
 jest.mock('react-router-dom', () => ({
-  useLocation: () => ({ pathname: '/missing-page' })
+  useLocation: () => ({ pathname: '/missing-page' }),
+  Navigate: () => null
 }))
 
 describe('NotFound page', () => {


### PR DESCRIPTION
## Summary
- redirect unmatched routes to `/` via `Navigate`
- fix test mock for `Navigate`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857fd45f1c8832584203e47914348ab