### PR TITLE
Add tests for additional sections

### DIFF
--- a/src/components/sections/__tests__/CameraCompositionSection.test.tsx
+++ b/src/components/sections/__tests__/CameraCompositionSection.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { CameraCompositionSection } from '../CameraCompositionSection';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('CameraCompositionSection', () => {
+  test('checkbox toggle updates option', () => {
+    const updateOptions = jest.fn();
+    const options = {
+      ...DEFAULT_OPTIONS,
+      use_camera_composition: true,
+      use_lens_type: false,
+    };
+    render(
+      <CameraCompositionSection
+        options={options}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/use lens type/i));
+    expect(updateOptions).toHaveBeenCalledWith({ use_lens_type: true });
+  });
+
+  test('lens type dropdown updates value and respects disabled flag', () => {
+    const updateOptions = jest.fn();
+    const enabledOptions = {
+      ...DEFAULT_OPTIONS,
+      use_camera_composition: true,
+      use_lens_type: true,
+      lens_type: 'default',
+    };
+    const { rerender } = render(
+      <CameraCompositionSection
+        options={enabledOptions}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    let lensSection = screen.getByText('Lens Type').parentElement as HTMLElement;
+    let dropdown = within(lensSection).getByRole('button');
+    fireEvent.click(dropdown);
+    fireEvent.click(screen.getByRole('button', { name: /wide 24mm/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ lens_type: 'wide 24mm' });
+
+    const disabledOptions = { ...enabledOptions, use_lens_type: false };
+    rerender(
+      <CameraCompositionSection
+        options={disabledOptions}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    lensSection = screen.getByText('Lens Type').parentElement as HTMLElement;
+    dropdown = within(lensSection).getByRole('button');
+    expect(dropdown.hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/src/components/sections/__tests__/EnhancementsSection.test.tsx
+++ b/src/components/sections/__tests__/EnhancementsSection.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { EnhancementsSection } from '../EnhancementsSection';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('EnhancementsSection', () => {
+  test('checkbox toggle updates option', () => {
+    const updateOptions = jest.fn();
+    const options = { ...DEFAULT_OPTIONS, use_safety_filter: false };
+    render(
+      <EnhancementsSection
+        options={options}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/use safety filter/i));
+    expect(updateOptions).toHaveBeenCalledWith({ use_safety_filter: true });
+  });
+
+  test('safety filter dropdown updates value and disabled when flag off', () => {
+    const updateOptions = jest.fn();
+    const enabledOptions = { ...DEFAULT_OPTIONS, use_safety_filter: true, safety_filter: 'moderate' };
+    const { rerender } = render(
+      <EnhancementsSection
+        options={enabledOptions}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    let section = screen.getByText('Safety Filter').parentElement as HTMLElement;
+    let dropdown = within(section).getByRole('button');
+    fireEvent.click(dropdown);
+    fireEvent.click(screen.getByRole('button', { name: /^strict/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ safety_filter: 'strict' });
+
+    const disabledOptions = { ...enabledOptions, use_safety_filter: false };
+    rerender(
+      <EnhancementsSection
+        options={disabledOptions}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    section = screen.getByText('Safety Filter').parentElement as HTMLElement;
+    dropdown = within(section).getByRole('button');
+    expect(dropdown.hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/src/components/sections/__tests__/FaceSection.test.tsx
+++ b/src/components/sections/__tests__/FaceSection.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { FaceSection } from '../FaceSection';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('FaceSection', () => {
+  test('checkbox toggle updates option', () => {
+    const updateOptions = jest.fn();
+    const options = { ...DEFAULT_OPTIONS, use_face_enhancements: true, use_subject_gender: false };
+    render(<FaceSection options={options} updateOptions={updateOptions} />);
+    fireEvent.click(screen.getByLabelText(/use subject gender/i));
+    expect(updateOptions).toHaveBeenCalledWith({ use_subject_gender: true });
+  });
+
+  test('subject gender dropdown updates value and disabled when flag off', () => {
+    const updateOptions = jest.fn();
+    const enabledOptions = { ...DEFAULT_OPTIONS, use_face_enhancements: true, use_subject_gender: true, subject_gender: 'default (auto/inferred gender)' };
+    const { rerender } = render(<FaceSection options={enabledOptions} updateOptions={updateOptions} />);
+    let section = screen.getByText('Subject Gender').parentElement as HTMLElement;
+    let dropdown = within(section).getByRole('button');
+    fireEvent.click(dropdown);
+    fireEvent.click(screen.getByRole('button', { name: /^female$/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ subject_gender: 'female' });
+
+    const disabledOptions = { ...enabledOptions, use_subject_gender: false };
+    rerender(<FaceSection options={disabledOptions} updateOptions={updateOptions} />);
+    section = screen.getByText('Subject Gender').parentElement as HTMLElement;
+    dropdown = within(section).getByRole('button');
+    expect(dropdown.hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/src/components/sections/__tests__/LightingSection.test.tsx
+++ b/src/components/sections/__tests__/LightingSection.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { LightingSection } from '../LightingSection';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('LightingSection', () => {
+  test('lighting dropdown updates value', () => {
+    const updateOptions = jest.fn();
+    const options = { ...DEFAULT_OPTIONS, use_lighting: true, lighting: '' };
+    render(<LightingSection options={options} updateOptions={updateOptions} />);
+    const dropdown = screen.getByRole('button', { name: /select lighting/i });
+    fireEvent.click(dropdown);
+    fireEvent.click(screen.getByRole('button', { name: /natural light/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ lighting: 'natural light' });
+  });
+
+  test('dropdown disabled when use_lighting is false', () => {
+    const updateOptions = jest.fn();
+    const options = { ...DEFAULT_OPTIONS, use_lighting: false };
+    render(<LightingSection options={options} updateOptions={updateOptions} />);
+    const dropdown = screen.getByRole('button', { name: /select lighting/i });
+    expect(dropdown.hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/src/components/sections/__tests__/MaterialSection.test.tsx
+++ b/src/components/sections/__tests__/MaterialSection.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MaterialSection } from '../MaterialSection';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('MaterialSection', () => {
+  test('checkbox toggle updates option', () => {
+    const updateOptions = jest.fn();
+    const options = { ...DEFAULT_OPTIONS, use_material: true, use_secondary_material: false };
+    render(<MaterialSection options={options} updateOptions={updateOptions} />);
+    fireEvent.click(screen.getByLabelText(/use secondary material/i));
+    expect(updateOptions).toHaveBeenCalledWith({ use_secondary_material: true });
+  });
+
+  test('secondary material dropdown updates value and disabled when flag off', () => {
+    const updateOptions = jest.fn();
+    const enabledOptions = { ...DEFAULT_OPTIONS, use_material: true, use_secondary_material: true, secondary_material: 'default' };
+    const { rerender } = render(
+      <MaterialSection options={enabledOptions} updateOptions={updateOptions} />,
+    );
+    const section = screen.getByText('Secondary Material').parentElement as HTMLElement;
+    let dropdown = within(section).getByRole('button');
+    fireEvent.click(dropdown);
+    fireEvent.click(screen.getByRole('button', { name: /^wood$/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ secondary_material: 'wood' });
+
+    const disabledOptions = { ...enabledOptions, use_secondary_material: false };
+    rerender(<MaterialSection options={disabledOptions} updateOptions={updateOptions} />);
+    dropdown = within(section).getByRole('button');
+    expect(dropdown.hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/src/components/sections/__tests__/SettingsLocationSection.test.tsx
+++ b/src/components/sections/__tests__/SettingsLocationSection.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { SettingsLocationSection } from '../SettingsLocationSection';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('SettingsLocationSection', () => {
+  test('checkbox toggle updates option', () => {
+    const updateOptions = jest.fn();
+    const options = { ...DEFAULT_OPTIONS, use_settings_location: true, use_environment: false };
+    render(<SettingsLocationSection options={options} updateOptions={updateOptions} />);
+    fireEvent.click(screen.getByLabelText(/use environment/i));
+    expect(updateOptions).toHaveBeenCalledWith({ use_environment: true });
+  });
+
+  test('environment dropdown disabled when flag false and updates when enabled', () => {
+    const updateOptions = jest.fn();
+    const enabledOptions = { ...DEFAULT_OPTIONS, use_settings_location: true, use_environment: true, environment: 'default' };
+    const { rerender } = render(
+      <SettingsLocationSection options={enabledOptions} updateOptions={updateOptions} />,
+    );
+    let envSection = screen.getByText('Environment').parentElement as HTMLElement;
+    let dropdown = within(envSection).getByRole('button');
+    fireEvent.click(dropdown);
+    fireEvent.click(screen.getByRole('button', { name: /^forest$/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ environment: 'forest' });
+
+    const disabledOptions = { ...enabledOptions, use_environment: false };
+    rerender(<SettingsLocationSection options={disabledOptions} updateOptions={updateOptions} />);
+    envSection = screen.getByText('Environment').parentElement as HTMLElement;
+    dropdown = within(envSection).getByRole('button');
+    expect(dropdown.hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/src/components/sections/__tests__/StyleSection.test.tsx
+++ b/src/components/sections/__tests__/StyleSection.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StyleSection } from '../StyleSection';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('StyleSection', () => {
+  test('selecting style updates options', () => {
+    const updateNestedOptions = jest.fn();
+    const updateOptions = jest.fn();
+    const options = { ...DEFAULT_OPTIONS, use_style_preset: true };
+    render(
+      <StyleSection
+        options={options}
+        updateNestedOptions={updateNestedOptions}
+        updateOptions={updateOptions}
+      />,
+    );
+    const comboboxes = screen.getAllByRole('combobox');
+    fireEvent.click(comboboxes[1]);
+    fireEvent.click(screen.getByRole('option', { name: /film still/i }));
+    expect(updateNestedOptions).toHaveBeenCalledWith('style_preset.style', 'film still');
+  });
+});

--- a/src/components/sections/__tests__/VideoMotionSection.test.tsx
+++ b/src/components/sections/__tests__/VideoMotionSection.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { VideoMotionSection } from '../VideoMotionSection';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('VideoMotionSection', () => {
+  test('checkbox toggle updates option and input disabled when flag false', () => {
+    const updateOptions = jest.fn();
+    const options = { ...DEFAULT_OPTIONS, use_duration: false };
+    const { rerender } = render(
+      <VideoMotionSection
+        options={options}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    const checkbox = screen.getByLabelText(/use duration/i);
+    fireEvent.click(checkbox);
+    expect(updateOptions).toHaveBeenCalledWith({ use_duration: true });
+
+    const input = screen.getByLabelText(/duration \(seconds\)/i) as HTMLInputElement;
+    expect(input.hasAttribute('disabled')).toBe(true);
+
+    const enabledOptions = { ...options, use_duration: true };
+    rerender(
+      <VideoMotionSection
+        options={enabledOptions}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    const enabledInput = screen.getByLabelText(/duration \(seconds\)/i);
+    expect(enabledInput.hasAttribute('disabled')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add component tests for CameraCompositionSection, MaterialSection, LightingSection, StyleSection, SettingsLocationSection, FaceSection, VideoMotionSection and EnhancementsSection
- cover checkbox updates, dropdown selections and disabled states

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685f17e5dedc83259970869659745d4b