### PR TITLE
Fix toast listener effect dependencies

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- register the toast listener only once in `use-toast`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685824806c48832595a8e2fa602d087e