### PR TITLE
Add failure case for GitHub stats fetch

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -72,6 +72,9 @@ const Dashboard = () => {
         const res = await fetch(
           'https://api.github.com/repos/supermarsx/sora-json-prompt-crafter'
         )
+        if (!res.ok) {
+          throw new Error('non ok')
+        }
         const data = await res.json()
         setGithubStats({
           stars: data.stargazers_count,


### PR DESCRIPTION
## Summary
- test Dashboard error toast when `fetch` rejects or returns `ok: false`
- handle non-ok GitHub stats responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c01b37df4832594f7a013d287036b