### PR TITLE
Add Sora integration helpers

### DIFF
--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -1,0 +1,37 @@
+// ==UserScript==
+// @name         Auto-inject JSON Prompt into Sora
+// @namespace    supermarsx
+// @version      1.0
+// @description  Inject JSON prompt from external tab into Sora textarea
+// @match        https://sora.chatgpt.com/*
+// @grant        none
+// @run-at       document-end
+// ==/UserScript==
+
+(function () {
+  console.log('[Sora Injector] Loaded');
+
+  const waitForTextarea = (callback) => {
+    const ta = document.querySelector('textarea');
+    if (ta) return callback(ta);
+    setTimeout(() => waitForTextarea(callback), 300);
+  };
+
+  window.addEventListener(
+    'message',
+    (event) => {
+      if (
+        event.origin !== window.origin &&
+        event.data?.type === 'INSERT_SORA_JSON'
+      ) {
+        console.log('[Sora Injector] Received JSON payload');
+        waitForTextarea((ta) => {
+          ta.value = JSON.stringify(event.data.json, null, 2);
+          ta.dispatchEvent(new Event('input', { bubbles: true }));
+          console.log('[Sora Injector] Textarea filled.');
+        });
+      }
+    },
+    false,
+  );
+})();

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ go "my eyes!" when there's bright white lights.
 - Advanced specialized prompting options
 - Artifact and defect correction presets
 - No-fuss tracking toggle
+- Optional Sora integration via userscript for one-click "Send to Sora"
 - Works offline thanks to service worker caching of assets
 
 Example JSON output:

--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -30,6 +30,7 @@ import {
   Eye,
   EyeOff,
   Trash2,
+  Send,
   Cog,
   ChevronDown,
   ChevronUp,
@@ -40,12 +41,15 @@ interface ActionBarProps {
   onCopy: () => void;
   onClear: () => void;
   onShare: () => void;
+  onSendToSora: () => void;
   onImport: () => void;
   onHistory: () => void;
   onReset: () => void;
   onRegenerate: () => void;
   onRandomize: () => void;
   trackingEnabled: boolean;
+  soraToolsEnabled: boolean;
+  onToggleSoraTools: () => void;
   onToggleTracking: () => void;
   copied: boolean;
   showJumpToJson?: boolean;
@@ -56,12 +60,15 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   onCopy,
   onClear,
   onShare,
+  onSendToSora,
   onImport,
   onHistory,
   onReset,
   onRegenerate,
   onRandomize,
   trackingEnabled,
+  soraToolsEnabled,
+  onToggleSoraTools,
   onToggleTracking,
   copied,
   showJumpToJson,
@@ -93,6 +100,17 @@ export const ActionBar: React.FC<ActionBarProps> = ({
 
   return (
     <div className="fixed bottom-4 right-4 z-50 bg-card border rounded-md shadow-lg p-3 flex flex-wrap items-center gap-2">
+      {soraToolsEnabled && (
+        <Button
+          onClick={onSendToSora}
+          variant="outline"
+          size="sm"
+          className="gap-2"
+        >
+          <Send className="w-4 h-4" />
+          Send to Sora
+        </Button>
+      )}
       <Button onClick={onCopy} variant="outline" size="sm" className="gap-2">
         {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
         Copy
@@ -150,6 +168,17 @@ export const ActionBar: React.FC<ActionBarProps> = ({
             ) : (
               <>
                 <Eye className="w-4 h-4" /> Enable Tracking
+              </>
+            )}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onToggleSoraTools} className="gap-2">
+            {soraToolsEnabled ? (
+              <>
+                <EyeOff className="w-4 h-4" /> Hide Sora Buttons
+              </>
+            ) : (
+              <>
+                <Eye className="w-4 h-4" /> Show Sora Buttons
               </>
             )}
           </DropdownMenuItem>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import { diffChars, Change } from 'diff';
-import { Sun, Moon, Heart, Github, Star, GitFork, Bug } from 'lucide-react';
+import {
+  Sun,
+  Moon,
+  Heart,
+  Github,
+  Star,
+  GitFork,
+  Bug,
+  Download,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { toast } from '@/components/ui/sonner-toast';
@@ -15,6 +24,7 @@ import DisclaimerModal from './DisclaimerModal';
 import { useIsSingleColumn } from '@/hooks/use-single-column';
 import { useDarkMode } from '@/hooks/use-dark-mode';
 import { useTracking } from '@/hooks/use-tracking';
+import { useSoraTools } from '@/hooks/use-sora-tools';
 import { useActionHistory } from '@/hooks/use-action-history';
 import { trackEvent } from '@/lib/analytics';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
@@ -60,6 +70,7 @@ const Dashboard = () => {
   const isSingleColumn = useIsSingleColumn();
   const [darkMode, setDarkMode] = useDarkMode();
   const [trackingEnabled, setTrackingEnabled] = useTracking();
+  const [soraToolsEnabled, setSoraToolsEnabled] = useSoraTools();
   const actionHistory = useActionHistory();
   const [githubStats, setGithubStats] = useState<{
     stars: number;
@@ -207,6 +218,18 @@ const Dashboard = () => {
   const shareJson = () => {
     setShowShareModal(true);
     trackEvent(trackingEnabled, 'share_button');
+  };
+
+  const sendToSora = () => {
+    const win = window.open('https://sora.chatgpt.com', '_blank');
+    if (!win) return;
+    setTimeout(() => {
+      win.postMessage(
+        { type: 'INSERT_SORA_JSON', json: JSON.parse(jsonString) },
+        '*',
+      );
+    }, 1000);
+    trackEvent(trackingEnabled, 'send_to_sora');
   };
 
   const importJson = (json: string) => {
@@ -474,6 +497,21 @@ const Dashboard = () => {
                   View on Lovable
                 </a>
               </Button>
+              {soraToolsEnabled && (
+                <Button asChild variant="outline" size="sm" className="gap-1">
+                  <a
+                    href="/sora-userscript.user.js"
+                    download
+                    className="flex items-center gap-1"
+                    onClick={() =>
+                      trackEvent(trackingEnabled, 'install_userscript')
+                    }
+                  >
+                    <Download className="w-4 h-4" />
+                    Install Userscript
+                  </a>
+                </Button>
+              )}
             </div>
             <p className="text-xs mt-2 text-muted-foreground">
               By using this tool you agree by the{' '}
@@ -565,12 +603,15 @@ const Dashboard = () => {
         onCopy={copyToClipboard}
         onClear={clearJson}
         onShare={shareJson}
+        onSendToSora={sendToSora}
         onImport={() => setShowImportModal(true)}
         onHistory={() => setShowHistory(true)}
         onReset={resetJson}
         onRegenerate={regenerateJson}
         onRandomize={randomizeJson}
         trackingEnabled={trackingEnabled}
+        soraToolsEnabled={soraToolsEnabled}
+        onToggleSoraTools={() => setSoraToolsEnabled(!soraToolsEnabled)}
         onToggleTracking={() => setTrackingEnabled(!trackingEnabled)}
         copied={copied}
         showJumpToJson={isSingleColumn}

--- a/src/components/__tests__/ActionBar.test.tsx
+++ b/src/components/__tests__/ActionBar.test.tsx
@@ -83,11 +83,14 @@ function createProps(
     onCopy: jest.fn(),
     onClear: jest.fn(),
     onShare: jest.fn(),
+    onSendToSora: jest.fn(),
     onImport: jest.fn(),
     onHistory: jest.fn(),
     onReset: jest.fn(),
     onRegenerate: jest.fn(),
     onRandomize: jest.fn(),
+    soraToolsEnabled: true,
+    onToggleSoraTools: jest.fn(),
     onToggleTracking: jest.fn(),
     copied: false,
     trackingEnabled: true,
@@ -161,6 +164,14 @@ describe('ActionBar', () => {
     fireEvent.click(btn);
     expect(onJumpToJson).toHaveBeenCalled();
     expect(trackEvent).toHaveBeenCalledWith(true, 'jump_to_json');
+  });
+
+  test('Send to Sora button appears and calls handler', () => {
+    const onSend = jest.fn();
+    const props = createProps({ onSendToSora: onSend, soraToolsEnabled: true });
+    render(<ActionBar {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /send to sora/i }));
+    expect(onSend).toHaveBeenCalled();
   });
 
   test('Minimize hides and restore shows bar again', () => {

--- a/src/hooks/__tests__/use-sora-tools.test.ts
+++ b/src/hooks/__tests__/use-sora-tools.test.ts
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react';
+import { useSoraTools } from '../use-sora-tools';
+
+describe('useSoraTools', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  test('initializes state from localStorage', () => {
+    const getSpy = jest.spyOn(Storage.prototype, 'getItem');
+    localStorage.setItem('soraToolsEnabled', 'false');
+    const { result } = renderHook(() => useSoraTools());
+    expect(result.current[0]).toBe(false);
+    expect(getSpy).toHaveBeenCalledWith('soraToolsEnabled');
+  });
+
+  test('persists state changes to localStorage', () => {
+    const setSpy = jest.spyOn(Storage.prototype, 'setItem');
+    const { result } = renderHook(() => useSoraTools());
+
+    act(() => {
+      result.current[1](false);
+    });
+
+    expect(localStorage.getItem('soraToolsEnabled')).toBe('false');
+    expect(setSpy).toHaveBeenCalledWith('soraToolsEnabled', 'false');
+  });
+});

--- a/src/hooks/use-sora-tools.ts
+++ b/src/hooks/use-sora-tools.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { safeGet, safeSet } from '@/lib/storage';
+
+export function useSoraTools() {
+  const [enabled, setEnabled] = useState(() => {
+    const stored = safeGet('soraToolsEnabled');
+    if (stored !== null) {
+      try {
+        return JSON.parse(stored);
+      } catch {
+        return true;
+      }
+    }
+    return true;
+  });
+
+  useEffect(() => {
+    safeSet('soraToolsEnabled', JSON.stringify(enabled));
+  }, [enabled]);
+
+  return [enabled, setEnabled] as const;
+}


### PR DESCRIPTION
## Summary
- allow toggling Sora helpers with new `useSoraTools` hook
- add Send to Sora button to the ActionBar
- add Install Userscript link near Lovable
- include Tampermonkey userscript in `public`
- document Sora integration option
- test new hook and button

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f28b91da88325b7ce7f8c3a39def7