### PR TITLE
Add warnings for storage write failures

### DIFF
--- a/src/lib/__tests__/storage.test.ts
+++ b/src/lib/__tests__/storage.test.ts
@@ -1,0 +1,26 @@
+import { safeSet, safeRemove } from '../storage'
+
+describe('storage utils', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    jest.restoreAllMocks()
+  })
+
+  test('safeSet logs warning when setItem fails', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('fail')
+    })
+    expect(safeSet('k', 'v')).toBe(false)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  test('safeRemove logs warning when removeItem fails', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('fail')
+    })
+    expect(safeRemove('k')).toBe(false)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+})

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -14,7 +14,8 @@ export function safeSet(key: string, value: unknown, stringify = false): boolean
     const data = stringify ? JSON.stringify(value) : (value as string)
     localStorage.setItem(key, data)
     return true
-  } catch {
+  } catch (e) {
+    console.warn(`safeSet: failed for key "${key}"`, e)
     return false
   }
 }
@@ -23,7 +24,8 @@ export function safeRemove(key: string): boolean {
   try {
     localStorage.removeItem(key)
     return true
-  } catch {
+  } catch (e) {
+    console.warn(`safeRemove: failed for key "${key}"`, e)
     return false
   }
 }


### PR DESCRIPTION
## Summary
- warn when `safeSet` or `safeRemove` fail
- test warning behaviour in storage utilities

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68581bb3b1d883258a5261b65fea9da7