### PR TITLE
Fix type for process env in DisclaimerModal

### DIFF
--- a/src/components/DisclaimerModal.tsx
+++ b/src/components/DisclaimerModal.tsx
@@ -47,7 +47,7 @@ const DisclaimerModal: React.FC<DisclaimerModalProps> = ({ open, onOpenChange })
       )() as string | undefined
     } catch {
       if (typeof process !== 'undefined') {
-        disclaimerUrl = (process as any).env?.VITE_DISCLAIMER_URL
+        disclaimerUrl = (process as { env?: { VITE_DISCLAIMER_URL?: string } }).env?.VITE_DISCLAIMER_URL
       }
     }
     const url = disclaimerUrl ?? '/disclaimer.txt'


### PR DESCRIPTION
## Summary
- fix eslint `no-explicit-any` warning in `DisclaimerModal`

## Testing
- `npx prettier src/components/DisclaimerModal.tsx --check`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c780343d083259b1c96043c369ae7