### PR TITLE
Hide Sora tools by default

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -181,7 +181,10 @@ export const ActionBar: React.FC<ActionBarProps> = ({
               </>
             )}
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={onToggleSoraTools} className="gap-2">
+          <DropdownMenuItem
+            onSelect={onToggleSoraTools}
+            className="gap-2 hidden"
+          >
             {soraToolsEnabled ? (
               <>
                 <EyeOff className="w-4 h-4" /> Hide Sora Integration

--- a/src/hooks/use-sora-tools.ts
+++ b/src/hooks/use-sora-tools.ts
@@ -8,10 +8,10 @@ export function useSoraTools() {
       try {
         return JSON.parse(stored);
       } catch {
-        return true;
+        return false;
       }
     }
-    return true;
+    return false;
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- hide Sora integration toggle in the `ActionBar`
- default `useSoraTools` to `false` so the features start disabled

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68604b92cf708325a93da4607461fd88