### PR TITLE
Support measurement ID from env

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,10 @@ After completing the prompts, Vercel will upload the `dist` folder and provide a
 URL where your application is hosted. You can use any other hosting provider in
 a similar fashion by pointing it to the `dist` folder.
 
+## Environment Variables
+
+- **`VITE_MEASUREMENT_ID`** (optional) – Google Analytics measurement ID. Defaults to `G-RVR9TSBQL7` if not set.
+
 ## Contributing
 
 Pull requests are welcome. Please open an issue first to discuss major changes.

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,6 +1,5 @@
 import { safeGet, safeSet } from './storage'
-
-const MEASUREMENT_ID = 'G-RVR9TSBQL7'
+import { MEASUREMENT_ID } from './config'
 
 let trackingFailures = 0
 let trackingDead = false

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,9 @@
+let measurementId: string | undefined
+try {
+  measurementId = new Function(
+    'return import.meta.env.VITE_MEASUREMENT_ID'
+  )() as string | undefined
+} catch {
+  measurementId = process.env.VITE_MEASUREMENT_ID
+}
+export const MEASUREMENT_ID = measurementId ?? 'G-RVR9TSBQL7'

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,4 +3,5 @@
 interface ImportMetaEnv {
   readonly VITE_COMMIT_HASH: string
   readonly VITE_COMMIT_DATE: string
+  readonly VITE_MEASUREMENT_ID?: string
 }


### PR DESCRIPTION
## Summary
- add config.ts for `MEASUREMENT_ID`
- consume env measurement id in analytics helper
- document optional `VITE_MEASUREMENT_ID` env variable
- update type declarations

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858153512848325a1aea869a430ad30