### PR TITLE
Add env variable to disable analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,9 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
-    <script>
+    <script type="module">
       (function () {
+        if (import.meta.env.VITE_DISABLE_ANALYTICS === 'true') return
         try {
           const enabled = localStorage.getItem('trackingEnabled');
           if (enabled === null || enabled === 'true') {

--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ a similar fashion by pointing it to the `dist` folder.
 ## Environment Variables
 
 - **`VITE_MEASUREMENT_ID`** (optional) – Google Analytics measurement ID. Defaults to `G-RVR9TSBQL7` if not set.
+- **`VITE_DISABLE_ANALYTICS`** (optional) – When set to `true`, prevents loading analytics scripts and disables analytics events.
 
 ## Contributing
 

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -9,6 +9,17 @@ describe('trackEvent', () => {
     ;({ trackEvent } = await import('../analytics'))
   })
 
+  test('does nothing when analytics disabled via env var', async () => {
+    process.env.VITE_DISABLE_ANALYTICS = 'true'
+    jest.resetModules()
+    ;({ trackEvent } = await import('../analytics'))
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent')
+    trackEvent(true, 'test')
+    expect(localStorage.getItem('trackingHistory')).toBeNull()
+    expect(dispatchSpy).not.toHaveBeenCalled()
+    delete process.env.VITE_DISABLE_ANALYTICS
+  })
+
   test('does nothing when tracking disabled', () => {
     const dispatchSpy = jest.spyOn(window, 'dispatchEvent')
     trackEvent(false, 'test')

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,5 @@
 import { safeGet, safeSet } from './storage'
-import { MEASUREMENT_ID } from './config'
+import { MEASUREMENT_ID, DISABLE_ANALYTICS } from './config'
 
 let trackingFailures = 0
 let trackingDead = false
@@ -10,7 +10,7 @@ export function trackEvent(
   event: string,
   params?: Record<string, unknown>
 ) {
-  if (!enabled) return
+  if (!enabled || DISABLE_ANALYTICS) return
 
   try {
     const list = (safeGet<{ date: string; action: string }[]>(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,9 +1,11 @@
-let measurementId: string | undefined
-try {
-  measurementId = new Function(
-    'return import.meta.env.VITE_MEASUREMENT_ID'
-  )() as string | undefined
-} catch {
-  measurementId = process.env.VITE_MEASUREMENT_ID
+function readEnv(key: string): string | undefined {
+  try {
+    return new Function(`return import.meta.env.${key}`)() as string | undefined
+  } catch {
+    return process.env[key]
+  }
 }
-export const MEASUREMENT_ID = measurementId ?? 'G-RVR9TSBQL7'
+
+export const MEASUREMENT_ID =
+  readEnv('VITE_MEASUREMENT_ID') ?? 'G-RVR9TSBQL7'
+export const DISABLE_ANALYTICS = readEnv('VITE_DISABLE_ANALYTICS') === 'true'

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,4 +4,5 @@ interface ImportMetaEnv {
   readonly VITE_COMMIT_HASH: string
   readonly VITE_COMMIT_DATE: string
   readonly VITE_MEASUREMENT_ID?: string
+  readonly VITE_DISABLE_ANALYTICS?: string
 }


### PR DESCRIPTION
## Summary
- add `DISABLE_ANALYTICS` constant in config
- guard analytics events with `VITE_DISABLE_ANALYTICS`
- disable analytics script in `index.html` when env var is set
- test analytics disable flag
- document the new env variable
- simplify env handling in `config.ts`

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_68581bc061348325baf453d70c1ad36b