### PR TITLE
Implement postMessage handshake

### DIFF
--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -12,6 +12,8 @@
 (function () {
   console.log('[Sora Injector] Loaded');
 
+  let readyInterval;
+
   const notifyReady = () => {
     try {
       const isCrafter = document.querySelector(
@@ -31,9 +33,29 @@
     }
   };
 
-  notifyReady();
-  setTimeout(notifyReady, 1000);
-  setTimeout(notifyReady, 3000);
+  const startNotify = () => {
+    notifyReady();
+    readyInterval = setInterval(notifyReady, 250);
+  };
+
+  const stopNotify = () => {
+    if (readyInterval) {
+      clearInterval(readyInterval);
+      readyInterval = undefined;
+    }
+  };
+
+  startNotify();
+
+  window.addEventListener(
+    'message',
+    (event) => {
+      if (event.data?.type === 'SORA_USERSCRIPT_ACK') {
+        stopNotify();
+      }
+    },
+    false,
+  );
 
   const waitForTextarea = (callback) => {
     const ta = document.querySelector('textarea');
@@ -53,6 +75,7 @@
           ta.value = JSON.stringify(event.data.json, null, 2);
           ta.dispatchEvent(new Event('input', { bubbles: true }));
           console.log('[Sora Injector] Textarea filled.');
+          event.source?.postMessage({ type: 'INSERT_SORA_JSON_ACK' }, '*');
         });
       }
     },

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -235,12 +235,17 @@ const Dashboard = () => {
   const sendToSora = () => {
     const win = window.open('https://sora.chatgpt.com', '_blank');
     if (!win) return;
-    setTimeout(() => {
-      win.postMessage(
-        { type: 'INSERT_SORA_JSON', json: JSON.parse(jsonString) },
-        '*',
-      );
-    }, 1000);
+    const payload = { type: 'INSERT_SORA_JSON', json: JSON.parse(jsonString) };
+    const interval = setInterval(() => {
+      win.postMessage(payload, '*');
+    }, 250);
+    const handler = (event: MessageEvent) => {
+      if (event.source === win && event.data?.type === 'INSERT_SORA_JSON_ACK') {
+        clearInterval(interval);
+        window.removeEventListener('message', handler);
+      }
+    };
+    window.addEventListener('message', handler);
     trackEvent(trackingEnabled, 'send_to_sora');
   };
 

--- a/src/hooks/__tests__/use-sora-userscript.test.ts
+++ b/src/hooks/__tests__/use-sora-userscript.test.ts
@@ -23,24 +23,29 @@ describe('useSoraUserscript', () => {
   });
 
   test('updates state on message event', () => {
+    const postSpy = jest.spyOn(window, 'postMessage');
     const { result } = renderHook(() => useSoraUserscript());
     act(() => {
       window.dispatchEvent(
         new MessageEvent('message', {
           data: { type: 'SORA_USERSCRIPT_READY' },
+          source: window,
         }),
       );
     });
     expect(result.current[0]).toBe(true);
     expect(localStorage.getItem('soraUserscriptInstalled')).toBe('true');
+    expect(postSpy).toHaveBeenCalledWith({ type: 'SORA_USERSCRIPT_ACK' }, '*');
   });
 
   test('updates state via global callback', () => {
+    const postSpy = jest.spyOn(window, 'postMessage');
     const { result } = renderHook(() => useSoraUserscript());
     act(() => {
       window.soraUserscriptReady!();
     });
     expect(result.current[0]).toBe(true);
+    expect(postSpy).toHaveBeenCalledWith({ type: 'SORA_USERSCRIPT_ACK' }, '*');
   });
 
   test('falls back to cookie when localStorage fails', () => {

--- a/src/hooks/use-sora-userscript.ts
+++ b/src/hooks/use-sora-userscript.ts
@@ -35,7 +35,10 @@ export function useSoraUserscript() {
   }, [installed]);
 
   useEffect(() => {
-    window.soraUserscriptReady = () => setInstalled(true);
+    window.soraUserscriptReady = () => {
+      setInstalled(true);
+      window.postMessage({ type: 'SORA_USERSCRIPT_ACK' }, '*');
+    };
     return () => {
       delete window.soraUserscriptReady;
     };
@@ -45,6 +48,10 @@ export function useSoraUserscript() {
     const handler = (event: MessageEvent) => {
       if (event.data?.type === 'SORA_USERSCRIPT_READY') {
         setInstalled(true);
+        (event.source as Window | null)?.postMessage(
+          { type: 'SORA_USERSCRIPT_ACK' },
+          '*',
+        );
       }
     };
     window.addEventListener('message', handler);


### PR DESCRIPTION
## Summary
- implement continuous userscript ready messages and ack handshake
- stop sending once ack received
- send ack for JSON injection and retry sending until ack
- test the handshake via unit tests

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc9cd6d2c8325a9dd3e0caf56658c