### PR TITLE
fix: persist JSON prompt in Sora textarea

### DIFF
--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -9,7 +9,7 @@
 // ==/UserScript==
 
 (() => {
-  const VERSION = '1.2';
+  const VERSION = '1.3';
   const DEBUG = true;
   console.log(`[Sora Injector] Loaded v${VERSION}`);
   if (DEBUG) {
@@ -164,8 +164,22 @@
           );
         }
         waitForTextarea((ta) => {
-          ta.value = JSON.stringify(event.data.json, null, 2);
+          const jsonStr = JSON.stringify(event.data.json, null, 2);
+          ta.value = jsonStr;
           ta.dispatchEvent(new Event('input', { bubbles: true }));
+          const enforceOnFocus = () => {
+            if (ta.value.trim() === '') {
+              ta.value = jsonStr;
+              ta.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+          };
+          const cancelEnforce = () => {
+            ta.removeEventListener('focus', enforceOnFocus);
+            ta.removeEventListener('input', cancelEnforce);
+          };
+          ta.addEventListener('focus', enforceOnFocus);
+          ta.addEventListener('input', cancelEnforce);
+          setTimeout(cancelEnforce, 5000);
           if (DEBUG) {
             console.debug('[Sora Injector] Textarea filled');
           }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -25,4 +25,4 @@ export const DISABLE_STATS = disableStats === 'true' || disableStats === '1';
 const gtagDebug = getEnvVar('VITE_GTAG_DEBUG');
 export const GTAG_DEBUG = gtagDebug === 'true' || gtagDebug === '1';
 
-export const USERSCRIPT_VERSION = '1.2';
+export const USERSCRIPT_VERSION = '1.3';


### PR DESCRIPTION
## Summary
- persist the generated JSON prompt in the Sora textarea
- bump userscript version to `1.3`

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68603cf4b910832585a88ed223ed61fd