### PR TITLE
fix: improve textarea detection

### DIFF
--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -127,7 +127,9 @@
    */
   const waitForTextarea = (callback) => {
     const attempt = () => {
-      const ta = document.querySelector('textarea');
+      const ta = document.querySelector(
+        'textarea, [data-testid="prompt-textarea"], [contenteditable="true"][role="textbox"]',
+      );
       if (ta) {
         if (DEBUG) {
           console.debug('[Sora Injector] Textarea found');


### PR DESCRIPTION
## Summary
- make the user script search for common textarea variants when waiting for the Sora input field

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68601859ffd48325ae483590d77a19df