### PR TITLE
fix: improve service worker update flow

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,20 +1,30 @@
-const cacheName = 'sora-prompt-cache-v1';
+const cacheName = 'sora-prompt-cache-v2';
 const staticAssets = [
   '/',
   '/index.html',
   '/favicon.ico',
   '/favicon.png',
   '/favicon.svg',
+  '/favicon-96x96.png',
+  '/apple-touch-icon.png',
   '/disclaimer.txt',
+  '/placeholder.svg',
   '/web-app-manifest-192x192.png',
   '/web-app-manifest-512x512.png',
   '/site.webmanifest',
+  '/robots.txt',
+  '/sora-userscript.user.js',
 ];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(cacheName).then((cache) => cache.addAll(staticAssets)),
   );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(clients.claim());
 });
 
 self.addEventListener('fetch', (event) => {


### PR DESCRIPTION
## Summary
- keep service worker update flow snappy by calling `skipWaiting` and `clients.claim`
- bump the cache name and include more static assets

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm run preview` (smoke test)

------
https://chatgpt.com/codex/tasks/task_e_68611ec999048325a291c8e1626db2fd