### PR TITLE
Add typecheck step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,20 @@ jobs:
       - run: npm ci
       - run: npm run lint
 
-  test:
+  typecheck:
     needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npx tsc --noEmit
+
+  test:
+    needs: [lint, typecheck]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +42,7 @@ jobs:
       - run: npm test
 
   build:
-    needs: test
+    needs: [test, typecheck]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- run `npx tsc --noEmit` in a new `typecheck` job
- ensure `test` and `build` depend on `typecheck`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685809d34e588325a533a71d66a51df3