### PR TITLE
Fix fallback for userscript detection

### DIFF
--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -15,10 +15,15 @@
   const notifyReady = () => {
     try {
       const isCrafter = document.querySelector(
-        'meta[name="sora-json-prompt-crafter"]'
+        'meta[name="sora-json-prompt-crafter"]',
       );
       if (isCrafter) {
-        localStorage.setItem('soraUserscriptInstalled', 'true');
+        try {
+          localStorage.setItem('soraUserscriptInstalled', 'true');
+        } catch {
+          document.cookie =
+            'soraUserscriptInstalled=true; path=/; max-age=31536000';
+        }
         window.postMessage({ type: 'SORA_USERSCRIPT_READY' }, '*');
       } else if (window.opener) {
         window.opener.postMessage({ type: 'SORA_USERSCRIPT_READY' }, '*');
@@ -29,7 +34,6 @@
   };
 
   notifyReady();
-
 
   const waitForTextarea = (callback) => {
     const ta = document.querySelector('textarea');

--- a/src/hooks/__tests__/use-sora-userscript.test.ts
+++ b/src/hooks/__tests__/use-sora-userscript.test.ts
@@ -4,6 +4,7 @@ import { useSoraUserscript } from '../use-sora-userscript';
 describe('useSoraUserscript', () => {
   beforeEach(() => {
     localStorage.clear();
+    Object.defineProperty(document, 'cookie', { writable: true, value: '' });
     jest.restoreAllMocks();
   });
 
@@ -15,15 +16,39 @@ describe('useSoraUserscript', () => {
     expect(getSpy).toHaveBeenCalledWith('soraUserscriptInstalled');
   });
 
+  test('initializes from cookie when localStorage missing', () => {
+    document.cookie = 'soraUserscriptInstalled=true';
+    const { result } = renderHook(() => useSoraUserscript());
+    expect(result.current[0]).toBe(true);
+  });
+
   test('updates state on message event', () => {
     const { result } = renderHook(() => useSoraUserscript());
     act(() => {
       window.dispatchEvent(
-        new MessageEvent('message', { data: { type: 'SORA_USERSCRIPT_READY' } })
+        new MessageEvent('message', {
+          data: { type: 'SORA_USERSCRIPT_READY' },
+        }),
       );
     });
     expect(result.current[0]).toBe(true);
     expect(localStorage.getItem('soraUserscriptInstalled')).toBe('true');
+  });
+
+  test('falls back to cookie when localStorage fails', () => {
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('fail');
+    });
+    const { result } = renderHook(() => useSoraUserscript());
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type: 'SORA_USERSCRIPT_READY' },
+        }),
+      );
+    });
+    expect(result.current[0]).toBe(true);
+    expect(document.cookie).toContain('soraUserscriptInstalled=true');
   });
 
   test('updates state on storage event', () => {
@@ -33,7 +58,7 @@ describe('useSoraUserscript', () => {
         new StorageEvent('storage', {
           key: 'soraUserscriptInstalled',
           newValue: 'true',
-        })
+        }),
       );
     });
     expect(result.current[0]).toBe(true);


### PR DESCRIPTION
## Summary
- handle localStorage failures in the userscript via cookies
- fall back to cookies in `useSoraUserscript` hook
- test cookie fallback logic

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fb7386ba4832589333aa74fd42f95