### PR TITLE
feat: detect Sora site via hostname

### DIFF
--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -13,12 +13,13 @@
   const DEBUG = true;
   console.log(`[Sora Injector] Loaded v${VERSION}`);
 
-  const isCrafter = document.querySelector(
-    'meta[name="sora-json-prompt-crafter"]',
+  const isCrafter = Boolean(
+    document.querySelector('meta[name="sora-json-prompt-crafter"]'),
   );
-  const isSora = document.querySelector(
-    'meta[property="og:title"][content="Sora"]',
-  );
+  const isSora =
+    Boolean(
+      document.querySelector('meta[property="og:title"][content="Sora"]'),
+    ) || window.location.hostname === 'sora.chatgpt.com';
 
   if (!isCrafter && !isSora) {
     if (DEBUG) {


### PR DESCRIPTION
## Summary
- expand Sora site detection logic in `sora-userscript.user.js` to also check the
  page hostname

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685ff87a879c83258c8c757c64c6ef44