### PR TITLE
Fix tests warnings by adding dialog descriptions

### DIFF
--- a/src/components/BulkFileImportModal.tsx
+++ b/src/components/BulkFileImportModal.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogFooter,
+  DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -69,6 +70,7 @@ const BulkFileImportModal: React.FC<BulkFileImportModalProps> = ({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Bulk File Import</DialogTitle>
+          <DialogDescription>Select a JSON file to import prompts.</DialogDescription>
         </DialogHeader>
         <Input type="file" accept=".json" onChange={e => setFile(e.target.files?.[0] || null)} />
         <DialogFooter>

--- a/src/components/ClipboardImportModal.tsx
+++ b/src/components/ClipboardImportModal.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogFooter,
+  DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -88,6 +89,7 @@ const ClipboardImportModal: React.FC<ClipboardImportModalProps> = ({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>Paste JSON below to import.</DialogDescription>
         </DialogHeader>
         <Textarea
           value={text}

--- a/src/components/DisclaimerModal.tsx
+++ b/src/components/DisclaimerModal.tsx
@@ -4,6 +4,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
 } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
@@ -35,6 +36,7 @@ const DisclaimerModal: React.FC<DisclaimerModalProps> = ({ open, onOpenChange })
       <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Intellectual Property &amp; Software Disclaimer</DialogTitle>
+          <DialogDescription>The text below explains important legal information.</DialogDescription>
         </DialogHeader>
         <ScrollArea className="h-[60vh] px-1">
           <p className="whitespace-pre-wrap text-sm">{text}</p>

--- a/src/components/ImportModal.tsx
+++ b/src/components/ImportModal.tsx
@@ -5,6 +5,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogFooter,
+  DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -46,6 +47,9 @@ export const ImportModal: React.FC<ImportModalProps> = ({ isOpen, onClose, onImp
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Import JSON</DialogTitle>
+          <DialogDescription>
+            Paste JSON or choose a file to import your prompt.
+          </DialogDescription>
         </DialogHeader>
         <div className="space-y-2 py-4">
           <Textarea

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -7,6 +7,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Facebook, Twitter, Instagram, MessageCircle, Send, Copy, Check } from 'lucide-react';
@@ -73,6 +74,9 @@ export const ShareModal: React.FC<ShareModalProps> = ({ isOpen, onClose, jsonCon
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Share your JSON prompt</DialogTitle>
+          <DialogDescription>
+            Choose a platform below or copy a direct link.
+          </DialogDescription>
         </DialogHeader>
         <div className="grid grid-cols-2 gap-4 py-4">
           <Button onClick={shareToFacebook} variant="outline" className="gap-2">


### PR DESCRIPTION
## Summary
- add `<DialogDescription>` for various Dialog modals so @radix-ui no longer warns

## Testing
- `npm test --silent -- -i`

------
https://chatgpt.com/codex/tasks/task_e_6858026dfb908325a73a8bffde2843b3