### PR TITLE
Check matchMedia before use in hooks

### DIFF
--- a/src/hooks/__tests__/use-mobile.test.tsx
+++ b/src/hooks/__tests__/use-mobile.test.tsx
@@ -36,6 +36,13 @@ describe('useIsMobile', () => {
     unmount()
     expect(remove).toHaveBeenCalledWith('change', handler)
   })
+
+  test('defaults to false when matchMedia is missing', () => {
+    delete (window as any).matchMedia
+    window.innerWidth = 500
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(false)
+  })
 })
 
 describe('useIsSingleColumn', () => {
@@ -71,5 +78,12 @@ describe('useIsSingleColumn', () => {
     const handler = add.mock.calls[0][1]
     unmount()
     expect(remove).toHaveBeenCalledWith('change', handler)
+  })
+
+  test('defaults to false when matchMedia is missing', () => {
+    delete (window as any).matchMedia
+    window.innerWidth = 900
+    const { result } = renderHook(() => useIsSingleColumn())
+    expect(result.current).toBe(false)
   })
 })

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -3,10 +3,17 @@ import * as React from "react"
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = React.useState(false)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    if (typeof window.matchMedia !== "function") {
+      setIsMobile(false)
+      return
+    }
+
+    const mql = window.matchMedia(
+      `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+    )
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     }
@@ -15,5 +22,5 @@ export function useIsMobile() {
     return () => mql.removeEventListener("change", onChange)
   }, [])
 
-  return !!isMobile
+  return isMobile
 }

--- a/src/hooks/use-single-column.tsx
+++ b/src/hooks/use-single-column.tsx
@@ -6,6 +6,11 @@ export function useIsSingleColumn() {
   const [isSingle, setIsSingle] = React.useState(false)
 
   React.useEffect(() => {
+    if (typeof window.matchMedia !== 'function') {
+      setIsSingle(false)
+      return
+    }
+
     const mq = window.matchMedia(`(max-width: ${BREAKPOINT - 1}px)`)
     const handler = () => setIsSingle(window.innerWidth < BREAKPOINT)
     mq.addEventListener('change', handler)


### PR DESCRIPTION
## Summary
- guard `window.matchMedia` usage in `useIsMobile` and `useIsSingleColumn`
- return `false` when `matchMedia` is unavailable
- cover the new edge case in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857fdd3322483258279cb97d691f4b7