### PR TITLE
Enforce 100-entry cap on history

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -164,7 +164,7 @@ const Dashboard = () => {
         date: new Date().toLocaleString(),
         json: jsonString,
       };
-      setHistory((prev) => [entry, ...prev]);
+      setHistory(prev => [entry, ...prev].slice(0, 100));
       toast.success('Sora JSON copied to clipboard!');
       const opts = options as unknown as Record<string, unknown>
       const sections = Object.keys(options).filter(key => key.startsWith('use_') && opts[key])
@@ -389,7 +389,7 @@ const Dashboard = () => {
       date: new Date().toLocaleString(),
       json: j,
     }));
-    setHistory(prev => [...entries, ...prev]);
+    setHistory(prev => [...entries, ...prev].slice(0, 100));
     trackEvent(trackingEnabled, 'history_import', { type: 'bulk' });
   };
 

--- a/src/components/__tests__/DashboardHistory.test.tsx
+++ b/src/components/__tests__/DashboardHistory.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
+import Dashboard from '../Dashboard'
+import { useIsSingleColumn } from '@/hooks/use-single-column'
+import { useDarkMode } from '@/hooks/use-dark-mode'
+import { useTracking } from '@/hooks/use-tracking'
+import { useActionHistory } from '@/hooks/use-action-history'
+import { trackEvent } from '@/lib/analytics'
+
+let importFn: ((jsons: string[]) => void) | null = null
+
+jest.mock('../HistoryPanel', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    importFn = props.onImport
+    return null
+  },
+}))
+
+jest.mock('../ControlPanel', () => ({
+  __esModule: true,
+  ControlPanel: () => null,
+}))
+
+jest.mock('../ShareModal', () => ({ __esModule: true, ShareModal: () => null }))
+jest.mock('../ImportModal', () => ({ __esModule: true, default: () => null }))
+jest.mock('../Footer', () => ({ __esModule: true, default: () => null }))
+jest.mock('../DisclaimerModal', () => ({ __esModule: true, default: () => null }))
+jest.mock('../ProgressBar', () => ({ __esModule: true, ProgressBar: () => null, default: () => null }))
+
+jest.mock('@/hooks/use-single-column', () => ({ __esModule: true, useIsSingleColumn: jest.fn(() => false) }))
+jest.mock('@/hooks/use-dark-mode', () => ({ __esModule: true, useDarkMode: jest.fn(() => [false, jest.fn()] as const) }))
+jest.mock('@/hooks/use-tracking', () => ({ __esModule: true, useTracking: jest.fn(() => [true, jest.fn()] as const) }))
+jest.mock('@/hooks/use-action-history', () => ({ __esModule: true, useActionHistory: jest.fn(() => []) }))
+jest.mock('@/lib/analytics', () => ({ __esModule: true, trackEvent: jest.fn() }))
+jest.mock('@/components/ui/sonner-toast', () => ({ __esModule: true, toast: { success: jest.fn(), error: jest.fn() } }))
+
+function createEntries(n: number) {
+  return Array.from({ length: n }, (_, i) => ({ id: i, date: 'd', json: '{}' }))
+}
+
+describe('Dashboard history limit', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    importFn = null
+    ;(navigator as any).clipboard = { writeText: jest.fn().mockResolvedValue(undefined) }
+    global.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve({}) })
+    window.matchMedia = jest.fn().mockReturnValue({ addEventListener: jest.fn(), removeEventListener: jest.fn() }) as any
+  })
+
+  test('caps history at 100 entries', async () => {
+    localStorage.setItem('jsonHistory', JSON.stringify(createEntries(95)))
+
+    render(<Dashboard />)
+
+    const copyButton = screen.getByText('Copy')
+
+    for (let i = 0; i < 10; i++) {
+      await act(async () => {
+        fireEvent.click(copyButton)
+      })
+    }
+
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem('jsonHistory') || '[]')).toHaveLength(100)
+    })
+
+    act(() => {
+      importFn?.(Array(20).fill('{}'))
+    })
+
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem('jsonHistory') || '[]')).toHaveLength(100)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- truncate history when adding entries in Dashboard
- capture import handler and write a test ensuring history length never exceeds 100

## Testing
- `npm test --silent --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6857fdaaa5f4832580bef8d333f0f220