### PR TITLE
Improve custom preset loading errors

### DIFF
--- a/src/lib/__tests__/presetLoader.test.ts
+++ b/src/lib/__tests__/presetLoader.test.ts
@@ -64,7 +64,9 @@ describe('loadCustomPresetsFromUrl', () => {
 
     const spy = jest.spyOn(presetLoaderModule, 'importCustomPresets');
 
-    await expect(loadCustomPresetsFromUrl('bad')).rejects.toThrow('network');
+    await expect(loadCustomPresetsFromUrl('bad')).rejects.toThrow(
+      'Failed to load custom presets: Error: network',
+    );
     expect(spy).not.toHaveBeenCalled();
   });
 
@@ -75,7 +77,9 @@ describe('loadCustomPresetsFromUrl', () => {
 
     const spy = jest.spyOn(presetLoaderModule, 'importCustomPresets');
 
-    await expect(loadCustomPresetsFromUrl('oops')).rejects.toThrow('invalid');
+    await expect(loadCustomPresetsFromUrl('oops')).rejects.toThrow(
+      'Failed to load custom presets: Error: invalid',
+    );
     expect(spy).not.toHaveBeenCalled();
   });
 
@@ -86,7 +90,9 @@ describe('loadCustomPresetsFromUrl', () => {
 
     const spy = jest.spyOn(presetLoaderModule, 'importCustomPresets');
 
-    await expect(loadCustomPresetsFromUrl('oops')).rejects.toThrow();
+    await expect(loadCustomPresetsFromUrl('oops')).rejects.toThrow(
+      'Failed to load custom presets:',
+    );
     expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/presetLoader.ts
+++ b/src/lib/presetLoader.ts
@@ -96,7 +96,11 @@ export function importCustomPresets(data: string | CustomPresetData): void {
 }
 
 export async function loadCustomPresetsFromUrl(url: string) {
-  const res = await fetch(url);
-  const json = await res.json();
-  importCustomPresets(json);
+  try {
+    const res = await fetch(url);
+    const json = await res.json();
+    importCustomPresets(json);
+  } catch (err) {
+    throw new Error('Failed to load custom presets: ' + err);
+  }
 }


### PR DESCRIPTION
## Summary
- add try/catch when fetching presets
- throw a clearer error when loading fails
- test for the new error message

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d4d60cb7483259978ea408f33132e