### PR TITLE
Add useLocalStorageState hook

### DIFF
--- a/src/hooks/__tests__/use-locale.test.ts
+++ b/src/hooks/__tests__/use-locale.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from '@testing-library/react';
 import { useLocale } from '../use-locale';
 import i18n from '@/i18n';
 import * as storage from '@/lib/storage';
+import { LOCALE } from '@/lib/storage-keys';
 
 jest.mock('@/i18n', () => ({
   __esModule: true,
@@ -23,7 +24,7 @@ describe('useLocale', () => {
     (storage.safeGet as jest.Mock).mockReturnValue('es');
     const { result } = renderHook(() => useLocale());
     expect(result.current[0]).toBe('es');
-    expect(storage.safeGet).toHaveBeenCalledWith('locale');
+    expect(storage.safeGet).toHaveBeenCalledWith(LOCALE, 'en', false);
   });
 
   test('updates locale and persists value', () => {
@@ -35,7 +36,7 @@ describe('useLocale', () => {
     });
 
     expect(i18n.changeLanguage).toHaveBeenLastCalledWith('fr');
-    expect(storage.safeSet).toHaveBeenLastCalledWith('locale', 'fr');
+    expect(storage.safeSet).toHaveBeenLastCalledWith(LOCALE, 'fr');
     expect(result.current[0]).toBe('fr');
   });
 });

--- a/src/hooks/use-action-labels.ts
+++ b/src/hooks/use-action-labels.ts
@@ -1,22 +1,6 @@
-import { useEffect, useState } from 'react';
-import { safeGet, safeSet } from '@/lib/storage';
+import { useLocalStorageState } from './use-local-storage-state';
+import { ACTION_LABELS_ENABLED } from '@/lib/storage-keys';
 
 export function useActionLabels() {
-  const [enabled, setEnabled] = useState(() => {
-    const stored = safeGet('actionLabelsEnabled');
-    if (stored !== null) {
-      try {
-        return JSON.parse(stored);
-      } catch {
-        return true;
-      }
-    }
-    return true;
-  });
-
-  useEffect(() => {
-    safeSet('actionLabelsEnabled', JSON.stringify(enabled));
-  }, [enabled]);
-
-  return [enabled, setEnabled] as const;
+  return useLocalStorageState(ACTION_LABELS_ENABLED, true);
 }

--- a/src/hooks/use-dark-mode.ts
+++ b/src/hooks/use-dark-mode.ts
@@ -1,24 +1,14 @@
-import { useEffect, useState } from 'react';
-import { safeGet, safeSet } from '@/lib/storage';
+import { useEffect } from 'react';
+import { useLocalStorageState } from './use-local-storage-state';
+import { DARK_MODE } from '@/lib/storage-keys';
 
 export function useDarkMode() {
-  const [isDark, setIsDark] = useState(() => {
-    const stored = safeGet('darkMode');
-    if (stored !== null) {
-      try {
-        return JSON.parse(stored);
-      } catch {
-        return true;
-      }
-    }
-    return true;
-  });
+  const [isDark, setIsDark] = useLocalStorageState(DARK_MODE, true);
 
   useEffect(() => {
     const root = document.documentElement;
     if (isDark) root.classList.add('dark');
     else root.classList.remove('dark');
-    safeSet('darkMode', JSON.stringify(isDark));
   }, [isDark]);
 
   return [isDark, setIsDark] as const;

--- a/src/hooks/use-header-buttons.ts
+++ b/src/hooks/use-header-buttons.ts
@@ -1,22 +1,6 @@
-import { useEffect, useState } from 'react';
-import { safeGet, safeSet } from '@/lib/storage';
+import { useLocalStorageState } from './use-local-storage-state';
+import { HEADER_BUTTONS_ENABLED } from '@/lib/storage-keys';
 
 export function useHeaderButtons() {
-  const [enabled, setEnabled] = useState(() => {
-    const stored = safeGet('headerButtonsEnabled');
-    if (stored !== null) {
-      try {
-        return JSON.parse(stored);
-      } catch {
-        return true;
-      }
-    }
-    return true;
-  });
-
-  useEffect(() => {
-    safeSet('headerButtonsEnabled', JSON.stringify(enabled));
-  }, [enabled]);
-
-  return [enabled, setEnabled] as const;
+  return useLocalStorageState(HEADER_BUTTONS_ENABLED, true);
 }

--- a/src/hooks/use-local-storage-state.ts
+++ b/src/hooks/use-local-storage-state.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState, Dispatch, SetStateAction } from 'react';
+import { safeGet, safeSet } from '@/lib/storage';
+
+export function useLocalStorageState<T>(
+  key: string,
+  defaultValue: T,
+): [T, Dispatch<SetStateAction<T>>] {
+  const isString = typeof defaultValue === 'string';
+
+  const [state, setState] = useState<T>(() => {
+    const stored = safeGet<T>(key, defaultValue, !isString);
+    return (stored as T) ?? defaultValue;
+  });
+
+  useEffect(() => {
+    if (isString) {
+      safeSet(key, state as unknown as string);
+    } else {
+      safeSet(key, state, true);
+    }
+  }, [key, state, isString]);
+
+  return [state, setState];
+}

--- a/src/hooks/use-locale.ts
+++ b/src/hooks/use-locale.ts
@@ -1,13 +1,13 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import i18n from '@/i18n';
-import { safeGet, safeSet } from '@/lib/storage';
+import { useLocalStorageState } from './use-local-storage-state';
+import { LOCALE } from '@/lib/storage-keys';
 
 export function useLocale() {
-  const [locale, setLocale] = useState(() => safeGet('locale') || 'en');
+  const [locale, setLocale] = useLocalStorageState(LOCALE, 'en');
 
   useEffect(() => {
     i18n.changeLanguage(locale);
-    safeSet('locale', locale);
   }, [locale]);
 
   return [locale, setLocale] as const;

--- a/src/hooks/use-logo.ts
+++ b/src/hooks/use-logo.ts
@@ -1,22 +1,6 @@
-import { useEffect, useState } from 'react';
-import { safeGet, safeSet } from '@/lib/storage';
+import { useLocalStorageState } from './use-local-storage-state';
+import { LOGO_ENABLED } from '@/lib/storage-keys';
 
 export function useLogo() {
-  const [enabled, setEnabled] = useState(() => {
-    const stored = safeGet('logoEnabled');
-    if (stored !== null) {
-      try {
-        return JSON.parse(stored);
-      } catch {
-        return true;
-      }
-    }
-    return true;
-  });
-
-  useEffect(() => {
-    safeSet('logoEnabled', JSON.stringify(enabled));
-  }, [enabled]);
-
-  return [enabled, setEnabled] as const;
+  return useLocalStorageState(LOGO_ENABLED, true);
 }

--- a/src/hooks/use-sora-tools.ts
+++ b/src/hooks/use-sora-tools.ts
@@ -1,22 +1,6 @@
-import { useEffect, useState } from 'react';
-import { safeGet, safeSet } from '@/lib/storage';
+import { useLocalStorageState } from './use-local-storage-state';
+import { SORA_TOOLS_ENABLED } from '@/lib/storage-keys';
 
 export function useSoraTools() {
-  const [enabled, setEnabled] = useState(() => {
-    const stored = safeGet('soraToolsEnabled');
-    if (stored !== null) {
-      try {
-        return JSON.parse(stored);
-      } catch {
-        return false;
-      }
-    }
-    return false;
-  });
-
-  useEffect(() => {
-    safeSet('soraToolsEnabled', JSON.stringify(enabled));
-  }, [enabled]);
-
-  return [enabled, setEnabled] as const;
+  return useLocalStorageState(SORA_TOOLS_ENABLED, false);
 }

--- a/src/hooks/use-tracking.ts
+++ b/src/hooks/use-tracking.ts
@@ -1,24 +1,10 @@
-import { useEffect, useState } from 'react';
-import { safeGet, safeSet } from '@/lib/storage';
 import { DISABLE_ANALYTICS } from '@/lib/config';
+import { useLocalStorageState } from './use-local-storage-state';
+import { TRACKING_ENABLED } from '@/lib/storage-keys';
 
 export function useTracking() {
-  const [enabled, setEnabled] = useState(() => {
-    if (DISABLE_ANALYTICS) return false;
-    const stored = safeGet('trackingEnabled');
-    if (stored !== null) {
-      try {
-        return JSON.parse(stored);
-      } catch {
-        return true;
-      }
-    }
-    return true;
-  });
-
-  useEffect(() => {
-    safeSet('trackingEnabled', JSON.stringify(enabled));
-  }, [enabled]);
-
-  return [enabled, setEnabled] as const;
+  return useLocalStorageState(
+    TRACKING_ENABLED,
+    DISABLE_ANALYTICS ? false : true,
+  );
 }

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -1,0 +1,7 @@
+export const DARK_MODE = 'darkMode';
+export const SORA_TOOLS_ENABLED = 'soraToolsEnabled';
+export const HEADER_BUTTONS_ENABLED = 'headerButtonsEnabled';
+export const LOGO_ENABLED = 'logoEnabled';
+export const ACTION_LABELS_ENABLED = 'actionLabelsEnabled';
+export const TRACKING_ENABLED = 'trackingEnabled';
+export const LOCALE = 'locale';


### PR DESCRIPTION
## Summary
- create `useLocalStorageState` helper hook with generic localStorage handling
- centralize storage keys
- refactor various hooks to reuse the helper
- update locale hook test

## Testing
- `npm test`
- `npm run lint`
- `npm run format`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686ade6397508325a6b2e1ac703c3732