### PR TITLE
Add tests for script utilities

### DIFF
--- a/scripts/__tests__/accessibilityCheck.test.ts
+++ b/scripts/__tests__/accessibilityCheck.test.ts
@@ -1,0 +1,38 @@
+import { jest } from '@jest/globals';
+
+const readFileSyncMock = jest.fn(() => '<html></html>');
+const JSDOMMock = jest.fn().mockImplementation(() => ({
+  window: { document: {}, Node: class {}, Element: class {} },
+}));
+interface AxeResults {
+  violations: { id: string; help: string }[];
+}
+const runMock = jest.fn(
+  (
+    doc: Document,
+    opts: unknown,
+    cb: (err: unknown, results: AxeResults) => void,
+  ) => {
+    cb(null, { violations: [{ id: 'foo', help: 'bar' }] });
+  },
+);
+
+jest.mock('fs', () => ({ __esModule: true, readFileSync: readFileSyncMock }));
+jest.mock('jsdom', () => ({ __esModule: true, JSDOM: JSDOMMock }));
+jest.mock('axe-core', () => ({ __esModule: true, default: { run: runMock } }));
+
+describe('accessibilityCheck', () => {
+  test('reports violations and exits with code 1', async () => {
+    process.exitCode = 0;
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await import('../accessibilityCheck.js');
+    await new Promise((r) => process.nextTick(r));
+    expect(runMock).toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      'Accessibility violations found:',
+      expect.any(Number),
+    );
+    expect(process.exitCode).toBe(1);
+    logSpy.mockRestore();
+  });
+});

--- a/scripts/__tests__/generateCoverageBadge.test.ts
+++ b/scripts/__tests__/generateCoverageBadge.test.ts
@@ -1,0 +1,32 @@
+import { jest } from '@jest/globals';
+
+const sampleXml = `<?xml version="1.0"?><coverage><project><metrics statements="20" coveredstatements="17"/></project></coverage>`;
+const writeFileSyncMock = jest.fn();
+
+jest.mock('fs', () => ({
+  __esModule: true,
+  readFileSync: jest.fn(() => sampleXml),
+  writeFileSync: writeFileSyncMock,
+}));
+
+const makeBadgeMock = jest.fn(() => '<svg>badge</svg>');
+jest.mock('badge-maker', () => ({
+  __esModule: true,
+  makeBadge: makeBadgeMock,
+}));
+
+describe('generateCoverageBadge', () => {
+  test('creates badge with correct percent and color', async () => {
+    await import('../generateCoverageBadge.js');
+    expect(makeBadgeMock).toHaveBeenCalledWith({
+      label: 'coverage',
+      message: '85%',
+      color: 'green',
+      style: 'for-the-badge',
+    });
+    expect(writeFileSyncMock).toHaveBeenCalledWith(
+      'coverage.svg',
+      '<svg>badge</svg>',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for accessibilityCheck and generateCoverageBadge scripts

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686da92552c48325b9232ab95117848d