### PR TITLE
Add fetch abort handling

### DIFF
--- a/src/components/__tests__/DisclaimerModal.test.tsx
+++ b/src/components/__tests__/DisclaimerModal.test.tsx
@@ -95,4 +95,24 @@ describe('DisclaimerModal', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
   })
+
+  test('no state update after unmount', async () => {
+    let aborted = false
+    global.fetch = jest.fn().mockImplementation((_url, init) => {
+      const signal = (init as RequestInit)?.signal
+      signal?.addEventListener('abort', () => {
+        aborted = true
+      })
+      return new Promise(() => {}) as unknown as Promise<Response>
+    }) as unknown as typeof fetch
+
+    const { unmount } = render(
+      <DisclaimerModal open={true} onOpenChange={() => {}} />
+    )
+    unmount()
+
+    expect(aborted).toBe(true)
+    await Promise.resolve()
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
- abort disclaimer text request with `AbortController`
- ensure no state updates after unmount in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68581c6024d48325a516636ee6fe7e3a