### PR TITLE
Centralize breakpoint values

### DIFF
--- a/src/hooks/__tests__/use-mobile.test.tsx
+++ b/src/hooks/__tests__/use-mobile.test.tsx
@@ -1,6 +1,10 @@
 import { renderHook, act } from '@testing-library/react'
 import { useIsMobile } from '../use-mobile'
 import { useIsSingleColumn } from '../use-single-column'
+import {
+  MOBILE_BREAKPOINT,
+  SINGLE_COLUMN_BREAKPOINT,
+} from '@/lib/breakpoints'
 
 describe('useIsMobile', () => {
   const originalMatchMedia = window.matchMedia
@@ -21,11 +25,11 @@ describe('useIsMobile', () => {
   })
 
   test('updates state on change and cleans up', () => {
-    window.innerWidth = 500
+    window.innerWidth = MOBILE_BREAKPOINT - 100
     const { result, unmount } = renderHook(() => useIsMobile())
     expect(result.current).toBe(true)
 
-    window.innerWidth = 800
+    window.innerWidth = MOBILE_BREAKPOINT + 32
     act(() => {
       const handler = add.mock.calls[0][1]
       handler()
@@ -39,7 +43,7 @@ describe('useIsMobile', () => {
 
   test('defaults to false when matchMedia is missing', () => {
     delete (window as unknown as { matchMedia?: typeof window.matchMedia }).matchMedia
-    window.innerWidth = 500
+    window.innerWidth = MOBILE_BREAKPOINT - 100
     const { result } = renderHook(() => useIsMobile())
     expect(result.current).toBe(false)
   })
@@ -64,11 +68,11 @@ describe('useIsSingleColumn', () => {
   })
 
   test('updates state on change and cleans up', () => {
-    window.innerWidth = 900
+    window.innerWidth = SINGLE_COLUMN_BREAKPOINT - 100
     const { result, unmount } = renderHook(() => useIsSingleColumn())
     expect(result.current).toBe(true)
 
-    window.innerWidth = 1100
+    window.innerWidth = SINGLE_COLUMN_BREAKPOINT + 100
     act(() => {
       const handler = add.mock.calls[0][1]
       handler()
@@ -82,7 +86,7 @@ describe('useIsSingleColumn', () => {
 
   test('defaults to false when matchMedia is missing', () => {
     delete (window as unknown as { matchMedia?: typeof window.matchMedia }).matchMedia
-    window.innerWidth = 900
+    window.innerWidth = SINGLE_COLUMN_BREAKPOINT - 100
     const { result } = renderHook(() => useIsSingleColumn())
     expect(result.current).toBe(false)
   })

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
-
-const MOBILE_BREAKPOINT = 768
+import { MOBILE_BREAKPOINT } from '@/lib/breakpoints'
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState(false)

--- a/src/hooks/use-single-column.tsx
+++ b/src/hooks/use-single-column.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
-
-const BREAKPOINT = 1024
+import { SINGLE_COLUMN_BREAKPOINT } from '@/lib/breakpoints'
 
 export function useIsSingleColumn() {
   const [isSingle, setIsSingle] = React.useState(false)
@@ -11,8 +10,8 @@ export function useIsSingleColumn() {
       return
     }
 
-    const mq = window.matchMedia(`(max-width: ${BREAKPOINT - 1}px)`)
-    const handler = () => setIsSingle(window.innerWidth < BREAKPOINT)
+    const mq = window.matchMedia(`(max-width: ${SINGLE_COLUMN_BREAKPOINT - 1}px)`)
+    const handler = () => setIsSingle(window.innerWidth < SINGLE_COLUMN_BREAKPOINT)
     mq.addEventListener('change', handler)
     handler()
     return () => mq.removeEventListener('change', handler)

--- a/src/lib/breakpoints.ts
+++ b/src/lib/breakpoints.ts
@@ -1,0 +1,3 @@
+export const MOBILE_BREAKPOINT = 768
+export const SINGLE_COLUMN_BREAKPOINT = 1024
+


### PR DESCRIPTION
## Summary
- add new `src/lib/breakpoints.ts` for shared breakpoint constants
- use `MOBILE_BREAKPOINT` and `SINGLE_COLUMN_BREAKPOINT` in hooks
- adjust tests to import constants

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68581e94d2d883259ac8081640802a87