### PR TITLE
Fix eslint errors

### DIFF
--- a/src/components/BulkFileImportModal.tsx
+++ b/src/components/BulkFileImportModal.tsx
@@ -43,7 +43,11 @@ const BulkFileImportModal: React.FC<BulkFileImportModalProps> = ({
           try { obj = JSON.parse(item); } catch { obj = undefined; }
         } else if (item && typeof item === 'object' && 'json' in item) {
           obj = (item as { json: string }).json;
-          try { obj = JSON.parse(String(obj)); } catch {}
+          try {
+            obj = JSON.parse(String(obj));
+          } catch {
+            /* ignore parse errors */
+          }
         }
         if (obj && typeof obj === 'object' && isValidOptions(obj)) {
           jsons.push(JSON.stringify(obj));

--- a/src/components/ClipboardImportModal.tsx
+++ b/src/components/ClipboardImportModal.tsx
@@ -33,7 +33,12 @@ const ClipboardImportModal: React.FC<ClipboardImportModalProps> = ({
   useEffect(() => {
     if (open) {
       if ('clipboard' in navigator) {
-        navigator.clipboard.readText().then(setText).catch(() => {});
+        navigator.clipboard
+          .readText()
+          .then(setText)
+          .catch(() => {
+            /* ignore clipboard read errors */
+          });
       } else {
         toast.error('Clipboard not supported');
       }
@@ -56,7 +61,11 @@ const ClipboardImportModal: React.FC<ClipboardImportModalProps> = ({
           try { obj = JSON.parse(item) } catch { obj = undefined }
         } else if (item && typeof item === 'object' && 'json' in item) {
           obj = (item as { json: string }).json
-          try { obj = JSON.parse(String(obj)) } catch {}
+          try {
+            obj = JSON.parse(String(obj))
+          } catch {
+            /* ignore parse errors */
+          }
         }
         if (obj && typeof obj === 'object' && isValidOptions(obj)) {
           strings.push(JSON.stringify(obj))

--- a/src/components/__tests__/DashboardHistory.test.tsx
+++ b/src/components/__tests__/DashboardHistory.test.tsx
@@ -10,8 +10,8 @@ let importFn: ((jsons: string[]) => void) | null = null
 
 jest.mock('../HistoryPanel', () => ({
   __esModule: true,
-  default: (props: any) => {
-    importFn = props.onImport
+  default: ({ onImport }: { onImport: (jsons: string[]) => void }) => {
+    importFn = onImport
     return null
   },
 }))
@@ -42,9 +42,16 @@ describe('Dashboard history limit', () => {
   beforeEach(() => {
     localStorage.clear()
     importFn = null
-    ;(navigator as any).clipboard = { writeText: jest.fn().mockResolvedValue(undefined) }
-    global.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve({}) })
-    window.matchMedia = jest.fn().mockReturnValue({ addEventListener: jest.fn(), removeEventListener: jest.fn() }) as any
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: jest.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve({}) });
+    window.matchMedia = jest
+      .fn()
+      .mockReturnValue({ addEventListener: jest.fn(), removeEventListener: jest.fn() }) as unknown as typeof window.matchMedia;
   })
 
   test('caps history at 100 entries', async () => {

--- a/src/hooks/__tests__/use-mobile.test.tsx
+++ b/src/hooks/__tests__/use-mobile.test.tsx
@@ -38,7 +38,7 @@ describe('useIsMobile', () => {
   })
 
   test('defaults to false when matchMedia is missing', () => {
-    delete (window as any).matchMedia
+    delete (window as unknown as { matchMedia?: typeof window.matchMedia }).matchMedia
     window.innerWidth = 500
     const { result } = renderHook(() => useIsMobile())
     expect(result.current).toBe(false)
@@ -81,7 +81,7 @@ describe('useIsSingleColumn', () => {
   })
 
   test('defaults to false when matchMedia is missing', () => {
-    delete (window as any).matchMedia
+    delete (window as unknown as { matchMedia?: typeof window.matchMedia }).matchMedia
     window.innerWidth = 900
     const { result } = renderHook(() => useIsSingleColumn())
     expect(result.current).toBe(false)


### PR DESCRIPTION
## Summary
- silence empty catch blocks with comments
- avoid `any` usages in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68580064dffc83259073cb8fc1503c0d