### PR TITLE
Add tests for new generateJson branches

### DIFF
--- a/src/lib/__tests__/generateJson.test.ts
+++ b/src/lib/__tests__/generateJson.test.ts
@@ -47,4 +47,42 @@ describe('generateJson', () => {
     const obj = parse(generateJson(opts))
     expect(obj.style_preset).toBeUndefined()
   })
+
+  test('removes material fields when use_material is false', () => {
+    const opts = { ...DEFAULT_OPTIONS, use_material: false }
+    const obj = parse(generateJson(opts))
+    expect(obj.made_out_of).toBeUndefined()
+    expect(obj.secondary_material).toBeUndefined()
+  })
+
+  test('removes motion fields when use_motion_animation is false', () => {
+    const opts = { ...DEFAULT_OPTIONS, use_motion_animation: false }
+    const obj = parse(generateJson(opts))
+    expect(obj.duration_seconds).toBeUndefined()
+    expect(obj.fps).toBeUndefined()
+    expect(obj.motion_strength).toBeUndefined()
+    expect(obj.camera_motion).toBeUndefined()
+    expect(obj.motion_direction).toBeUndefined()
+    expect(obj.frame_interpolation).toBeUndefined()
+  })
+
+  test('keeps material and motion fields when enabled', () => {
+    const opts = {
+      ...DEFAULT_OPTIONS,
+      use_material: true,
+      use_secondary_material: true,
+      secondary_material: 'wood',
+      use_motion_animation: true,
+      use_duration: true,
+    }
+    const obj = parse(generateJson(opts))
+    expect(obj.made_out_of).toBeDefined()
+    expect(obj.secondary_material).toBeDefined()
+    expect(obj.duration_seconds).toBeDefined()
+    expect(obj.fps).toBeDefined()
+    expect(obj.motion_strength).toBeDefined()
+    expect(obj.camera_motion).toBeDefined()
+    expect(obj.motion_direction).toBeDefined()
+    expect(obj.frame_interpolation).toBeDefined()
+  })
 })


### PR DESCRIPTION
## Summary
- add test cases for material and motion feature toggles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68581ed58a9c8325bbc409e50d64f5b9