### PR TITLE
Add jest-axe dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
     "jest": "^30.0.2",
+    "jest-axe": "^10.0.0",
     "jest-environment-jsdom": "^30.0.2",
     "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",

--- a/src/components/sections/__tests__/CameraCompositionSection.test.tsx
+++ b/src/components/sections/__tests__/CameraCompositionSection.test.tsx
@@ -47,7 +47,8 @@ describe('CameraCompositionSection', () => {
         onToggle={() => {}}
       />,
     );
-    let lensSection = screen.getByText('Lens Type').parentElement as HTMLElement;
+    let lensSection = screen.getByText('Lens Type')
+      .parentElement as HTMLElement;
     let dropdown = within(lensSection).getByRole('button');
     fireEvent.click(dropdown);
     fireEvent.click(screen.getByRole('button', { name: /wide 24mm/i }));

--- a/src/components/sections/__tests__/EnhancementsSection.test.tsx
+++ b/src/components/sections/__tests__/EnhancementsSection.test.tsx
@@ -29,7 +29,11 @@ describe('EnhancementsSection', () => {
 
   test('safety filter dropdown updates value and disabled when flag off', () => {
     const updateOptions = jest.fn();
-    const enabledOptions = { ...DEFAULT_OPTIONS, use_safety_filter: true, safety_filter: 'moderate' };
+    const enabledOptions = {
+      ...DEFAULT_OPTIONS,
+      use_safety_filter: true,
+      safety_filter: 'moderate',
+    };
     const { rerender } = render(
       <EnhancementsSection
         options={enabledOptions}
@@ -38,7 +42,8 @@ describe('EnhancementsSection', () => {
         onToggle={() => {}}
       />,
     );
-    let section = screen.getByText('Safety Filter').parentElement as HTMLElement;
+    let section = screen.getByText('Safety Filter')
+      .parentElement as HTMLElement;
     let dropdown = within(section).getByRole('button');
     fireEvent.click(dropdown);
     fireEvent.click(screen.getByRole('button', { name: /^strict/i }));

--- a/src/components/sections/__tests__/FaceSection.test.tsx
+++ b/src/components/sections/__tests__/FaceSection.test.tsx
@@ -14,7 +14,11 @@ beforeAll(() => {
 describe('FaceSection', () => {
   test('checkbox toggle updates option', () => {
     const updateOptions = jest.fn();
-    const options = { ...DEFAULT_OPTIONS, use_face_enhancements: true, use_subject_gender: false };
+    const options = {
+      ...DEFAULT_OPTIONS,
+      use_face_enhancements: true,
+      use_subject_gender: false,
+    };
     render(<FaceSection options={options} updateOptions={updateOptions} />);
     fireEvent.click(screen.getByLabelText(/use subject gender/i));
     expect(updateOptions).toHaveBeenCalledWith({ use_subject_gender: true });
@@ -22,16 +26,26 @@ describe('FaceSection', () => {
 
   test('subject gender dropdown updates value and disabled when flag off', () => {
     const updateOptions = jest.fn();
-    const enabledOptions = { ...DEFAULT_OPTIONS, use_face_enhancements: true, use_subject_gender: true, subject_gender: 'default (auto/inferred gender)' };
-    const { rerender } = render(<FaceSection options={enabledOptions} updateOptions={updateOptions} />);
-    let section = screen.getByText('Subject Gender').parentElement as HTMLElement;
+    const enabledOptions = {
+      ...DEFAULT_OPTIONS,
+      use_face_enhancements: true,
+      use_subject_gender: true,
+      subject_gender: 'default (auto/inferred gender)',
+    };
+    const { rerender } = render(
+      <FaceSection options={enabledOptions} updateOptions={updateOptions} />,
+    );
+    let section = screen.getByText('Subject Gender')
+      .parentElement as HTMLElement;
     let dropdown = within(section).getByRole('button');
     fireEvent.click(dropdown);
     fireEvent.click(screen.getByRole('button', { name: /^female$/i }));
     expect(updateOptions).toHaveBeenCalledWith({ subject_gender: 'female' });
 
     const disabledOptions = { ...enabledOptions, use_subject_gender: false };
-    rerender(<FaceSection options={disabledOptions} updateOptions={updateOptions} />);
+    rerender(
+      <FaceSection options={disabledOptions} updateOptions={updateOptions} />,
+    );
     section = screen.getByText('Subject Gender').parentElement as HTMLElement;
     dropdown = within(section).getByRole('button');
     expect(dropdown.hasAttribute('disabled')).toBe(true);

--- a/src/components/sections/__tests__/MaterialSection.test.tsx
+++ b/src/components/sections/__tests__/MaterialSection.test.tsx
@@ -14,26 +14,49 @@ beforeAll(() => {
 describe('MaterialSection', () => {
   test('checkbox toggle updates option', () => {
     const updateOptions = jest.fn();
-    const options = { ...DEFAULT_OPTIONS, use_material: true, use_secondary_material: false };
+    const options = {
+      ...DEFAULT_OPTIONS,
+      use_material: true,
+      use_secondary_material: false,
+    };
     render(<MaterialSection options={options} updateOptions={updateOptions} />);
     fireEvent.click(screen.getByLabelText(/use secondary material/i));
-    expect(updateOptions).toHaveBeenCalledWith({ use_secondary_material: true });
+    expect(updateOptions).toHaveBeenCalledWith({
+      use_secondary_material: true,
+    });
   });
 
   test('secondary material dropdown updates value and disabled when flag off', () => {
     const updateOptions = jest.fn();
-    const enabledOptions = { ...DEFAULT_OPTIONS, use_material: true, use_secondary_material: true, secondary_material: 'default' };
+    const enabledOptions = {
+      ...DEFAULT_OPTIONS,
+      use_material: true,
+      use_secondary_material: true,
+      secondary_material: 'default',
+    };
     const { rerender } = render(
-      <MaterialSection options={enabledOptions} updateOptions={updateOptions} />,
+      <MaterialSection
+        options={enabledOptions}
+        updateOptions={updateOptions}
+      />,
     );
-    const section = screen.getByText('Secondary Material').parentElement as HTMLElement;
+    const section = screen.getByText('Secondary Material')
+      .parentElement as HTMLElement;
     let dropdown = within(section).getByRole('button');
     fireEvent.click(dropdown);
     fireEvent.click(screen.getByRole('button', { name: /^wood$/i }));
     expect(updateOptions).toHaveBeenCalledWith({ secondary_material: 'wood' });
 
-    const disabledOptions = { ...enabledOptions, use_secondary_material: false };
-    rerender(<MaterialSection options={disabledOptions} updateOptions={updateOptions} />);
+    const disabledOptions = {
+      ...enabledOptions,
+      use_secondary_material: false,
+    };
+    rerender(
+      <MaterialSection
+        options={disabledOptions}
+        updateOptions={updateOptions}
+      />,
+    );
     dropdown = within(section).getByRole('button');
     expect(dropdown.hasAttribute('disabled')).toBe(true);
   });

--- a/src/components/sections/__tests__/SettingsLocationSection.test.tsx
+++ b/src/components/sections/__tests__/SettingsLocationSection.test.tsx
@@ -14,26 +14,49 @@ beforeAll(() => {
 describe('SettingsLocationSection', () => {
   test('checkbox toggle updates option', () => {
     const updateOptions = jest.fn();
-    const options = { ...DEFAULT_OPTIONS, use_settings_location: true, use_environment: false };
-    render(<SettingsLocationSection options={options} updateOptions={updateOptions} />);
+    const options = {
+      ...DEFAULT_OPTIONS,
+      use_settings_location: true,
+      use_environment: false,
+    };
+    render(
+      <SettingsLocationSection
+        options={options}
+        updateOptions={updateOptions}
+      />,
+    );
     fireEvent.click(screen.getByLabelText(/use environment/i));
     expect(updateOptions).toHaveBeenCalledWith({ use_environment: true });
   });
 
   test('environment dropdown disabled when flag false and updates when enabled', () => {
     const updateOptions = jest.fn();
-    const enabledOptions = { ...DEFAULT_OPTIONS, use_settings_location: true, use_environment: true, environment: 'default' };
+    const enabledOptions = {
+      ...DEFAULT_OPTIONS,
+      use_settings_location: true,
+      use_environment: true,
+      environment: 'default',
+    };
     const { rerender } = render(
-      <SettingsLocationSection options={enabledOptions} updateOptions={updateOptions} />,
+      <SettingsLocationSection
+        options={enabledOptions}
+        updateOptions={updateOptions}
+      />,
     );
-    let envSection = screen.getByText('Environment').parentElement as HTMLElement;
+    let envSection = screen.getByText('Environment')
+      .parentElement as HTMLElement;
     let dropdown = within(envSection).getByRole('button');
     fireEvent.click(dropdown);
     fireEvent.click(screen.getByRole('button', { name: /^forest$/i }));
     expect(updateOptions).toHaveBeenCalledWith({ environment: 'forest' });
 
     const disabledOptions = { ...enabledOptions, use_environment: false };
-    rerender(<SettingsLocationSection options={disabledOptions} updateOptions={updateOptions} />);
+    rerender(
+      <SettingsLocationSection
+        options={disabledOptions}
+        updateOptions={updateOptions}
+      />,
+    );
     envSection = screen.getByText('Environment').parentElement as HTMLElement;
     dropdown = within(envSection).getByRole('button');
     expect(dropdown.hasAttribute('disabled')).toBe(true);
@@ -48,7 +71,10 @@ describe('SettingsLocationSection', () => {
       time_of_year: 'spring',
     };
     const { rerender } = render(
-      <SettingsLocationSection options={enabled} updateOptions={updateOptions} />,
+      <SettingsLocationSection
+        options={enabled}
+        updateOptions={updateOptions}
+      />,
     );
     const input = screen.getByLabelText(/^time of year$/i);
     fireEvent.change(input, { target: { value: 'winter' } });
@@ -56,7 +82,10 @@ describe('SettingsLocationSection', () => {
 
     const disabled = { ...enabled, use_time_of_year: false };
     rerender(
-      <SettingsLocationSection options={disabled} updateOptions={updateOptions} />,
+      <SettingsLocationSection
+        options={disabled}
+        updateOptions={updateOptions}
+      />,
     );
     const disabledInput = screen.getByLabelText(/^time of year$/i);
     expect(disabledInput.hasAttribute('disabled')).toBe(true);

--- a/src/components/sections/__tests__/StyleSection.test.tsx
+++ b/src/components/sections/__tests__/StyleSection.test.tsx
@@ -26,6 +26,9 @@ describe('StyleSection', () => {
     const comboboxes = screen.getAllByRole('combobox');
     fireEvent.click(comboboxes[1]);
     fireEvent.click(screen.getByRole('option', { name: /film still/i }));
-    expect(updateNestedOptions).toHaveBeenCalledWith('style_preset.style', 'film still');
+    expect(updateNestedOptions).toHaveBeenCalledWith(
+      'style_preset.style',
+      'film still',
+    );
   });
 });

--- a/src/components/sections/__tests__/VideoMotionSection.test.tsx
+++ b/src/components/sections/__tests__/VideoMotionSection.test.tsx
@@ -27,7 +27,9 @@ describe('VideoMotionSection', () => {
     fireEvent.click(checkbox);
     expect(updateOptions).toHaveBeenCalledWith({ use_duration: true });
 
-    const input = screen.getByLabelText(/duration \(seconds\)/i) as HTMLInputElement;
+    const input = screen.getByLabelText(
+      /duration \(seconds\)/i,
+    ) as HTMLInputElement;
     expect(input.hasAttribute('disabled')).toBe(true);
 
     const enabledOptions = { ...options, use_duration: true };


### PR DESCRIPTION
## Summary
- fix failing accessibility test by adding `jest-axe`
- run formatter which updated some test files

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686144597edc83258d2149e9b07e98c0