### PR TITLE
Fix Vite build warnings

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,11 +1,15 @@
 
-import Dashboard from "@/components/Dashboard";
+import { lazy, Suspense } from "react";
 import ErrorBoundary from "@/components/ErrorBoundary";
+
+const Dashboard = lazy(() => import("@/components/Dashboard"));
 
 const Index = () => {
   return (
     <ErrorBoundary>
-      <Dashboard />
+      <Suspense fallback={<div className="p-4 text-center">Loading...</div>}>
+        <Dashboard />
+      </Suspense>
     </ErrorBoundary>
   );
 };


### PR DESCRIPTION
## Summary
- lazy load the dashboard page to automatically split a large chunk

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858007eb100832593c3c0abf332a605