### PR TITLE
fix userscript run-at

### DIFF
--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -5,7 +5,7 @@
 // @description  Inject JSON prompt from external tab into Sora textarea
 // @match *://*/*
 // @grant        none
-// @run-at       document-end
+// @run-at       document-start
 // ==/UserScript==
 
 (() => {


### PR DESCRIPTION
## Summary
- run the Sora integration userscript at `document-start`

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686018d54af483258120d9151c3099f1