### PR TITLE
Add Google Analytics debug mode support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ VITE_MEASUREMENT_ID=your-id-here
 
 # Optional custom disclaimer location. Defaults to /disclaimer.txt
 # VITE_DISCLAIMER_URL=https://example.com/disclaimer.txt
+
+# Set to "true" to enable GA debug mode
+# VITE_GTAG_DEBUG=true

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ npm install
 npm run dev
 ```
 
-Copy `.env.example` to `.env` and adjust the variables. `VITE_MEASUREMENT_ID` holds your Google Analytics ID and `VITE_DISABLE_ANALYTICS` disables tracking. `VITE_DISABLE_STATS` disables the GitHub stats fetch. `VITE_DISCLAIMER_URL` can be set to load the disclaimer from a different URL.
+Copy `.env.example` to `.env` and adjust the variables. `VITE_MEASUREMENT_ID` holds your Google Analytics ID and `VITE_DISABLE_ANALYTICS` disables tracking. `VITE_DISABLE_STATS` disables the GitHub stats fetch. `VITE_DISCLAIMER_URL` can be set to load the disclaimer from a different URL. Set `VITE_GTAG_DEBUG` to `true` to enable GA debug mode.
 Then open http://localhost:8080 in your browser.
 
 ### Docker
@@ -160,6 +160,7 @@ Copy `.env.example` to `.env` and adjust values as needed.
 - **`VITE_DISABLE_ANALYTICS`** (optional) – Set to `true` to disable all analytics tracking. Example provided in `.env.example`.
 - **`VITE_DISABLE_STATS`** (optional) – Set to `true` to disable fetching GitHub stats. Example provided in `.env.example`.
 - **`VITE_DISCLAIMER_URL`** (optional) – URL for the disclaimer text. Defaults to `/disclaimer.txt`.
+- **`VITE_GTAG_DEBUG`** (optional) – Set to `true` to enable Google Analytics debug mode.
 
 ## Contributing
 

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -78,4 +78,21 @@ describe('trackEvent', () => {
     );
     expect(errorSpy).toHaveBeenCalledTimes(2);
   });
+
+  test('passes debug_mode when GTAG_DEBUG enabled', async () => {
+    process.env.VITE_GTAG_DEBUG = 'true';
+    jest.resetModules();
+    ({ trackEvent } = await import('../analytics'));
+
+    const gtagMock = jest.fn();
+    (window as unknown as { gtag?: jest.Mock }).gtag = gtagMock;
+    trackEvent(true, 'foo');
+
+    expect(gtagMock).toHaveBeenCalledWith(
+      'event',
+      'page_action',
+      expect.objectContaining({ debug_mode: true }),
+    );
+    delete process.env.VITE_GTAG_DEBUG;
+  });
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,5 @@
 import { safeGet, safeSet } from './storage';
-import { MEASUREMENT_ID } from './config';
+import { MEASUREMENT_ID, GTAG_DEBUG } from './config';
 
 let trackingFailures = 0;
 let trackingDead = false;
@@ -47,11 +47,16 @@ export function trackEvent(
   }
 
   try {
-    gtag('event', 'page_action', {
+    const eventParams: Record<string, unknown> = {
       send_to: MEASUREMENT_ID,
       action: event,
       ...params,
-    });
+    };
+    if (GTAG_DEBUG) {
+      eventParams.debug_mode = true;
+      console.debug('gtag event', event, params);
+    }
+    gtag('event', 'page_action', eventParams);
   } catch (e) {
     trackingFailures++;
     if (trackingFailures <= 5) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -34,3 +34,15 @@ try {
   }
 }
 export const DISABLE_STATS = disableStats === 'true' || disableStats === '1';
+
+let gtagDebug: string | undefined;
+try {
+  gtagDebug = new Function('return import.meta.env.VITE_GTAG_DEBUG')() as
+    | string
+    | undefined;
+} catch {
+  if (typeof process !== 'undefined') {
+    gtagDebug = process.env.VITE_GTAG_DEBUG;
+  }
+}
+export const GTAG_DEBUG = gtagDebug === 'true' || gtagDebug === '1';

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,4 +7,5 @@ interface ImportMetaEnv {
   readonly VITE_DISABLE_ANALYTICS?: string;
   readonly VITE_DISABLE_STATS?: string;
   readonly VITE_DISCLAIMER_URL?: string;
+  readonly VITE_GTAG_DEBUG?: string;
 }


### PR DESCRIPTION
## Summary
- add `GTAG_DEBUG` config from `VITE_GTAG_DEBUG`
- log GA events in debug mode and pass `debug_mode` to gtag
- document `VITE_GTAG_DEBUG` variable in env files and README
- test analytics debug flag behavior

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ea699276c8325b4473da640c43c77