### PR TITLE
Fix test warnings

### DIFF
--- a/src/components/__tests__/DisclaimerModal.test.tsx
+++ b/src/components/__tests__/DisclaimerModal.test.tsx
@@ -4,12 +4,15 @@ import DisclaimerModal from '../DisclaimerModal'
 
 describe('DisclaimerModal', () => {
   const originalFetch = global.fetch
+  let warnSpy: jest.SpyInstance
   beforeEach(() => {
     jest.restoreAllMocks()
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
   afterEach(() => {
     global.fetch = originalFetch
+    warnSpy.mockRestore()
   })
 
   test('renders fetched text on success', async () => {

--- a/src/components/__tests__/clipboardFallback.test.tsx
+++ b/src/components/__tests__/clipboardFallback.test.tsx
@@ -40,8 +40,10 @@ const restoreClipboard = () => {
 
 describe('clipboard fallback', () => {
   const originalMatchMedia = window.matchMedia
+  let warnSpy: jest.SpyInstance
 
   beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
     ;(toast.error as jest.Mock).mockClear()
     ;(toast.success as jest.Mock).mockClear()
     global.fetch = jest.fn().mockResolvedValue({
@@ -55,6 +57,7 @@ describe('clipboard fallback', () => {
 
   afterEach(() => {
     window.matchMedia = originalMatchMedia
+    warnSpy.mockRestore()
   })
 
   test('ShareModal copy shows error', () => {

--- a/src/components/ui/__tests__/sidebar.test.tsx
+++ b/src/components/ui/__tests__/sidebar.test.tsx
@@ -21,9 +21,11 @@ describe('useSidebar hook', () => {
   })
 
   test('throws when used without provider', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
     expect(() => renderHook(() => useSidebar())).toThrow(
       'useSidebar must be used within a SidebarProvider.'
     )
+    spy.mockRestore()
   })
 
   test('toggleSidebar updates state and cookie on desktop', () => {

--- a/src/lib/__tests__/loadOptionsFromJson.test.ts
+++ b/src/lib/__tests__/loadOptionsFromJson.test.ts
@@ -13,6 +13,8 @@ describe('loadOptionsFromJson', () => {
 
   test('returns null for invalid JSON', () => {
     const bad = '{ invalid json'
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
     expect(loadOptionsFromJson(bad)).toBeNull()
+    spy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary
- silence console warnings in tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6858026dfb908325a73a8bffde2843b3