### PR TITLE
Add basic service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,5 +43,12 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js');
+        });
+      }
+    </script>
   </body>
 </html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,25 @@
+const cacheName = 'sora-prompt-cache-v1';
+const staticAssets = [
+  '/',
+  '/index.html',
+  '/favicon.ico',
+  '/favicon.png',
+  '/favicon.svg',
+  '/web-app-manifest-192x192.png',
+  '/web-app-manifest-512x512.png',
+  '/site.webmanifest'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(cacheName).then(cache => cache.addAll(staticAssets))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@ go "my eyes!" when there's bright white lights.
 - Advanced specialized prompting options
 - Artifact and defect correction presets
 - No-fuss tracking toggle
+- Works offline thanks to service worker caching of assets
 
 Example JSON output:
 


### PR DESCRIPTION
## Summary
- add a simple service worker in `public/sw.js` for caching static assets
- register the service worker in `index.html` when supported
- document offline support in the features list

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685c2028004c8325b787d79831b80862