### PR TITLE
Allow custom disclaimer URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ VITE_MEASUREMENT_ID=your-id-here
 
 # Set to "true" to disable analytics completely
 # VITE_DISABLE_ANALYTICS=true
+
+# Optional custom disclaimer location. Defaults to /disclaimer.txt
+# VITE_DISCLAIMER_URL=https://example.com/disclaimer.txt

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ npm install
 npm run dev
 ```
 Copy `.env.example` to `.env` and adjust the variables. `VITE_MEASUREMENT_ID` holds your Google Analytics ID and `VITE_DISABLE_ANALYTICS` disables tracking.
+`VITE_DISCLAIMER_URL` can be set to load the disclaimer from a different URL.
 Then open http://localhost:8080 in your browser.
 
 ### Docker
@@ -149,6 +150,7 @@ Copy `.env.example` to `.env` and adjust values as needed.
 
 - **`VITE_MEASUREMENT_ID`** (optional) – Google Analytics measurement ID. Defaults to `G-RVR9TSBQL7` if not set. See `.env.example` for the placeholder.
 - **`VITE_DISABLE_ANALYTICS`** (optional) – Set to `true` to disable all analytics tracking. Example provided in `.env.example`.
+- **`VITE_DISCLAIMER_URL`** (optional) – URL for the disclaimer text. Defaults to `/disclaimer.txt`.
 ## Contributing
 
 Pull requests are welcome. Please open an issue first to discuss major changes.
@@ -157,7 +159,8 @@ Pull requests are welcome. Please open an issue first to discuss major changes.
 
 The full legal disclaimer displayed in the application is stored in
 `public/disclaimer.txt`. This file is copied to the `dist` directory during the
-build so it can be viewed at `/disclaimer.txt` in production.
+build so it can be viewed at `/disclaimer.txt` in production. You can change the
+location by setting `VITE_DISCLAIMER_URL`.
 
 ## Tracking/Analytics
 

--- a/src/components/DisclaimerModal.tsx
+++ b/src/components/DisclaimerModal.tsx
@@ -26,7 +26,18 @@ const DisclaimerModal: React.FC<DisclaimerModalProps> = ({ open, onOpenChange })
     const controller = new AbortController();
     const { signal } = controller;
 
-    fetch('/disclaimer.txt', { signal })
+    let disclaimerUrl: string | undefined
+    try {
+      disclaimerUrl = new Function(
+        'return import.meta.env.VITE_DISCLAIMER_URL'
+      )() as string | undefined
+    } catch {
+      if (typeof process !== 'undefined') {
+        disclaimerUrl = (process as any).env?.VITE_DISCLAIMER_URL
+      }
+    }
+    const url = disclaimerUrl ?? '/disclaimer.txt'
+    fetch(url, { signal })
       .then((res) => {
         if (!res.ok) {
           throw new Error('Failed to fetch disclaimer');

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,4 +5,5 @@ interface ImportMetaEnv {
   readonly VITE_COMMIT_DATE: string
   readonly VITE_MEASUREMENT_ID?: string
   readonly VITE_DISABLE_ANALYTICS?: string
+  readonly VITE_DISCLAIMER_URL?: string
 }


### PR DESCRIPTION
## Summary
- add `VITE_DISCLAIMER_URL` example in `.env.example`
- read disclaimer URL from `import.meta.env` in `DisclaimerModal`
- document new env var in README
- type new env var

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c201551c48325b9c1f096369afe7e