### PR TITLE
Add Dockerfile for containerized builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+.gitignore
+dist
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+RUN npm install -g serve
+COPY --from=build /app/dist ./dist
+EXPOSE 8080
+CMD ["serve", "-s", "dist", "-l", "8080"]

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,17 @@ npm run dev
 ```
 Then open http://localhost:8080 in your browser.
 
+### Docker
+
+Build and run a containerized version of the app:
+
+```sh
+docker build -t sora-json-prompt-crafter .
+docker run -p 8080:8080 sora-json-prompt-crafter
+```
+
+The application will then be available at http://localhost:8080.
+
 ### Running Tests
 
 ```sh


### PR DESCRIPTION
## Summary
- add a Dockerfile with multistage build
- ignore node_modules and build output when building images
- document how to run the app via Docker

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6858560c9c888325a83cff4d050f49f5