### PR TITLE
fix: expose gtag globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -10,31 +10,39 @@
     <meta property="og:title" content="Sora JSON Prompt Crafter" />
     <meta property="og:description" content="Lovable Generated Project" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta
+      property="og:image"
+      content="https://lovable.dev/opengraph-image-p98pqg.png"
+    />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta
+      name="twitter:image"
+      content="https://lovable.dev/opengraph-image-p98pqg.png"
+    />
     <script type="module">
       (() => {
         try {
-          const disabled = import.meta.env.VITE_DISABLE_ANALYTICS === 'true'
-          if (disabled) return
-          const enabled = localStorage.getItem('trackingEnabled')
+          const disabled = import.meta.env.VITE_DISABLE_ANALYTICS === 'true';
+          if (disabled) return;
+          const enabled = localStorage.getItem('trackingEnabled');
           if (enabled === null || enabled === 'true') {
-            const id =
-              import.meta.env.VITE_MEASUREMENT_ID || 'G-RVR9TSBQL7'
-            const s = document.createElement('script')
-            s.async = true
-            s.src = `https://www.googletagmanager.com/gtag/js?id=${id}`
-            document.head.appendChild(s)
-            window.dataLayer = window.dataLayer || []
-            function gtag() { dataLayer.push(arguments) }
-            gtag('js', new Date())
-            gtag('config', id)
+            const id = import.meta.env.VITE_MEASUREMENT_ID || 'G-RVR9TSBQL7';
+            const s = document.createElement('script');
+            s.async = true;
+            s.src = `https://www.googletagmanager.com/gtag/js?id=${id}`;
+            document.head.appendChild(s);
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+              dataLayer.push(arguments);
+            }
+            window.gtag = gtag;
+            gtag('js', new Date());
+            gtag('config', id);
           }
         } catch (e) {
-          console.error('Tracking initialization failed', e)
+          console.error('Tracking initialization failed', e);
         }
       })();
     </script>


### PR DESCRIPTION
## Summary
- expose the analytics `gtag` function globally

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e8b2ef4ac83258fa7073903bbc318