### PR TITLE
Add section interaction tests

### DIFF
--- a/src/components/sections/__tests__/DimensionsFormatSection.test.tsx
+++ b/src/components/sections/__tests__/DimensionsFormatSection.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DimensionsFormatSection } from '../DimensionsFormatSection';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
+
+describe('DimensionsFormatSection', () => {
+  test('checkbox toggle updates option', () => {
+    const updateOptions = jest.fn();
+    const options = {
+      ...DEFAULT_OPTIONS,
+      use_dimensions_format: true,
+      use_dimensions: false,
+    };
+    render(
+      <DimensionsFormatSection
+        options={options}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/use custom dimensions/i));
+    expect(updateOptions).toHaveBeenCalledWith({ use_dimensions: true });
+  });
+
+  test('dropdown selection calls updateOptions', () => {
+    const updateOptions = jest.fn();
+    const options = {
+      ...DEFAULT_OPTIONS,
+      use_dimensions_format: true,
+      aspect_ratio: '16:9',
+      quality: 'high',
+    };
+    render(
+      <DimensionsFormatSection
+        options={options}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    const comboboxes = screen.getAllByRole('combobox');
+    fireEvent.click(comboboxes[0]);
+    fireEvent.click(screen.getByRole('option', { name: /4:3/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ aspect_ratio: '4:3' });
+
+    fireEvent.click(comboboxes[1]);
+    fireEvent.click(screen.getByRole('option', { name: /ultra/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ quality: 'ultra' });
+  });
+});

--- a/src/components/sections/__tests__/DnDSection.test.tsx
+++ b/src/components/sections/__tests__/DnDSection.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DnDSection } from '../DnDSection';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
+
+describe('DnDSection', () => {
+  test('checkbox toggle updates option', () => {
+    const updateOptions = jest.fn();
+    const options = {
+      ...DEFAULT_OPTIONS,
+      use_dnd_section: true,
+      use_dnd_character_race: false,
+    };
+    render(
+      <DnDSection
+        options={options}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    const checkbox = screen.getByLabelText(/use character race/i);
+    fireEvent.click(checkbox);
+    expect(updateOptions).toHaveBeenCalledWith({
+      use_dnd_character_race: true,
+    });
+  });
+
+  test('dropdown selection calls updateOptions', () => {
+    const updateOptions = jest.fn();
+    const options = {
+      ...DEFAULT_OPTIONS,
+      use_dnd_section: true,
+      use_dnd_character_race: true,
+      dnd_character_race: 'human',
+    };
+    render(
+      <DnDSection
+        options={options}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /human/i }));
+    fireEvent.click(screen.getByRole('button', { name: /tortle/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ dnd_character_race: 'tortle' });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `DnDSection`
- add unit tests for `DimensionsFormatSection`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f00cbca848325802034536deb2968