### PR TITLE
Add environment config tests

### DIFF
--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+
+const metaEnv = (
+  globalThis as unknown as {
+    import: { meta: { env: Record<string, string | undefined> } };
+  }
+).import.meta.env;
+
+function clearEnv() {
+  delete metaEnv.VITE_MEASUREMENT_ID;
+  delete metaEnv.VITE_DISABLE_ANALYTICS;
+  delete metaEnv.VITE_DISABLE_STATS;
+  delete metaEnv.VITE_GTAG_DEBUG;
+  delete process.env.VITE_MEASUREMENT_ID;
+  delete process.env.VITE_DISABLE_ANALYTICS;
+  delete process.env.VITE_DISABLE_STATS;
+  delete process.env.VITE_GTAG_DEBUG;
+}
+
+describe('config', () => {
+  let originalFunction: FunctionConstructor;
+
+  beforeEach(() => {
+    clearEnv();
+    jest.resetModules();
+    originalFunction = globalThis.Function;
+  });
+
+  afterEach(() => {
+    clearEnv();
+    jest.resetModules();
+    globalThis.Function = originalFunction;
+  });
+
+  test('reads values from import.meta.env', async () => {
+    metaEnv.VITE_MEASUREMENT_ID = 'AAA';
+    metaEnv.VITE_DISABLE_ANALYTICS = 'true';
+    metaEnv.VITE_DISABLE_STATS = '1';
+    metaEnv.VITE_GTAG_DEBUG = 'true';
+    globalThis.Function = function (this: unknown, code: string) {
+      switch (code) {
+        case 'return import.meta.env.VITE_MEASUREMENT_ID':
+          return () => metaEnv.VITE_MEASUREMENT_ID;
+        case 'return import.meta.env.VITE_DISABLE_ANALYTICS':
+          return () => metaEnv.VITE_DISABLE_ANALYTICS;
+        case 'return import.meta.env.VITE_DISABLE_STATS':
+          return () => metaEnv.VITE_DISABLE_STATS;
+        case 'return import.meta.env.VITE_GTAG_DEBUG':
+          return () => metaEnv.VITE_GTAG_DEBUG;
+        default:
+          return () => undefined;
+      }
+    } as unknown as FunctionConstructor;
+
+    const config = await import('../config');
+    expect(config.MEASUREMENT_ID).toBe('AAA');
+    expect(config.DISABLE_ANALYTICS).toBe(true);
+    expect(config.DISABLE_STATS).toBe(true);
+    expect(config.GTAG_DEBUG).toBe(true);
+  });
+
+  test('falls back to process.env when import.meta.env undefined', async () => {
+    process.env.VITE_MEASUREMENT_ID = 'BBB';
+    process.env.VITE_DISABLE_ANALYTICS = '1';
+    process.env.VITE_DISABLE_STATS = 'true';
+    process.env.VITE_GTAG_DEBUG = '1';
+    const config = await import('../config');
+    expect(config.MEASUREMENT_ID).toBe('BBB');
+    expect(config.DISABLE_ANALYTICS).toBe(true);
+    expect(config.DISABLE_STATS).toBe(true);
+    expect(config.GTAG_DEBUG).toBe(true);
+  });
+
+  test('uses defaults when env variables are missing', async () => {
+    const config = await import('../config');
+    expect(config.MEASUREMENT_ID).toBe('G-RVR9TSBQL7');
+    expect(config.DISABLE_ANALYTICS).toBe(false);
+    expect(config.DISABLE_STATS).toBe(false);
+    expect(config.GTAG_DEBUG).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for config env variables
- verify measurement ID and toggles use correct sources

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f0ac949888325948a9628f7c69879