### PR TITLE
Fix gtag event name

### DIFF
--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -184,7 +184,9 @@ describe('HistoryPanel', () => {
       revokeObjectURL: jest.fn(),
     });
     const origCreate = document.createElement;
-    jest.spyOn(document, 'createElement').mockImplementation(function (tag: string) {
+    jest.spyOn(document, 'createElement').mockImplementation(function (
+      tag: string,
+    ) {
       if (tag === 'a') return anchor as unknown as HTMLElement;
       return origCreate.call(this, tag);
     });
@@ -209,7 +211,9 @@ describe('HistoryPanel', () => {
       revokeObjectURL: jest.fn(),
     });
     const origCreate = document.createElement;
-    jest.spyOn(document, 'createElement').mockImplementation(function (tag: string) {
+    jest.spyOn(document, 'createElement').mockImplementation(function (
+      tag: string,
+    ) {
       if (tag === 'a') return anchor as unknown as HTMLElement;
       return origCreate.call(this, tag);
     });
@@ -222,9 +226,7 @@ describe('HistoryPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: /^export$/i }));
 
     expect(anchor.click).toHaveBeenCalled();
-    expect(anchor.download).toBe(
-      'latest-actions-20240101-000000-199999.json',
-    );
+    expect(anchor.download).toBe('latest-actions-20240101-000000-199999.json');
   });
 
   test('deleting an action confirms then removes it', () => {

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -90,7 +90,7 @@ describe('trackEvent', () => {
 
     expect(gtagMock).toHaveBeenCalledWith(
       'event',
-      'page_action',
+      'foo',
       expect.objectContaining({ debug_mode: true }),
     );
     delete process.env.VITE_GTAG_DEBUG;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -56,7 +56,7 @@ export function trackEvent(
       eventParams.debug_mode = true;
       console.debug('gtag event', event, params);
     }
-    gtag('event', 'page_action', eventParams);
+    gtag('event', event, eventParams);
   } catch (e) {
     trackingFailures++;
     if (trackingFailures <= 5) {


### PR DESCRIPTION
## Summary
- send analytics event name directly
- update analytics tests
- format HistoryPanel test due to prettier

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ed4d6c5ec8325abf29ba81ce41ee7