### PR TITLE
Add dark mode startup test

### DIFF
--- a/src/__tests__/AppDarkMode.test.tsx
+++ b/src/__tests__/AppDarkMode.test.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react';
+import App from '../App';
+import { safeGet } from '@/lib/storage';
+
+jest.mock('@/lib/storage', () => ({
+  __esModule: true,
+  safeGet: jest.fn(),
+}));
+
+describe('App dark mode handling', () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove('dark');
+    (safeGet as jest.Mock).mockReset();
+    window.matchMedia = jest.fn().mockReturnValue({
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }) as unknown as typeof window.matchMedia;
+  });
+
+  test('adds dark class when safeGet returns null', () => {
+    (safeGet as jest.Mock).mockReturnValueOnce(null);
+    render(<App />);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  test('does not add dark class when safeGet returns value', () => {
+    (safeGet as jest.Mock).mockReturnValueOnce('true');
+    render(<App />);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- test that the `dark` class is applied on startup when no stored setting exists
- confirm that the class is not added when `safeGet` returns a value

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f091ba2c88325b9e9efb088726436