### PR TITLE
fix userscript detection on lovable host

### DIFF
--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -4,6 +4,7 @@
 // @version      1.0
 // @description  Inject JSON prompt from external tab into Sora textarea
 // @match        https://sora.chatgpt.com/*
+// @match        https://sora-json-prompt-crafter.lovable.app/*
 // @grant        none
 // @run-at       document-end
 // ==/UserScript==
@@ -13,6 +14,8 @@
 
   if (window.opener) {
     window.opener.postMessage({ type: 'SORA_USERSCRIPT_READY' }, '*');
+  } else if (window.location.host.endsWith('lovable.app')) {
+    window.postMessage({ type: 'SORA_USERSCRIPT_READY' }, '*');
   }
 
 


### PR DESCRIPTION
## Summary
- update userscript metadata to run on the lovable hosted URL
- post ready message when loaded on lovable domain

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685f3102f5248325b07e3e3df0cc8bb4