### PR TITLE
Add const typed camera options

### DIFF
--- a/src/components/MultiSelectDropdown.tsx
+++ b/src/components/MultiSelectDropdown.tsx
@@ -13,7 +13,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { ChevronDown, Search } from 'lucide-react';
 
 interface MultiSelectDropdownProps {
-  options: string[];
+  options: readonly string[];
   value: string[];
   onValueChange: (value: string[]) => void;
   placeholder?: string;

--- a/src/components/SearchableDropdown.tsx
+++ b/src/components/SearchableDropdown.tsx
@@ -13,7 +13,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { ChevronDown, Search } from 'lucide-react';
 
 interface SearchableDropdownProps {
-  options: string[];
+  options: readonly string[];
   value: string;
   onValueChange: (value: string) => void;
   placeholder?: string;

--- a/src/data/cameraOptions.ts
+++ b/src/data/cameraOptions.ts
@@ -10,7 +10,8 @@ export const shotTypeOptions = [
   "panoramic", "panorama", "static", "still", "freeze frame", "motion blur",
   "slow motion", "time-lapse", "macro", "cut-in", "cutaway", "insert detail",
   "subjective", "objective", "isometric"
-];
+] as const;
+export type ShotTypeOption = typeof shotTypeOptions[number];
 
 export const cameraAngleOptions = [
   "default", "as is", "not defined", "keep original", "eye-level", "high",
@@ -20,7 +21,8 @@ export const cameraAngleOptions = [
   "behind", "above", "below", "under", "point-of-view", "POV",
   "over-the-shoulder", "mirror", "reflection", "through-glass",
   "through-object", "hidden", "peek", "peeking", "side", "diagonal", "tilted"
-];
+] as const;
+export type CameraAngleOption = typeof cameraAngleOptions[number];
 
 export const compositionRulesOptions = [
   "rule of thirds", "golden ratio", "golden spiral", "diagonal method",
@@ -36,7 +38,8 @@ export const compositionRulesOptions = [
   "tight crop", "open composition", "closed composition", "high horizon",
   "low horizon", "eye-level perspective", "bird's eye perspective",
   "worm's eye perspective"
-];
+] as const;
+export type CompositionRulesOption = typeof compositionRulesOptions[number];
 
 export const cameraTypeOptions = [
   "default (auto/any camera)",
@@ -113,7 +116,8 @@ export const cameraTypeOptions = [
   "DJI Mavic 3 (drone camera)",
   "GoPro HERO12 Black (action camera)",
   "GoPro Max (360 action cam)"
-];
+] as const;
+export type CameraTypeOption = typeof cameraTypeOptions[number];
 
 export const lensTypeOptions = [
   "default",
@@ -153,7 +157,8 @@ export const lensTypeOptions = [
   "defocus 100mm",
   "superzoom 18-200mm",
   "perspective control 24mm"
-];
+] as const;
+export type LensTypeOption = typeof lensTypeOptions[number];
 
 export const apertureOptions = [
   "default (auto aperture)",
@@ -201,7 +206,8 @@ export const apertureOptions = [
   "f/51 (historic large format/technical use)",
   "f/57 (very rare, large format only)",
   "f/64 (famous Ansel Adams, Group f/64, maximum depth)"
-];
+] as const;
+export type ApertureOption = typeof apertureOptions[number];
 
 export const blurStyleOptions = [
   "default",
@@ -265,7 +271,8 @@ export const blurStyleOptions = [
   "neon blur",
   "glitter blur",
   "zoom burst blur"
-];
+] as const;
+export type BlurStyleOption = typeof blurStyleOptions[number];
 
 export const depthOfFieldOptions = [
   "default",
@@ -294,4 +301,5 @@ export const depthOfFieldOptions = [
   "subject in focus",
   "foreground in focus",
   "background in focus"
-];
+] as const;
+export type DepthOfFieldOption = typeof depthOfFieldOptions[number];

--- a/src/lib/soraOptions.ts
+++ b/src/lib/soraOptions.ts
@@ -1,3 +1,14 @@
+import type {
+  ShotTypeOption,
+  CameraAngleOption,
+  CompositionRulesOption,
+  CameraTypeOption,
+  LensTypeOption,
+  ApertureOption,
+  BlurStyleOption,
+  DepthOfFieldOption,
+} from '@/data/cameraOptions';
+
 export interface SoraOptions {
   prompt: string
   negative_prompt: string
@@ -40,14 +51,14 @@ export interface SoraOptions {
   motion_strength: number
   camera_motion: string
   motion_direction: 'forward' | 'backward' | 'left' | 'right' | 'up' | 'down'
-  camera_angle: string
-  shot_type: string
+  camera_angle: CameraAngleOption
+  shot_type: ShotTypeOption
   subject_focus: 'center' | 'left' | 'right' | 'top' | 'bottom'
-  composition_rules: string[]
+  composition_rules: CompositionRulesOption[]
   lighting: string
   color_grade: string
-  depth_of_field: string
-  lens_type: string
+  depth_of_field: DepthOfFieldOption
+  lens_type: LensTypeOption
   frame_interpolation: 'smooth' | 'realistic' | 'sharp'
   upscale: number
   safety_filter: 'strict' | 'moderate' | 'off'
@@ -55,11 +66,11 @@ export interface SoraOptions {
   environment: string
   use_signature: boolean
   signature?: string
-  blur_style: string
-  aperture: string
+  blur_style: BlurStyleOption
+  aperture: ApertureOption
   use_motion_animation: boolean
   use_enhancement_safety: boolean
-  camera_type: string
+  camera_type: CameraTypeOption
   use_settings_location: boolean
   year: number
   use_season: boolean


### PR DESCRIPTION
## Summary
- append `as const` to camera option arrays
- export union types for each camera option set
- use camera option types in `SoraOptions`
- allow readonly arrays in dropdown components

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685824d692c48325820cea7694f675ca