### PR TITLE
Fix user script detection timing

### DIFF
--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -32,6 +32,8 @@
   };
 
   notifyReady();
+  setTimeout(notifyReady, 1000);
+  setTimeout(notifyReady, 3000);
 
   const waitForTextarea = (callback) => {
     const ta = document.querySelector('textarea');


### PR DESCRIPTION
## Summary
- wait a bit before declaring the userscript ready to ensure message handlers are registered

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fc46921008325a72c6b882d4131f6