### PR TITLE
Fix runtime process undefined

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,6 +4,8 @@ try {
     'return import.meta.env.VITE_MEASUREMENT_ID'
   )() as string | undefined
 } catch {
-  measurementId = process.env.VITE_MEASUREMENT_ID
+  if (typeof process !== 'undefined') {
+    measurementId = process.env.VITE_MEASUREMENT_ID
+  }
 }
 export const MEASUREMENT_ID = measurementId ?? 'G-RVR9TSBQL7'


### PR DESCRIPTION
## Summary
- avoid runtime `process` reference if not defined

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68581aff36448325ba2dd8a0889f8b69