### PR TITLE
Add time_of_year option

### DIFF
--- a/src/components/sections/SettingsLocationSection.tsx
+++ b/src/components/sections/SettingsLocationSection.tsx
@@ -586,6 +586,27 @@ export const SettingsLocationSection: React.FC<
 
         <div className="flex items-center space-x-2">
           <Checkbox
+            id="use_time_of_year"
+            checked={options.use_time_of_year}
+            onCheckedChange={(checked) =>
+              updateOptions({ use_time_of_year: !!checked })
+            }
+          />
+          <Label htmlFor="use_time_of_year">Use Time of Year</Label>
+        </div>
+
+        <div>
+          <Label htmlFor="time_of_year">Time of Year</Label>
+          <Input
+            id="time_of_year"
+            value={options.time_of_year}
+            onChange={(e) => updateOptions({ time_of_year: e.target.value })}
+            disabled={!options.use_time_of_year}
+          />
+        </div>
+
+        <div className="flex items-center space-x-2">
+          <Checkbox
             id="use_atmosphere_mood"
             checked={options.use_atmosphere_mood}
             onCheckedChange={(checked) =>

--- a/src/components/sections/__tests__/SettingsLocationSection.test.tsx
+++ b/src/components/sections/__tests__/SettingsLocationSection.test.tsx
@@ -38,4 +38,27 @@ describe('SettingsLocationSection', () => {
     dropdown = within(envSection).getByRole('button');
     expect(dropdown.hasAttribute('disabled')).toBe(true);
   });
+
+  test('time_of_year input updates and disables correctly', () => {
+    const updateOptions = jest.fn();
+    const enabled = {
+      ...DEFAULT_OPTIONS,
+      use_settings_location: true,
+      use_time_of_year: true,
+      time_of_year: 'spring',
+    };
+    const { rerender } = render(
+      <SettingsLocationSection options={enabled} updateOptions={updateOptions} />,
+    );
+    const input = screen.getByLabelText(/^time of year$/i);
+    fireEvent.change(input, { target: { value: 'winter' } });
+    expect(updateOptions).toHaveBeenCalledWith({ time_of_year: 'winter' });
+
+    const disabled = { ...enabled, use_time_of_year: false };
+    rerender(
+      <SettingsLocationSection options={disabled} updateOptions={updateOptions} />,
+    );
+    const disabledInput = screen.getByLabelText(/^time of year$/i);
+    expect(disabledInput.hasAttribute('disabled')).toBe(true);
+  });
 });

--- a/src/lib/__tests__/generateJson.test.ts
+++ b/src/lib/__tests__/generateJson.test.ts
@@ -130,13 +130,27 @@ describe('generateJson', () => {
       season: 'summer',
       use_atmosphere_mood: true,
       atmosphere_mood: 'gloomy',
+      use_time_of_year: true,
+      time_of_year: 'holidays',
     };
     const obj = parse(generateJson(opts));
     expect(obj.environment).toBeUndefined();
     expect(obj.location).toBeUndefined();
+    expect(obj.time_of_year).toBeUndefined();
     expect(obj.season).toBeUndefined();
     expect(obj.atmosphere_mood).toBeUndefined();
     expect(obj.year).toBeUndefined();
+  });
+
+  test('includes time_of_year when enabled', () => {
+    const opts = {
+      ...DEFAULT_OPTIONS,
+      use_settings_location: true,
+      use_time_of_year: true,
+      time_of_year: 'spring festival',
+    };
+    const obj = parse(generateJson(opts));
+    expect(obj.time_of_year).toBe('spring festival');
   });
 
   test('handles sword type with dnd section enabled', () => {

--- a/src/lib/defaultOptions.ts
+++ b/src/lib/defaultOptions.ts
@@ -49,6 +49,7 @@ export const DEFAULT_OPTIONS: SoraOptions = {
   camera_type: 'default (auto/any camera)',
   use_settings_location: false,
   year: new Date().getFullYear(),
+  time_of_year: 'default (any time of year)',
   use_season: false,
   use_atmosphere_mood: false,
   use_subject_mood: false,

--- a/src/lib/generateJson.ts
+++ b/src/lib/generateJson.ts
@@ -134,6 +134,7 @@ export function generateJson(options: SoraOptions): string {
       'year',
       'environment',
       'location',
+      'time_of_year',
       'season',
       'atmosphere_mood',
     ]);
@@ -143,6 +144,7 @@ export function generateJson(options: SoraOptions): string {
   }
 
   removeIfDisabled(cleanOptions, options.use_season, ['season']);
+  removeIfDisabled(cleanOptions, options.use_time_of_year, ['time_of_year']);
   removeIfDisabled(cleanOptions, options.use_atmosphere_mood, [
     'atmosphere_mood',
   ]);

--- a/src/lib/optionFlagMap.ts
+++ b/src/lib/optionFlagMap.ts
@@ -14,6 +14,7 @@ export const OPTION_FLAG_MAP: Record<string, keyof SoraOptions> = {
   color_grade: 'use_color_grading',
   environment: 'use_environment',
   location: 'use_location',
+  time_of_year: 'use_time_of_year',
   year: 'use_settings_location',
   season: 'use_season',
   atmosphere_mood: 'use_atmosphere_mood',

--- a/src/lib/soraOptions.ts
+++ b/src/lib/soraOptions.ts
@@ -91,6 +91,7 @@ export interface SoraOptions {
   use_color_grading: boolean;
   use_environment: boolean;
   use_time_of_year: boolean;
+  time_of_year?: string;
   use_character_mood: boolean;
   character_mood?: string;
   use_sword_details: boolean;

--- a/src/lib/validateOptions.ts
+++ b/src/lib/validateOptions.ts
@@ -15,6 +15,7 @@ const extraShape = {
   makeup_style: z.string(),
   quality_booster: z.string(),
   black_and_white_preset: z.string(),
+  time_of_year: z.string(),
   location: z.string(),
   special_effects: z.array(z.string()),
   lut_preset: z.string(),


### PR DESCRIPTION
## Summary
- allow configuring `time_of_year` in Settings & Location
- support new `time_of_year` field in options and defaults
- generate JSON with `time_of_year` when enabled
- ensure option flag mapping and validation include new field
- test component behaviour and generation logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68610a3b186c8325b3e1a6d22bdb1773