### PR TITLE
Add flag tests for loadOptionsFromJson

### DIFF
--- a/src/lib/__tests__/loadOptionsFromJson.test.ts
+++ b/src/lib/__tests__/loadOptionsFromJson.test.ts
@@ -1,4 +1,5 @@
 import { loadOptionsFromJson } from '../loadOptionsFromJson';
+import { OPTION_FLAG_MAP } from '../optionFlagMap';
 
 describe('loadOptionsFromJson', () => {
   test('returns merged options and enables flags for valid JSON', () => {
@@ -22,5 +23,30 @@ describe('loadOptionsFromJson', () => {
     const json = JSON.stringify({ composition_rules: ['rule_of_thirds'] });
     const result = loadOptionsFromJson(json);
     expect(result!.composition_rules).toEqual(['rule of thirds']);
+  });
+
+  test('sets lighting flag when lighting provided', () => {
+    const json = JSON.stringify({ lighting: 'studio' });
+    const result = loadOptionsFromJson(json)!;
+    const flag = OPTION_FLAG_MAP.lighting;
+    expect(result[flag as keyof typeof result]).toBe(true);
+    expect(result.lighting).toBe('studio');
+  });
+
+  test('sets secondary material flag when secondary_material provided', () => {
+    const json = JSON.stringify({ secondary_material: 'metal' });
+    const result = loadOptionsFromJson(json)!;
+    const flag = OPTION_FLAG_MAP.secondary_material;
+    expect(result[flag as keyof typeof result]).toBe(true);
+    expect(result.secondary_material).toBe('metal');
+  });
+
+  test('sets dnd flags when dnd field provided', () => {
+    const json = JSON.stringify({ dnd_character_race: 'elf' });
+    const result = loadOptionsFromJson(json)!;
+    const flag = OPTION_FLAG_MAP.dnd_character_race;
+    expect(result[flag as keyof typeof result]).toBe(true);
+    expect(result.use_dnd_section).toBe(true);
+    expect(result.dnd_character_race).toBe('elf');
   });
 });


### PR DESCRIPTION
## Summary
- cover more fields in `loadOptionsFromJson` tests
- verify lighting, secondary_material, and dnd flags set according to `OPTION_FLAG_MAP`

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68614a70ac1483259f245840c79e0d2f