### PR TITLE
Add dialog descriptions

### DIFF
--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -4,6 +4,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -180,6 +181,9 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
         <DialogContent className="max-w-2xl">
           <DialogHeader>
             <DialogTitle>History</DialogTitle>
+            <DialogDescription>
+              Review and manage your saved prompts and recent actions.
+            </DialogDescription>
           </DialogHeader>
           <Tabs value={tab} onValueChange={setTab}>
             <TabsList className="mb-4">
@@ -456,6 +460,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
         <DialogContent className="max-w-2xl">
           <DialogHeader>
             <DialogTitle>JSON Preview</DialogTitle>
+            <DialogDescription>Preview the generated JSON output.</DialogDescription>
           </DialogHeader>
           {preview && (
             <ScrollArea className="h-[60vh]">

--- a/src/components/MultiSelectDropdown.tsx
+++ b/src/components/MultiSelectDropdown.tsx
@@ -4,7 +4,8 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogTrigger
+  DialogTrigger,
+  DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -74,6 +75,9 @@ export const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
       <DialogContent className="max-w-md max-h-[80vh]">
         <DialogHeader>
           <DialogTitle>{label}</DialogTitle>
+          <DialogDescription>
+            Search for options and select any that apply.
+          </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
           <div className="relative">

--- a/src/components/SearchableDropdown.tsx
+++ b/src/components/SearchableDropdown.tsx
@@ -6,6 +6,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -79,6 +80,9 @@ export const SearchableDropdown: React.FC<SearchableDropdownProps> = ({
       <DialogContent className="max-w-md max-h-[80vh]">
         <DialogHeader>
           <DialogTitle>{label}</DialogTitle>
+          <DialogDescription>
+            Search for an option and select a single value.
+          </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
           <div className="relative">


### PR DESCRIPTION
## Summary
- add `DialogDescription` imports and descriptions for MultiSelectDropdown and SearchableDropdown
- describe HistoryPanel dialogs and JSON preview for accessibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685824a416e483258802a6bf972fa3d5