### PR TITLE
Fix warnings in tests

### DIFF
--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -34,7 +34,7 @@ jest.mock('../BulkFileImportModal', () => ({
 jest.mock('@/components/ui/dropdown-menu', () => ({
   __esModule: true,
   DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuTrigger: ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
+  DropdownMenuTrigger: ({ children, asChild: _asChild, ...props }: React.HTMLAttributes<HTMLSpanElement> & { asChild?: boolean }) => (
     <span {...props}>{children}</span>
   ),
   DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -33,6 +33,9 @@ describe('trackEvent', () => {
     const errorSpy = jest
       .spyOn(console, 'error')
       .mockImplementation(() => {})
+    const warnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {})
     const gtagMock = jest.fn()
     ;(window as unknown as { gtag?: jest.Mock }).gtag = gtagMock
     jest
@@ -47,6 +50,7 @@ describe('trackEvent', () => {
       'Tracking History: There was an error.'
     )
     expect(gtagMock).toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalled()
   })
 
   test('does not call gtag when missing', () => {


### PR DESCRIPTION
## Summary
- filter out the `asChild` prop in HistoryPanel tests
- suppress `safeSet` console warnings in analytics tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858298e319c83259648f06f9f40f4d1