### PR TITLE
Handle GitHub fetch failure in Dashboard

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -67,16 +67,22 @@ const Dashboard = () => {
   }>()
 
   useEffect(() => {
-    fetch('https://api.github.com/repos/supermarsx/sora-json-prompt-crafter')
-      .then(res => res.json())
-      .then(data =>
+    const loadStats = async () => {
+      try {
+        const res = await fetch(
+          'https://api.github.com/repos/supermarsx/sora-json-prompt-crafter'
+        )
+        const data = await res.json()
         setGithubStats({
           stars: data.stargazers_count,
           forks: data.forks_count,
           issues: data.open_issues_count,
         })
-      )
-      .catch(() => {})
+      } catch (error) {
+        toast.error('Failed to load GitHub stats')
+      }
+    }
+    void loadStats()
   }, [])
 
   useEffect(() => {

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -1,0 +1,37 @@
+import { render, waitFor } from '@testing-library/react'
+import Dashboard from '../Dashboard'
+import { toast } from '@/components/ui/sonner-toast'
+
+jest.mock('../HistoryPanel', () => ({ __esModule: true, default: () => null }))
+jest.mock('../ControlPanel', () => ({ __esModule: true, ControlPanel: () => null }))
+jest.mock('../ShareModal', () => ({ __esModule: true, ShareModal: () => null }))
+jest.mock('../ImportModal', () => ({ __esModule: true, default: () => null }))
+jest.mock('../Footer', () => ({ __esModule: true, default: () => null }))
+jest.mock('../DisclaimerModal', () => ({ __esModule: true, default: () => null }))
+jest.mock('../ProgressBar', () => ({ __esModule: true, ProgressBar: () => null, default: () => null }))
+
+jest.mock('@/hooks/use-single-column', () => ({ __esModule: true, useIsSingleColumn: jest.fn(() => false) }))
+jest.mock('@/hooks/use-dark-mode', () => ({ __esModule: true, useDarkMode: jest.fn(() => [false, jest.fn()] as const) }))
+jest.mock('@/hooks/use-tracking', () => ({ __esModule: true, useTracking: jest.fn(() => [true, jest.fn()] as const) }))
+jest.mock('@/hooks/use-action-history', () => ({ __esModule: true, useActionHistory: jest.fn(() => []) }))
+jest.mock('@/lib/analytics', () => ({ __esModule: true, trackEvent: jest.fn() }))
+jest.mock('@/components/ui/sonner-toast', () => ({ __esModule: true, toast: { success: jest.fn(), error: jest.fn() } }))
+
+describe('Dashboard github stats failure', () => {
+  beforeEach(() => {
+    ;(toast.error as jest.Mock).mockClear()
+    localStorage.clear()
+    global.fetch = jest.fn().mockRejectedValue(new Error('fail')) as unknown as typeof fetch
+    window.matchMedia = jest.fn().mockReturnValue({
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }) as unknown as typeof window.matchMedia
+  })
+
+  test('shows toast when stats fail to load', async () => {
+    render(<Dashboard />)
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Failed to load GitHub stats')
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- handle GitHub stats fetch errors by showing a toast
- test Dashboard error path when fetch rejects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68581802a2a48325abbfa23c7193c8c9