### PR TITLE
Add artifact upload to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist


### PR DESCRIPTION
## Summary
- upload the `dist` folder as an artifact in the CI workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68580cda9d048325be318711ec696448