### PR TITLE
Load disclaimer from cache

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -5,6 +5,7 @@ const staticAssets = [
   '/favicon.ico',
   '/favicon.png',
   '/favicon.svg',
+  '/disclaimer.txt',
   '/web-app-manifest-192x192.png',
   '/web-app-manifest-512x512.png',
   '/site.webmanifest',

--- a/src/components/__tests__/DisclaimerModal.test.tsx
+++ b/src/components/__tests__/DisclaimerModal.test.tsx
@@ -117,6 +117,28 @@ describe('DisclaimerModal', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  test('loads disclaimer from cache when offline', async () => {
+    const matchMock = jest.fn().mockResolvedValue({
+      text: () => Promise.resolve('cache text'),
+    } as Response);
+    (global as unknown as { caches: CacheStorage }).caches = {
+      match: matchMock,
+    } as unknown as CacheStorage;
+
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValue(new Error('network unavailable'));
+    global.fetch = fetchMock;
+
+    render(<DisclaimerModal open={true} onOpenChange={() => {}} />);
+
+    expect(await screen.findByText('cache text')).toBeDefined();
+    expect(matchMock).toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    delete (global as unknown as { caches?: CacheStorage }).caches;
+  });
+
   test('no state update after unmount', async () => {
     let aborted = false;
     global.fetch = jest.fn().mockImplementation((_url, init) => {


### PR DESCRIPTION
## Summary
- cache `/disclaimer.txt` in the service worker
- try cached response before network in DisclaimerModal
- test modal offline capability using Cache API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861139462ec8325a2e91de0082baee3