### PR TITLE
Fix act warning in dark mode test

### DIFF
--- a/src/__tests__/AppDarkMode.test.tsx
+++ b/src/__tests__/AppDarkMode.test.tsx
@@ -1,4 +1,16 @@
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
+
+// Mock components that rely on import.meta to avoid syntax errors in Jest
+jest.mock('../components/Footer', () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock('../components/Dashboard', () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
 import App from '../App';
 import { safeGet } from '@/lib/storage';
 
@@ -17,15 +29,19 @@ describe('App dark mode handling', () => {
     }) as unknown as typeof window.matchMedia;
   });
 
-  test('adds dark class when safeGet returns null', () => {
+  test('adds dark class when safeGet returns null', async () => {
     (safeGet as jest.Mock).mockReturnValueOnce(null);
-    render(<App />);
+    await act(async () => {
+      render(<App />);
+    });
     expect(document.documentElement.classList.contains('dark')).toBe(true);
   });
 
-  test('does not add dark class when safeGet returns value', () => {
+  test('does not add dark class when safeGet returns value', async () => {
     (safeGet as jest.Mock).mockReturnValueOnce('true');
-    render(<App />);
+    await act(async () => {
+      render(<App />);
+    });
     expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
 });

--- a/src/components/sections/__tests__/DnDSection.test.tsx
+++ b/src/components/sections/__tests__/DnDSection.test.tsx
@@ -43,6 +43,8 @@ describe('DnDSection', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: /human/i }));
     fireEvent.click(screen.getByRole('button', { name: /tortle/i }));
-    expect(updateOptions).toHaveBeenCalledWith({ dnd_character_race: 'tortle' });
+    expect(updateOptions).toHaveBeenCalledWith({
+      dnd_character_race: 'tortle',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- fix AppDarkMode test by mocking heavy components and wrapping render in `act`
- update Prettier formatting for DnDSection test

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f133590e883258701cadb76f0a537