### PR TITLE
Add missing empty file import test

### DIFF
--- a/src/components/__tests__/BulkFileImportModal.test.tsx
+++ b/src/components/__tests__/BulkFileImportModal.test.tsx
@@ -89,4 +89,22 @@ describe('BulkFileImportModal', () => {
     );
     expect(onImport).not.toHaveBeenCalled();
   });
+
+  test('shows error toast when no file selected', () => {
+    const onImport = jest.fn();
+    const onOpenChange = jest.fn();
+
+    render(
+      <BulkFileImportModal
+        open={true}
+        onOpenChange={onOpenChange}
+        onImport={onImport}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /import/i }));
+
+    expect(toast.error).toHaveBeenCalledWith('Please select a file');
+    expect(onImport).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/__tests__/DashboardHistory.test.tsx
+++ b/src/components/__tests__/DashboardHistory.test.tsx
@@ -87,12 +87,10 @@ describe('Dashboard history limit', () => {
     global.fetch = jest
       .fn()
       .mockResolvedValue({ json: () => Promise.resolve({}) });
-    window.matchMedia = jest
-      .fn()
-      .mockReturnValue({
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-      }) as unknown as typeof window.matchMedia;
+    window.matchMedia = jest.fn().mockReturnValue({
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }) as unknown as typeof window.matchMedia;
   });
 
   test('caps history at 100 entries', async () => {


### PR DESCRIPTION
## Summary
- cover empty file path in `BulkFileImportModal`
- format `DashboardHistory.test` with prettier

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ed2ae038483258eac20091b730d41