### PR TITLE
Prioritize selected items in dropdown

### DIFF
--- a/src/components/MultiSelectDropdown.tsx
+++ b/src/components/MultiSelectDropdown.tsx
@@ -38,14 +38,14 @@ export const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
       'not defined',
       'keep original',
     ];
-    const regularOptions = options
-      .filter((opt) => !priorityOptions.includes(opt))
-      .sort();
-    const presentPriorityOptions = priorityOptions.filter((opt) =>
-      options.includes(opt),
-    );
-    return [...presentPriorityOptions, ...regularOptions];
-  }, [options]);
+    const baseSorted = [
+      ...priorityOptions.filter((opt) => options.includes(opt)),
+      ...options.filter((opt) => !priorityOptions.includes(opt)).sort(),
+    ];
+    const selectedOptions = baseSorted.filter((opt) => value.includes(opt));
+    const unselectedOptions = baseSorted.filter((opt) => !value.includes(opt));
+    return [...selectedOptions, ...unselectedOptions];
+  }, [options, value]);
 
   const filteredOptions = useMemo(() => {
     if (!searchQuery) return sortedOptions;

--- a/src/components/__tests__/MultiSelectDropdown.test.tsx
+++ b/src/components/__tests__/MultiSelectDropdown.test.tsx
@@ -72,4 +72,18 @@ describe('MultiSelectDropdown', () => {
     fireEvent.click(secondCheck);
     expect(handleChange).toHaveBeenLastCalledWith([]);
   });
+
+  test('selected options appear first in the list', () => {
+    render(
+      <MultiSelectDropdown
+        options={options}
+        value={['bar']}
+        onValueChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect((checkboxes[0] as HTMLElement).id).toBe('bar');
+  });
 });


### PR DESCRIPTION
## Summary
- sort MultiSelectDropdown options so chosen items render first
- verify the order in MultiSelectDropdown test

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f14cc6fe48325b1961f176cf279fe