### PR TITLE
Add date helper and refactor HistoryPanel

### DIFF
--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -36,6 +36,7 @@ import {
 import ClipboardImportModal from './ClipboardImportModal'
 import BulkFileImportModal from './BulkFileImportModal'
 import { trackEvent } from '@/lib/analytics'
+import { formatDateTime } from '@/lib/date'
 import { useTracking } from '@/hooks/use-tracking'
 import { safeGet, safeSet, safeRemove } from '@/lib/storage'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -117,22 +118,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
     const blob = new Blob([data], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
-    const now = new Date()
-    const datetime = `${now.getFullYear()}${(now.getMonth() + 1)
-      .toString()
-      .padStart(2, '0')}${now
-        .getDate()
-        .toString()
-        .padStart(2, '0')}-${now
-          .getHours()
-          .toString()
-          .padStart(2, '0')}${now
-            .getMinutes()
-            .toString()
-            .padStart(2, '0')}${now
-              .getSeconds()
-              .toString()
-              .padStart(2, '0')}`
+    const datetime = formatDateTime()
     const rand = Math.random().toString(16).slice(2, 8)
     a.href = url
     a.download = `history-${datetime}-${rand}.json`
@@ -147,22 +133,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
     const blob = new Blob([data], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
-    const now = new Date()
-    const datetime = `${now.getFullYear()}${(now.getMonth() + 1)
-      .toString()
-      .padStart(2, '0')}${now
-        .getDate()
-        .toString()
-        .padStart(2, '0')}-${now
-          .getHours()
-          .toString()
-          .padStart(2, '0')}${now
-            .getMinutes()
-            .toString()
-            .padStart(2, '0')}${now
-              .getSeconds()
-              .toString()
-              .padStart(2, '0')}`
+    const datetime = formatDateTime()
     const rand = Math.random().toString(16).slice(2, 8)
     a.href = url
     a.download = `latest-actions-${datetime}-${rand}.json`

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -1,0 +1,10 @@
+import { formatDateTime } from '../date'
+
+describe('formatDateTime', () => {
+  test('formats date to YYYYMMDD-HHMMSS', () => {
+    const d = new Date('2024-02-03T04:05:06Z')
+    // Use timezone offset of 0 to avoid local timezone, but JS Date may convert
+    d.setMinutes(d.getMinutes() + d.getTimezoneOffset())
+    expect(formatDateTime(d)).toBe('20240203-040506')
+  })
+})

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,9 @@
+export function formatDateTime(date: Date = new Date()): string {
+  const year = date.getFullYear()
+  const month = (date.getMonth() + 1).toString().padStart(2, '0')
+  const day = date.getDate().toString().padStart(2, '0')
+  const hours = date.getHours().toString().padStart(2, '0')
+  const minutes = date.getMinutes().toString().padStart(2, '0')
+  const seconds = date.getSeconds().toString().padStart(2, '0')
+  return `${year}${month}${day}-${hours}${minutes}${seconds}`
+}


### PR DESCRIPTION
## Summary
- add `formatDateTime` helper
- use `formatDateTime` in HistoryPanel when exporting files
- test the helper

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68581ea6bb1083258009e0d5add53172