### PR TITLE
Add debug ping/pong tests

### DIFF
--- a/src/hooks/__tests__/use-sora-userscript.test.ts
+++ b/src/hooks/__tests__/use-sora-userscript.test.ts
@@ -39,4 +39,36 @@ describe('useSoraUserscript', () => {
     expect(result.current[1]).toBe('1.0');
     expect(postSpy).toHaveBeenCalledWith({ type: 'SORA_USERSCRIPT_ACK' }, '*');
   });
+
+  test('responds to debug ping with pong', () => {
+    const postSpy = jest.spyOn(window, 'postMessage');
+    renderHook(() => useSoraUserscript());
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type: 'SORA_DEBUG_PING' },
+          source: window,
+        }),
+      );
+    });
+
+    expect(postSpy).toHaveBeenCalledWith({ type: 'SORA_DEBUG_PONG' }, '*');
+  });
+
+  test('logs when debug pong received', () => {
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    renderHook(() => useSoraUserscript());
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type: 'SORA_DEBUG_PONG' },
+          source: window,
+        }),
+      );
+    });
+
+    expect(debugSpy).toHaveBeenCalledWith('[Sora Loader] Debug pong received');
+  });
 });


### PR DESCRIPTION
## Summary
- test SORA_DEBUG_PING/PONG interactions in `useSoraUserscript`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686109fd8e0c83258c014a775238a2d0