### PR TITLE
Add analytics disable env option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # Optional Google Analytics measurement ID
 VITE_MEASUREMENT_ID=your-id-here
+
+# Set to "true" to disable analytics completely
+# VITE_DISABLE_ANALYTICS=true

--- a/index.html
+++ b/index.html
@@ -15,22 +15,26 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
-    <script>
-      (function () {
+    <script type="module">
+      (() => {
         try {
-          const enabled = localStorage.getItem('trackingEnabled');
+          const disabled = import.meta.env.VITE_DISABLE_ANALYTICS === 'true'
+          if (disabled) return
+          const enabled = localStorage.getItem('trackingEnabled')
           if (enabled === null || enabled === 'true') {
-            const s = document.createElement('script');
-            s.async = true;
-            s.src = 'https://www.googletagmanager.com/gtag/js?id=G-RVR9TSBQL7';
-            document.head.appendChild(s);
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', 'G-RVR9TSBQL7');
+            const id =
+              import.meta.env.VITE_MEASUREMENT_ID || 'G-RVR9TSBQL7'
+            const s = document.createElement('script')
+            s.async = true
+            s.src = `https://www.googletagmanager.com/gtag/js?id=${id}`
+            document.head.appendChild(s)
+            window.dataLayer = window.dataLayer || []
+            function gtag() { dataLayer.push(arguments) }
+            gtag('js', new Date())
+            gtag('config', id)
           }
         } catch (e) {
-          console.error('Tracking initialization failed', e);
+          console.error('Tracking initialization failed', e)
         }
       })();
     </script>

--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,7 @@ a similar fashion by pointing it to the `dist` folder.
 Copy `.env.example` to `.env` and adjust values as needed.
 
 - **`VITE_MEASUREMENT_ID`** (optional) – Google Analytics measurement ID. Defaults to `G-RVR9TSBQL7` if not set.
+- **`VITE_DISABLE_ANALYTICS`** (optional) – Set to `true` to disable all analytics tracking.
 
 ## Contributing
 

--- a/src/hooks/use-tracking.ts
+++ b/src/hooks/use-tracking.ts
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react'
 import { safeGet, safeSet } from '@/lib/storage'
+import { DISABLE_ANALYTICS } from '@/lib/config'
 
 export function useTracking() {
   const [enabled, setEnabled] = useState(() => {
+    if (DISABLE_ANALYTICS) return false
     const stored = safeGet('trackingEnabled')
     if (stored !== null) {
       try {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -9,3 +9,16 @@ try {
   }
 }
 export const MEASUREMENT_ID = measurementId ?? 'G-RVR9TSBQL7'
+
+let disableAnalytics: string | undefined
+try {
+  disableAnalytics = new Function(
+    'return import.meta.env.VITE_DISABLE_ANALYTICS'
+  )() as string | undefined
+} catch {
+  if (typeof process !== 'undefined') {
+    disableAnalytics = process.env.VITE_DISABLE_ANALYTICS
+  }
+}
+export const DISABLE_ANALYTICS =
+  disableAnalytics === 'true' || disableAnalytics === '1'

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,4 +4,5 @@ interface ImportMetaEnv {
   readonly VITE_COMMIT_HASH: string
   readonly VITE_COMMIT_DATE: string
   readonly VITE_MEASUREMENT_ID?: string
+  readonly VITE_DISABLE_ANALYTICS?: string
 }


### PR DESCRIPTION
## Summary
- support `VITE_DISABLE_ANALYTICS` env var
- respect analytics disable setting in index.html and tracking hook
- document the new variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685826e95d5c83258b37d832c6cb9613