### PR TITLE
Refactor Dashboard state

### DIFF
--- a/src/components/GeneratedJson.tsx
+++ b/src/components/GeneratedJson.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { diffChars, Change } from 'diff';
+import { trackEvent } from '@/lib/analytics';
+
+interface Props {
+  json: string;
+  trackingEnabled: boolean;
+}
+
+const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const prevRef = useRef(json);
+  const [diffParts, setDiffParts] = useState<Change[] | null>(null);
+
+  useEffect(() => {
+    const diff = diffChars(prevRef.current, json).filter((p) => !p.removed);
+    prevRef.current = json;
+    setDiffParts(diff);
+    const timer = setTimeout(() => {
+      setDiffParts(diff.map((p) => ({ ...p, added: false }) as Change));
+    }, 2000);
+    trackEvent(trackingEnabled, 'json_changed');
+    return () => clearTimeout(timer);
+  }, [json, trackingEnabled]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const atBottom =
+      Math.abs(container.scrollHeight - container.scrollTop - container.clientHeight) < 5;
+    const atTop = container.scrollTop === 0;
+    if (atBottom) {
+      container.scrollTop = container.scrollHeight;
+    } else if (atTop) {
+      container.scrollTop = 0;
+    }
+  }, [json]);
+
+  return (
+    <div className="h-full overflow-y-auto" ref={containerRef}>
+      <pre className="p-6 text-sm font-mono whitespace-pre-wrap break-words leading-relaxed">
+        <code>
+          {diffParts
+            ? diffParts.map((part, idx) => (
+                <span key={idx} className={part.added ? 'animate-highlight' : undefined}>
+                  {part.value}
+                </span>
+              ))
+            : json}
+        </code>
+      </pre>
+    </div>
+  );
+};
+
+export default GeneratedJson;

--- a/src/hooks/__tests__/use-github-stats.test.ts
+++ b/src/hooks/__tests__/use-github-stats.test.ts
@@ -1,0 +1,51 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useGithubStats } from '../use-github-stats';
+import { toast } from '@/components/ui/sonner-toast';
+
+jest.mock('@/components/ui/sonner-toast', () => ({
+  __esModule: true,
+  toast: { error: jest.fn() },
+}));
+
+describe('useGithubStats', () => {
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    localStorage.clear();
+    (toast.error as jest.Mock).mockClear();
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('uses cache when fresh', () => {
+    localStorage.setItem('githubStats', JSON.stringify({ stars: 1, forks: 2, issues: 3 }));
+    localStorage.setItem('githubStatsTimestamp', JSON.stringify(Date.now()));
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const { result } = renderHook(() => useGithubStats());
+    expect(result.current).toEqual({ stars: 1, forks: 2, issues: 3 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('fetches stats when cache expired', async () => {
+    localStorage.setItem('githubStatsTimestamp', JSON.stringify(Date.now() - 7200000));
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ stargazers_count: 4, forks_count: 5 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ total_count: 6 }),
+      }) as unknown as typeof fetch;
+    const { result } = renderHook(() => useGithubStats());
+    await waitFor(() => expect(result.current).toEqual({ stars: 4, forks: 5, issues: 6 }));
+  });
+
+  test('shows toast on fetch error', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('fail')) as unknown as typeof fetch;
+    renderHook(() => useGithubStats());
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to load GitHub stats'));
+  });
+});

--- a/src/hooks/use-clipboard.ts
+++ b/src/hooks/use-clipboard.ts
@@ -1,0 +1,20 @@
+import { toast } from '@/components/ui/sonner-toast';
+
+export function useClipboard() {
+  const copy = async (text: string, success?: string) => {
+    if (!('clipboard' in navigator)) {
+      toast.error('Clipboard not supported');
+      return false;
+    }
+    try {
+      await navigator.clipboard.writeText(text);
+      if (success) toast.success(success);
+      return true;
+    } catch {
+      toast.error('Failed to copy to clipboard');
+      return false;
+    }
+  };
+
+  return { copy };
+}

--- a/src/hooks/use-github-stats.ts
+++ b/src/hooks/use-github-stats.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import { toast } from '@/components/ui/sonner-toast';
+import { DISABLE_STATS } from '@/lib/config';
+import { safeGet, safeSet } from '@/lib/storage';
+
+export interface GithubStats {
+  stars: number;
+  forks: number;
+  issues: number;
+}
+
+export function useGithubStats() {
+  const [stats, setStats] = useState<GithubStats>();
+
+  useEffect(() => {
+    if (DISABLE_STATS) return;
+    const cached = safeGet<GithubStats>('githubStats', null, true);
+    const cachedTs = safeGet<number>('githubStatsTimestamp', 0, true);
+    if (cached && typeof cachedTs === 'number' && Date.now() - cachedTs < 3600000) {
+      setStats(cached);
+      return;
+    }
+    const controller = new AbortController();
+    const { signal } = controller;
+    const load = async () => {
+      try {
+        const repoRes = await fetch(
+          'https://api.github.com/repos/supermarsx/sora-json-prompt-crafter',
+          { signal },
+        );
+        if (!repoRes.ok) throw new Error('non ok');
+        const repoData = await repoRes.json();
+
+        const issuesRes = await fetch(
+          'https://api.github.com/search/issues?q=repo:supermarsx/sora-json-prompt-crafter+type:issue+state:open',
+          { signal },
+        );
+        if (!issuesRes.ok) throw new Error('non ok');
+        const issuesData = await issuesRes.json();
+
+        if (!signal.aborted) {
+          const data: GithubStats = {
+            stars: repoData.stargazers_count,
+            forks: repoData.forks_count,
+            issues: issuesData.total_count,
+          };
+          setStats(data);
+          safeSet('githubStats', data, true);
+          safeSet('githubStatsTimestamp', Date.now(), true);
+        }
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') {
+          toast.error('Failed to load GitHub stats');
+        }
+      }
+    };
+    void load();
+    return () => controller.abort();
+  }, []);
+
+  return stats;
+}


### PR DESCRIPTION
## Summary
- extract GitHub stats logic into `useGithubStats`
- create `useClipboard` for copy helpers
- move JSON diff/scroll logic into new `GeneratedJson` component
- simplify `Dashboard` by using the new hooks/components
- add unit tests for `useGithubStats`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686af2d0d1d88325a8dffe0871f4cb47