### PR TITLE
Add Node version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,8 @@
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "license": "MIT"
 }

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,8 @@ Example JSON output:
 
 ## Quick Start
 
+Requires **Node.js 18** or higher.
+
 To start using the prompt crafter locally clone and run using the following commands:
 
 ```sh


### PR DESCRIPTION
## Summary
- require Node.js 18+ via `engines` in `package.json`
- mention Node.js version in **Quick Start** section of the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bf4515798832590b42f1a879ae0d1