### PR TITLE
Handle missing clipboard gracefully

### DIFF
--- a/src/components/ClipboardImportModal.tsx
+++ b/src/components/ClipboardImportModal.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/ui/sonner-toast';
 
 interface ClipboardImportModalProps {
   open: boolean;
@@ -29,7 +30,11 @@ const ClipboardImportModal: React.FC<ClipboardImportModalProps> = ({
 
   useEffect(() => {
     if (open) {
-      navigator.clipboard.readText().then(setText).catch(() => {});
+      if ('clipboard' in navigator) {
+        navigator.clipboard.readText().then(setText).catch(() => {});
+      } else {
+        toast.error('Clipboard not supported');
+      }
     }
   }, [open]);
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -156,6 +156,10 @@ const Dashboard = () => {
   }, [options])
 
   const copyToClipboard = async () => {
+    if (!('clipboard' in navigator)) {
+      toast.error('Clipboard not supported');
+      return;
+    }
     try {
       await navigator.clipboard.writeText(jsonString);
       setCopied(true);
@@ -279,6 +283,10 @@ const Dashboard = () => {
   const clearHistory = () => setHistory([]);
 
   const copyHistoryEntry = async (json: string) => {
+    if (!('clipboard' in navigator)) {
+      toast.error('Clipboard not supported');
+      return;
+    }
     try {
       await navigator.clipboard.writeText(json);
       toast.success('Sora JSON copied to clipboard!');

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -98,6 +98,10 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
 
 
   const exportClipboard = async () => {
+    if (!('clipboard' in navigator)) {
+      toast.error('Clipboard not supported')
+      return
+    }
     try {
       await navigator.clipboard.writeText(JSON.stringify(history, null, 2))
       toast.success('Copied all history to clipboard!')

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -53,6 +53,10 @@ export const ShareModal: React.FC<ShareModalProps> = ({ isOpen, onClose, jsonCon
   };
 
   const copyLink = async () => {
+    if (!('clipboard' in navigator)) {
+      toast.error('Clipboard not supported');
+      return;
+    }
     try {
       await navigator.clipboard.writeText(window.location.href);
       setCopied(true);

--- a/src/components/__tests__/clipboardFallback.test.tsx
+++ b/src/components/__tests__/clipboardFallback.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import Dashboard from '../Dashboard'
+jest.mock('../Footer', () => ({ __esModule: true, default: () => null }))
+import { ShareModal } from '../ShareModal'
+import ClipboardImportModal from '../ClipboardImportModal'
+import { HistoryPanel } from '../HistoryPanel'
+import { toast } from '@/components/ui/sonner-toast'
+
+jest.mock('@/lib/analytics', () => ({
+  __esModule: true,
+  trackEvent: jest.fn(),
+}))
+
+jest.mock('@/hooks/use-tracking', () => ({
+  __esModule: true,
+  useTracking: jest.fn(() => [false] as const),
+}))
+
+jest.mock('@/components/ui/sonner-toast', () => ({
+  __esModule: true,
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
+const restoreClipboard = () => {
+  const nav = navigator as unknown as { clipboard?: unknown }
+  const original = nav.clipboard
+  delete nav.clipboard
+  return () => {
+    if (original !== undefined) {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: original,
+      })
+    }
+  }
+}
+
+describe('clipboard fallback', () => {
+  const originalMatchMedia = window.matchMedia
+
+  beforeEach(() => {
+    ;(toast.error as jest.Mock).mockClear()
+    ;(toast.success as jest.Mock).mockClear()
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ stargazers_count: 0, forks_count: 0, open_issues_count: 0 }),
+    }) as unknown as typeof fetch
+    window.matchMedia = jest.fn().mockReturnValue({
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }) as unknown as typeof window.matchMedia
+  })
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia
+  })
+
+  test('ShareModal copy shows error', () => {
+    const restore = restoreClipboard()
+    render(<ShareModal isOpen={true} onClose={() => {}} jsonContent="{}" />)
+    const btn = screen.getByRole('button', { name: /copy link/i })
+    fireEvent.click(btn)
+    expect(toast.error).toHaveBeenCalledWith('Clipboard not supported')
+    restore()
+  })
+
+  test('ClipboardImportModal reads clipboard failure', async () => {
+    const restore = restoreClipboard()
+    render(
+      <ClipboardImportModal open={true} onOpenChange={() => {}} onImport={() => {}} title="Import" />
+    )
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Clipboard not supported'))
+    restore()
+  })
+
+})


### PR DESCRIPTION
## Summary
- add clipboard fallback for Dashboard, HistoryPanel, ShareModal and clipboard imports
- test clipboard fallback behavior when clipboard API is unavailable

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857fdb90f8c832584ed01c4324552c0