### PR TITLE
Fix Sora window message sending

### DIFF
--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JSON Prompt Crafter Integration Sora Integration
 // @namespace    supermarsx
-// @version      1.1
+// @version      1.2
 // @description  Inject JSON prompt from external tab into Sora textarea
 // @match *://*/*
 // @grant        none
@@ -9,7 +9,7 @@
 // ==/UserScript==
 
 (() => {
-  const VERSION = '1.1';
+  const VERSION = '1.2';
   const DEBUG = true;
   console.log(`[Sora Injector] Loaded v${VERSION}`);
   if (DEBUG) {
@@ -127,7 +127,7 @@
    */
   const waitForTextarea = (callback) => {
     const attempt = () => {
-      const ta = document.querySelector('textarea');
+      const ta = document.querySelector('#prompt-textarea, textarea');
       if (ta) {
         if (DEBUG) {
           console.debug('[Sora Injector] Textarea found');

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -256,7 +256,9 @@ const Dashboard = () => {
       };
       window.addEventListener('message', handler);
     };
-    win.addEventListener('load', start, { once: true });
+    // The load event doesn't reliably fire for cross-origin windows, so
+    // start sending the payload after a short delay instead.
+    setTimeout(start, 500);
     trackEvent(trackingEnabled, 'send_to_sora');
   };
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -25,4 +25,4 @@ export const DISABLE_STATS = disableStats === 'true' || disableStats === '1';
 const gtagDebug = getEnvVar('VITE_GTAG_DEBUG');
 export const GTAG_DEBUG = gtagDebug === 'true' || gtagDebug === '1';
 
-export const USERSCRIPT_VERSION = '1.0';
+export const USERSCRIPT_VERSION = '1.2';


### PR DESCRIPTION
## Summary
- start sending `INSERT_SORA_JSON` payloads without relying on the `load` event
- broaden textarea detection in the Sora userscript
- bump userscript version to 1.2

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860362893f08325b1566408a0baa890