### PR TITLE
Add useLocale hook test

### DIFF
--- a/src/hooks/__tests__/use-locale.test.ts
+++ b/src/hooks/__tests__/use-locale.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react';
 import { useLocale } from '../use-locale';
 import i18n from '@/i18n';
-import { safeGet, safeSet } from '@/lib/storage';
+import * as storage from '@/lib/storage';
 
 jest.mock('@/i18n', () => ({
   __esModule: true,
@@ -16,20 +16,18 @@ jest.mock('@/lib/storage', () => ({
 
 describe('useLocale', () => {
   beforeEach(() => {
-    (i18n.changeLanguage as jest.Mock).mockClear();
-    (safeGet as jest.Mock).mockReset();
-    (safeSet as jest.Mock).mockClear();
+    jest.clearAllMocks();
   });
 
   test('initializes state from localStorage', () => {
-    (safeGet as jest.Mock).mockReturnValue('es');
+    (storage.safeGet as jest.Mock).mockReturnValue('es');
     const { result } = renderHook(() => useLocale());
     expect(result.current[0]).toBe('es');
-    expect(safeGet).toHaveBeenCalledWith('locale');
+    expect(storage.safeGet).toHaveBeenCalledWith('locale');
   });
 
   test('updates locale and persists value', () => {
-    (safeGet as jest.Mock).mockReturnValue('en');
+    (storage.safeGet as jest.Mock).mockReturnValue('en');
     const { result } = renderHook(() => useLocale());
 
     act(() => {
@@ -37,7 +35,7 @@ describe('useLocale', () => {
     });
 
     expect(i18n.changeLanguage).toHaveBeenLastCalledWith('fr');
-    expect(safeSet).toHaveBeenLastCalledWith('locale', 'fr');
+    expect(storage.safeSet).toHaveBeenLastCalledWith('locale', 'fr');
     expect(result.current[0]).toBe('fr');
   });
 });


### PR DESCRIPTION
## Summary
- add unit tests for useLocale to ensure persistence and language change

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68615b895c3883258c05dbe85338a596