### PR TITLE
feat: warn on invalid safeSet usage

### DIFF
--- a/src/lib/__tests__/storage.test.ts
+++ b/src/lib/__tests__/storage.test.ts
@@ -15,6 +15,12 @@ describe('storage utils', () => {
     expect(warnSpy).toHaveBeenCalled()
   })
 
+  test('safeSet logs warning when value is not string and stringify is false', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(safeSet('k', { a: 1 })).toBe(false)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
   test('safeRemove logs warning when removeItem fails', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
     jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -10,6 +10,12 @@ export function safeGet<T = string>(key: string, defaultValue: T | null = null, 
 }
 
 export function safeSet(key: string, value: unknown, stringify = false): boolean {
+  if (!stringify && typeof value !== 'string') {
+    console.warn(
+      `safeSet: value for key "${key}" must be a string when stringify is false`
+    )
+    return false
+  }
   try {
     const data = stringify ? JSON.stringify(value) : (value as string)
     localStorage.setItem(key, data)


### PR DESCRIPTION
## Summary
- warn if non-string values are passed to `safeSet` without the `stringify` flag
- test new warning behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68581e7fb6a883258a07171b2b6dc39f