### PR TITLE
Detect userscript via meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Sora JSON Prompt Crafter</title>
     <meta name="description" content="Lovable Generated Project" />
     <meta name="author" content="Lovable" />
+    <meta name="sora-json-prompt-crafter" content="true" />
 
     <meta property="og:title" content="Sora JSON Prompt Crafter" />
     <meta property="og:description" content="Lovable Generated Project" />

--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -12,11 +12,23 @@
 (function () {
   console.log('[Sora Injector] Loaded');
 
-  if (window.opener) {
-    window.opener.postMessage({ type: 'SORA_USERSCRIPT_READY' }, '*');
-  } else if (window.location.host.endsWith('lovable.app')) {
-    window.postMessage({ type: 'SORA_USERSCRIPT_READY' }, '*');
-  }
+  const notifyReady = () => {
+    try {
+      const isCrafter = document.querySelector(
+        'meta[name="sora-json-prompt-crafter"]'
+      );
+      if (isCrafter) {
+        localStorage.setItem('soraUserscriptInstalled', 'true');
+        window.postMessage({ type: 'SORA_USERSCRIPT_READY' }, '*');
+      } else if (window.opener) {
+        window.opener.postMessage({ type: 'SORA_USERSCRIPT_READY' }, '*');
+      }
+    } catch (e) {
+      console.warn('[Sora Injector] Failed to notify readiness', e);
+    }
+  };
+
+  notifyReady();
 
 
   const waitForTextarea = (callback) => {

--- a/src/hooks/__tests__/use-sora-userscript.test.ts
+++ b/src/hooks/__tests__/use-sora-userscript.test.ts
@@ -25,4 +25,17 @@ describe('useSoraUserscript', () => {
     expect(result.current[0]).toBe(true);
     expect(localStorage.getItem('soraUserscriptInstalled')).toBe('true');
   });
+
+  test('updates state on storage event', () => {
+    const { result } = renderHook(() => useSoraUserscript());
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'soraUserscriptInstalled',
+          newValue: 'true',
+        })
+      );
+    });
+    expect(result.current[0]).toBe(true);
+  });
 });

--- a/src/hooks/use-sora-userscript.ts
+++ b/src/hooks/use-sora-userscript.ts
@@ -28,5 +28,18 @@ export function useSoraUserscript() {
     return () => window.removeEventListener('message', handler);
   }, []);
 
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (
+        event.key === 'soraUserscriptInstalled' &&
+        event.newValue === 'true'
+      ) {
+        setInstalled(true);
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
   return [installed, setInstalled] as const;
 }


### PR DESCRIPTION
## Summary
- mark host page with `sora-json-prompt-crafter` meta tag
- detect the meta tag in userscript instead of using domain ending

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fb233eb6483259fc9931c35e6298f