### PR TITLE
Add language menu and action label toggle

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -4,6 +4,7 @@ import { useLocale } from '@/hooks/use-locale';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/sonner-toast';
 import { trackEvent } from '@/lib/analytics';
+import { cn } from '@/lib/utils';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -58,6 +59,8 @@ interface ActionBarProps {
   onToggleHeaderButtons: () => void;
   logoEnabled: boolean;
   onToggleLogo: () => void;
+  actionLabelsEnabled: boolean;
+  onToggleActionLabels: () => void;
   copied: boolean;
   showJumpToJson?: boolean;
   onJumpToJson?: () => void;
@@ -82,6 +85,8 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   onToggleHeaderButtons,
   logoEnabled,
   onToggleLogo,
+  actionLabelsEnabled,
+  onToggleActionLabels,
   copied,
   showJumpToJson,
   onJumpToJson,
@@ -119,15 +124,20 @@ export const ActionBar: React.FC<ActionBarProps> = ({
           onClick={onSendToSora}
           variant="outline"
           size="sm"
-          className="gap-2"
+          className={cn({ 'gap-2': actionLabelsEnabled })}
         >
           <Send className="w-4 h-4" />
-          {t('sendToSora')}
+          {actionLabelsEnabled && t('sendToSora')}
         </Button>
       )}
-      <Button onClick={onCopy} variant="outline" size="sm" className="gap-2">
+      <Button
+        onClick={onCopy}
+        variant="outline"
+        size="sm"
+        className={cn({ 'gap-2': actionLabelsEnabled })}
+      >
         {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-        {t('copy')}
+        {actionLabelsEnabled && t('copy')}
       </Button>
       <Button
         onClick={() => {
@@ -137,19 +147,28 @@ export const ActionBar: React.FC<ActionBarProps> = ({
         }}
         variant="outline"
         size="sm"
-        className="gap-2"
+        className={cn({ 'gap-2': actionLabelsEnabled })}
       >
         <Trash2 className={`w-4 h-4 ${clearing ? 'animate-spin' : ''}`} />
-        {t('clear')}
+        {actionLabelsEnabled && t('clear')}
       </Button>
-      <Button onClick={onShare} variant="outline" size="sm" className="gap-2">
+      <Button
+        onClick={onShare}
+        variant="outline"
+        size="sm"
+        className={cn({ 'gap-2': actionLabelsEnabled })}
+      >
         <Share className="w-4 h-4" />
-        {t('share')}
+        {actionLabelsEnabled && t('share')}
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="sm" className="gap-2">
-            <Cog className="w-4 h-4" /> {t('manage')}
+          <Button
+            variant="outline"
+            size="sm"
+            className={cn({ 'gap-2': actionLabelsEnabled })}
+          >
+            <Cog className="w-4 h-4" /> {actionLabelsEnabled && t('manage')}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
@@ -237,6 +256,38 @@ export const ActionBar: React.FC<ActionBarProps> = ({
               </>
             )}
           </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => {
+              onToggleActionLabels();
+              trackEvent(trackingEnabled, 'toggle_action_labels', {
+                enabled: !actionLabelsEnabled,
+              });
+            }}
+            className="gap-2"
+          >
+            {actionLabelsEnabled ? (
+              <>
+                <EyeOff className="w-4 h-4" /> {t('hideLabels')}
+              </>
+            ) : (
+              <>
+                <Eye className="w-4 h-4" /> {t('showLabels')}
+              </>
+            )}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className={cn({ 'gap-2': actionLabelsEnabled })}
+          >
+            {t('language')}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
           <DropdownMenuItem onSelect={() => setLocale('en')}>
             English
           </DropdownMenuItem>
@@ -245,9 +296,14 @@ export const ActionBar: React.FC<ActionBarProps> = ({
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <Button onClick={onHistory} variant="outline" size="sm" className="gap-2">
+      <Button
+        onClick={onHistory}
+        variant="outline"
+        size="sm"
+        className={cn({ 'gap-2': actionLabelsEnabled })}
+      >
         <History className="w-4 h-4" />
-        {t('history')}
+        {actionLabelsEnabled && t('history')}
       </Button>
       {showJumpToJson && (
         <Button
@@ -257,10 +313,10 @@ export const ActionBar: React.FC<ActionBarProps> = ({
           }}
           variant="outline"
           size="sm"
-          className="gap-2"
+          className={cn({ 'gap-2': actionLabelsEnabled })}
         >
           <MoveDown className="w-4 h-4" />
-          {t('jumpToJson')}
+          {actionLabelsEnabled && t('jumpToJson')}
         </Button>
       )}
       <Button

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -28,6 +28,7 @@ import { useTracking } from '@/hooks/use-tracking';
 import { useSoraTools } from '@/hooks/use-sora-tools';
 import { useHeaderButtons } from '@/hooks/use-header-buttons';
 import { useLogo } from '@/hooks/use-logo';
+import { useActionLabels } from '@/hooks/use-action-labels';
 import { useSoraUserscript } from '@/hooks/use-sora-userscript';
 import { useActionHistory } from '@/hooks/use-action-history';
 import { trackEvent } from '@/lib/analytics';
@@ -81,6 +82,7 @@ const Dashboard = () => {
   const [soraToolsEnabled, setSoraToolsEnabled] = useSoraTools();
   const [headerButtonsEnabled, setHeaderButtonsEnabled] = useHeaderButtons();
   const [logoEnabled, setLogoEnabled] = useLogo();
+  const [actionLabelsEnabled, setActionLabelsEnabled] = useActionLabels();
   const [userscriptInstalled, userscriptVersion] = useSoraUserscript();
   const actionHistory = useActionHistory();
   const [githubStats, setGithubStats] = useState<{
@@ -697,6 +699,10 @@ const Dashboard = () => {
         }
         logoEnabled={logoEnabled}
         onToggleLogo={() => setLogoEnabled(!logoEnabled)}
+        actionLabelsEnabled={actionLabelsEnabled}
+        onToggleActionLabels={() =>
+          setActionLabelsEnabled(!actionLabelsEnabled)
+        }
         copied={copied}
         showJumpToJson={isSingleColumn}
         onJumpToJson={scrollToJson}

--- a/src/components/__tests__/ActionBar.test.tsx
+++ b/src/components/__tests__/ActionBar.test.tsx
@@ -97,6 +97,8 @@ function createProps(
     onToggleHeaderButtons: jest.fn(),
     logoEnabled: true,
     onToggleLogo: jest.fn(),
+    actionLabelsEnabled: true,
+    onToggleActionLabels: jest.fn(),
     copied: false,
     trackingEnabled: true,
     ...overrides,

--- a/src/hooks/__tests__/use-action-labels.test.ts
+++ b/src/hooks/__tests__/use-action-labels.test.ts
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react';
+import { useActionLabels } from '../use-action-labels';
+
+describe('useActionLabels', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  test('initializes state from localStorage', () => {
+    const getSpy = jest.spyOn(Storage.prototype, 'getItem');
+    localStorage.setItem('actionLabelsEnabled', 'false');
+    const { result } = renderHook(() => useActionLabels());
+    expect(result.current[0]).toBe(false);
+    expect(getSpy).toHaveBeenCalledWith('actionLabelsEnabled');
+  });
+
+  test('persists state changes to localStorage', () => {
+    const setSpy = jest.spyOn(Storage.prototype, 'setItem');
+    const { result } = renderHook(() => useActionLabels());
+
+    act(() => {
+      result.current[1](false);
+    });
+
+    expect(localStorage.getItem('actionLabelsEnabled')).toBe('false');
+    expect(setSpy).toHaveBeenCalledWith('actionLabelsEnabled', 'false');
+  });
+});

--- a/src/hooks/use-action-labels.ts
+++ b/src/hooks/use-action-labels.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { safeGet, safeSet } from '@/lib/storage';
+
+export function useActionLabels() {
+  const [enabled, setEnabled] = useState(() => {
+    const stored = safeGet('actionLabelsEnabled');
+    if (stored !== null) {
+      try {
+        return JSON.parse(stored);
+      } catch {
+        return true;
+      }
+    }
+    return true;
+  });
+
+  useEffect(() => {
+    safeSet('actionLabelsEnabled', JSON.stringify(enabled));
+  }, [enabled]);
+
+  return [enabled, setEnabled] as const;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -34,5 +34,8 @@
   "prompt": "Prompt",
   "promptPlaceholder": "Describe what you want to generate...",
   "negativePrompt": "Negative Prompt",
-  "negativePromptPlaceholder": "Describe what you want to avoid..."
+  "negativePromptPlaceholder": "Describe what you want to avoid...",
+  "showLabels": "Show Labels",
+  "hideLabels": "Hide Labels",
+  "language": "Language"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -34,5 +34,8 @@
   "prompt": "Prompt",
   "promptPlaceholder": "Describe lo que quieres generar...",
   "negativePrompt": "Prompt Negativo",
-  "negativePromptPlaceholder": "Describe lo que quieres evitar..."
+  "negativePromptPlaceholder": "Describe lo que quieres evitar...",
+  "showLabels": "Mostrar Etiquetas",
+  "hideLabels": "Ocultar Etiquetas",
+  "language": "Idioma"
 }


### PR DESCRIPTION
## Summary
- add `useActionLabels` hook to persist the new setting
- move language selection to its own dropdown
- allow toggling action button labels in settings
- update translations
- test coverage for the new hook

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a6658c1c08325a656bc52a19b14f8