### PR TITLE
Fetch disclaimer on modal open

### DIFF
--- a/src/components/DisclaimerModal.tsx
+++ b/src/components/DisclaimerModal.tsx
@@ -16,8 +16,13 @@ interface DisclaimerModalProps {
 
 const DisclaimerModal: React.FC<DisclaimerModalProps> = ({ open, onOpenChange }) => {
   const [text, setText] = useState('');
+  const [hasFetched, setHasFetched] = useState(false);
 
   useEffect(() => {
+    if (!open || hasFetched) {
+      return;
+    }
+
     fetch('/disclaimer.txt')
       .then((res) => {
         if (!res.ok) {
@@ -28,8 +33,11 @@ const DisclaimerModal: React.FC<DisclaimerModalProps> = ({ open, onOpenChange })
       .then(setText)
       .catch(() => {
         setText('Failed to load disclaimer.');
+      })
+      .finally(() => {
+        setHasFetched(true);
       });
-  }, []);
+  }, [open, hasFetched]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/__tests__/DisclaimerModal.test.tsx
+++ b/src/components/__tests__/DisclaimerModal.test.tsx
@@ -48,4 +48,51 @@ describe('DisclaimerModal', () => {
       await screen.findByText('Failed to load disclaimer.')
     ).toBeDefined()
   })
+
+  test('does not fetch when closed', () => {
+    const mockFetch = jest.fn()
+    global.fetch = mockFetch
+
+    render(<DisclaimerModal open={false} onOpenChange={() => {}} />)
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  test('fetches only when opened', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('loaded text'),
+    } as Response)
+    global.fetch = mockFetch
+
+    const { rerender } = render(
+      <DisclaimerModal open={false} onOpenChange={() => {}} />
+    )
+
+    expect(mockFetch).not.toHaveBeenCalled()
+
+    rerender(<DisclaimerModal open={true} onOpenChange={() => {}} />)
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(await screen.findByText('loaded text')).toBeDefined()
+  })
+
+  test('does not refetch on reopen', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('loaded text'),
+    } as Response)
+    global.fetch = mockFetch
+
+    const { rerender } = render(
+      <DisclaimerModal open={true} onOpenChange={() => {}} />
+    )
+    expect(await screen.findByText('loaded text')).toBeDefined()
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    rerender(<DisclaimerModal open={false} onOpenChange={() => {}} />)
+    rerender(<DisclaimerModal open={true} onOpenChange={() => {}} />)
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
## Summary
- update `DisclaimerModal` to lazily fetch `/disclaimer.txt` only on first open
- extend tests to verify fetch only happens when modal opens and that reopening uses cached text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685817c0b540832599897ee0712d9bda