### PR TITLE
Fix composition rules import

### DIFF
--- a/src/lib/__tests__/loadOptionsFromJson.test.ts
+++ b/src/lib/__tests__/loadOptionsFromJson.test.ts
@@ -17,4 +17,10 @@ describe('loadOptionsFromJson', () => {
     expect(loadOptionsFromJson(bad)).toBeNull();
     spy.mockRestore();
   });
+
+  test('normalizes composition_rules from snake_case', () => {
+    const json = JSON.stringify({ composition_rules: ['rule_of_thirds'] });
+    const result = loadOptionsFromJson(json);
+    expect(result!.composition_rules).toEqual(['rule of thirds']);
+  });
 });

--- a/src/lib/loadOptionsFromJson.ts
+++ b/src/lib/loadOptionsFromJson.ts
@@ -5,6 +5,11 @@ import { OPTION_FLAG_MAP } from './optionFlagMap';
 export function loadOptionsFromJson(json: string): SoraOptions | null {
   try {
     const obj = JSON.parse(json);
+    if (Array.isArray(obj.composition_rules)) {
+      obj.composition_rules = obj.composition_rules.map((r: string) =>
+        r.replace(/_/g, ' '),
+      );
+    }
     const enableMap = OPTION_FLAG_MAP;
 
     const flagUpdates: Partial<SoraOptions> = {};


### PR DESCRIPTION
## Summary
- normalize `composition_rules` values when importing JSON
- cover this case in tests

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f12e9c3a08325a7c37bbfe336508f