### PR TITLE
Add coverage step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm test
+      - run: npm run coverage
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.node-version }}
+          path: coverage
 
   build:
     needs: [test, typecheck]

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "jest",
+    "coverage": "jest --coverage",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add `npm run coverage` script
- run coverage after tests in CI
- upload coverage artifacts

## Testing
- `npm test`
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_685aeb8df14883259a0f36babd34c937