### PR TITLE
Add runtime options validator

### DIFF
--- a/src/components/ClipboardImportModal.tsx
+++ b/src/components/ClipboardImportModal.tsx
@@ -10,6 +10,8 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/ui/sonner-toast'
+import { isValidOptions } from '@/lib/validateOptions'
 
 interface ClipboardImportModalProps {
   open: boolean;
@@ -41,24 +43,26 @@ const ClipboardImportModal: React.FC<ClipboardImportModalProps> = ({
     const type = title.toLowerCase().includes('bulk') ? 'bulk_clipboard' : 'clipboard'
     try {
       const parsed = JSON.parse(text)
-      if (Array.isArray(parsed)) {
-        const strings = parsed.map(j => {
-          if (typeof j === 'string') return j
-          if (j && typeof j === 'object' && 'json' in j) return j.json as string
-          return JSON.stringify(j)
-        })
-        onImport(strings)
-      } else {
-        onImport([
-          typeof parsed === 'string'
-            ? parsed
-            : parsed && typeof parsed === 'object' && 'json' in parsed
-              ? (parsed as { json: string }).json
-              : JSON.stringify(parsed)
-        ])
+      const arr = Array.isArray(parsed) ? parsed : [parsed]
+      const strings: string[] = []
+      for (const item of arr) {
+        let obj: unknown = item
+        if (typeof item === 'string') {
+          try { obj = JSON.parse(item) } catch { obj = undefined }
+        } else if (item && typeof item === 'object' && 'json' in item) {
+          obj = (item as { json: string }).json
+          try { obj = JSON.parse(String(obj)) } catch {}
+        }
+        if (obj && typeof obj === 'object' && isValidOptions(obj)) {
+          strings.push(JSON.stringify(obj))
+        }
       }
+      if (!strings.length) throw new Error('invalid')
+      onImport(strings)
     } catch {
-      onImport([text])
+      toast.error('Invalid JSON')
+      onOpenChange(false)
+      return
     }
     trackEvent(trackingEnabled, 'history_import', { type })
     setText('')

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -21,6 +21,7 @@ import { DEFAULT_OPTIONS } from '@/lib/defaultOptions'
 import { generateJson } from '@/lib/generateJson'
 import type { SoraOptions } from '@/lib/soraOptions'
 import { loadOptionsFromJson } from '@/lib/loadOptionsFromJson'
+import { isValidOptions } from '@/lib/validateOptions'
 
 const Dashboard = () => {
   const [options, setOptions] = useState<SoraOptions>(() => {
@@ -188,13 +189,14 @@ const Dashboard = () => {
 
   const importJson = (json: string) => {
     try {
-      const obj = JSON.parse(json);
-      setOptions(prev => ({ ...prev, ...obj }));
-      setShowImportModal(false);
-      toast.success('JSON imported!');
-      trackEvent(trackingEnabled, 'import_button');
+      const obj = JSON.parse(json)
+      if (!isValidOptions(obj)) throw new Error('invalid')
+      setOptions(prev => ({ ...prev, ...obj }))
+      setShowImportModal(false)
+      toast.success('JSON imported!')
+      trackEvent(trackingEnabled, 'import_button')
     } catch {
-      toast.error('Invalid JSON');
+      toast.error('Invalid JSON')
     }
   };
 
@@ -291,6 +293,7 @@ const Dashboard = () => {
   const editHistoryEntry = (json: string) => {
     try {
       const obj = JSON.parse(json);
+      if (!isValidOptions(obj)) throw new Error('invalid');
       const enableMap: Record<string, keyof SoraOptions> = {
         negative_prompt: 'use_negative_prompt',
         width: 'use_dimensions_format',

--- a/src/components/ImportModal.tsx
+++ b/src/components/ImportModal.tsx
@@ -9,6 +9,8 @@ import {
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
+import { toast } from '@/components/ui/sonner-toast';
+import { isValidOptions } from '@/lib/validateOptions';
 
 interface ImportModalProps {
   isOpen: boolean;
@@ -28,10 +30,16 @@ export const ImportModal: React.FC<ImportModalProps> = ({ isOpen, onClose, onImp
   };
 
   const handleImport = () => {
-    onImport(text);
-    setText('');
-    onClose();
-  };
+    try {
+      const obj = JSON.parse(text)
+      if (!isValidOptions(obj)) throw new Error('invalid')
+      onImport(JSON.stringify(obj))
+      setText('')
+      onClose()
+    } catch {
+      toast.error('Invalid JSON')
+    }
+  }
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>

--- a/src/lib/__tests__/validateOptions.test.ts
+++ b/src/lib/__tests__/validateOptions.test.ts
@@ -1,0 +1,15 @@
+import { isValidOptions } from '../validateOptions'
+
+describe('isValidOptions', () => {
+  test('accepts partial valid options', () => {
+    expect(isValidOptions({ prompt: 'hi', steps: 10 })).toBe(true)
+  })
+
+  test('rejects unknown keys', () => {
+    expect(isValidOptions({ foo: 'bar' })).toBe(false)
+  })
+
+  test('rejects wrong types', () => {
+    expect(isValidOptions({ steps: 'ten' })).toBe(false)
+  })
+})

--- a/src/lib/validateOptions.ts
+++ b/src/lib/validateOptions.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod'
+import { DEFAULT_OPTIONS } from './defaultOptions'
+import type { SoraOptions } from './soraOptions'
+
+const extraShape = {
+  signature: z.string(),
+  season: z.string(),
+  atmosphere_mood: z.string(),
+  subject_mood: z.string(),
+  sword_type: z.string(),
+  sword_vibe: z.string(),
+  secondary_material: z.string(),
+  character_mood: z.string(),
+  subject_gender: z.string(),
+  makeup_style: z.string(),
+  quality_booster: z.string(),
+  black_and_white_preset: z.string(),
+  location: z.string(),
+  special_effects: z.array(z.string()),
+  lut_preset: z.string(),
+  dnd_character_race: z.string(),
+  dnd_character_class: z.string(),
+  dnd_character_background: z.string(),
+  dnd_character_alignment: z.string(),
+  dnd_monster_type: z.string(),
+  dnd_environment: z.string(),
+  dnd_magic_school: z.string(),
+  dnd_item_type: z.string(),
+} as const
+
+function schemaFor(value: unknown): z.ZodTypeAny {
+  if (typeof value === 'string') return z.string()
+  if (typeof value === 'number') return z.number()
+  if (typeof value === 'boolean') return z.boolean()
+  if (Array.isArray(value)) return z.array(z.any())
+  if (value === null) return z.null()
+  if (typeof value === 'object') return z.record(z.any())
+  return z.any()
+}
+
+const shape: Record<string, z.ZodTypeAny> = {}
+for (const [key, value] of Object.entries(DEFAULT_OPTIONS)) {
+  if (key === 'seed') {
+    shape[key] = z.union([z.number(), z.null()])
+  } else if (key === 'style_preset') {
+    shape[key] = z.object({ category: z.string(), style: z.string() })
+  } else if (key === 'composition_rules') {
+    shape[key] = z.array(z.string())
+  } else {
+    shape[key] = schemaFor(value)
+  }
+}
+Object.entries(extraShape).forEach(([k, s]) => {
+  shape[k] = s
+})
+
+export const partialOptionsSchema = z.object(shape).partial().strict()
+export type PartialSoraOptions = z.infer<typeof partialOptionsSchema>
+
+export function isValidOptions(obj: unknown): obj is Partial<SoraOptions> {
+  return partialOptionsSchema.safeParse(obj).success
+}


### PR DESCRIPTION
## Summary
- validate option objects at runtime using a new `isValidOptions` util
- guard all JSON import locations with the validator
- test validator behaviour for invalid objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857fd900c74832583145f238da142cf