### PR TITLE
Extend generateJson tests

### DIFF
--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -190,6 +190,7 @@ describe('HistoryPanel', () => {
     const clearActions = screen.getByRole('button', { name: /clear actions/i });
     expect(exportActions.hasAttribute('disabled')).toBe(true);
     expect(clearActions.hasAttribute('disabled')).toBe(true);
+  });
 
   test('downloads history file', async () => {
     const anchor: Partial<HTMLAnchorElement> & { click: jest.Mock } = {
@@ -200,7 +201,9 @@ describe('HistoryPanel', () => {
       revokeObjectURL: jest.fn(),
     });
     const origCreate = document.createElement;
-    jest.spyOn(document, 'createElement').mockImplementation(function (tag: string) {
+    jest.spyOn(document, 'createElement').mockImplementation(function (
+      tag: string,
+    ) {
       if (tag === 'a') return anchor as unknown as HTMLElement;
       return origCreate.call(this, tag);
     });
@@ -225,7 +228,9 @@ describe('HistoryPanel', () => {
       revokeObjectURL: jest.fn(),
     });
     const origCreate = document.createElement;
-    jest.spyOn(document, 'createElement').mockImplementation(function (tag: string) {
+    jest.spyOn(document, 'createElement').mockImplementation(function (
+      tag: string,
+    ) {
       if (tag === 'a') return anchor as unknown as HTMLElement;
       return origCreate.call(this, tag);
     });
@@ -238,9 +243,7 @@ describe('HistoryPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: /^export$/i }));
 
     expect(anchor.click).toHaveBeenCalled();
-    expect(anchor.download).toBe(
-      'latest-actions-20240101-000000-199999.json',
-    );
+    expect(anchor.download).toBe('latest-actions-20240101-000000-199999.json');
   });
 
   test('deleting an action confirms then removes it', () => {

--- a/src/lib/__tests__/generateJson.test.ts
+++ b/src/lib/__tests__/generateJson.test.ts
@@ -85,4 +85,72 @@ describe('generateJson', () => {
     expect(obj.motion_direction).toBeDefined();
     expect(obj.frame_interpolation).toBeDefined();
   });
+
+  test('includes dnd fields when section and flags enabled', () => {
+    const opts = {
+      ...DEFAULT_OPTIONS,
+      use_dnd_section: true,
+      use_dnd_character_race: true,
+      dnd_character_race: 'elf',
+      use_dnd_character_class: true,
+      dnd_character_class: 'wizard',
+      use_dnd_character_background: true,
+      dnd_character_background: 'noble',
+      use_dnd_character_alignment: true,
+      dnd_character_alignment: 'chaotic good',
+      use_dnd_monster_type: true,
+      dnd_monster_type: 'dragon',
+      use_dnd_environment: true,
+      dnd_environment: 'dungeon',
+      use_dnd_magic_school: true,
+      dnd_magic_school: 'evocation',
+      use_dnd_item_type: true,
+      dnd_item_type: 'sword',
+    };
+    const obj = parse(generateJson(opts));
+    expect(obj.dnd_character_race).toBeDefined();
+    expect(obj.dnd_character_class).toBeDefined();
+    expect(obj.dnd_character_background).toBeDefined();
+    expect(obj.dnd_character_alignment).toBeDefined();
+    expect(obj.dnd_monster_type).toBeDefined();
+    expect(obj.dnd_environment).toBeDefined();
+    expect(obj.dnd_magic_school).toBeDefined();
+    expect(obj.dnd_item_type).toBeDefined();
+  });
+
+  test('removes location related fields when settings location disabled', () => {
+    const opts = {
+      ...DEFAULT_OPTIONS,
+      use_settings_location: false,
+      environment: 'desert',
+      use_environment: true,
+      location: 'cave',
+      use_location: true,
+      use_season: true,
+      season: 'summer',
+      use_atmosphere_mood: true,
+      atmosphere_mood: 'gloomy',
+    };
+    const obj = parse(generateJson(opts));
+    expect(obj.environment).toBeUndefined();
+    expect(obj.location).toBeUndefined();
+    expect(obj.season).toBeUndefined();
+    expect(obj.atmosphere_mood).toBeUndefined();
+    expect(obj.year).toBeUndefined();
+  });
+
+  test('handles sword type with dnd section enabled', () => {
+    const opts = {
+      ...DEFAULT_OPTIONS,
+      use_sword_type: true,
+      sword_type: 'longsword',
+      sword_vibe: 'ancient',
+      use_dnd_section: true,
+      use_dnd_character_race: true,
+      dnd_character_race: 'human',
+    };
+    const obj = parse(generateJson(opts));
+    expect(obj.sword_type).toBeDefined();
+    expect(obj.dnd_character_race).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary
- exercise DnD section and sword options when generating JSON
- verify environment fields disappear when location settings are disabled
- close an unbalanced test block in `HistoryPanel.test.tsx`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ed5339ff083258258b444d571b0be