### PR TITLE
Add diff highlighting test for GeneratedJson

### DIFF
--- a/public/__tests__/sw.test.ts
+++ b/public/__tests__/sw.test.ts
@@ -58,7 +58,9 @@ describe('service worker', () => {
       { url: '/assets/style.css' },
     ];
     await import('../sw.js');
-    const installEvent: { waitUntil: (p: Promise<unknown>) => Promise<unknown> } = {
+    const installEvent: {
+      waitUntil: (p: Promise<unknown>) => Promise<unknown>;
+    } = {
       waitUntil: (p: Promise<unknown>) => p,
     };
     await listeners.install(installEvent);

--- a/src/components/__tests__/GeneratedJson.test.tsx
+++ b/src/components/__tests__/GeneratedJson.test.tsx
@@ -48,9 +48,9 @@ describe('GeneratedJson', () => {
 
     expect(trackEvent).toHaveBeenCalledWith(true, 'json_changed');
     expect(div.scrollTop).toBe(202);
-    expect(
-      div.querySelectorAll('span.animate-highlight').length,
-    ).toBeGreaterThan(0);
+    const added = div.querySelectorAll('span.animate-highlight');
+    expect(added.length).toBeGreaterThan(0);
+    expect(added[0].textContent).toBe(',"b":2');
 
     act(() => {
       jest.advanceTimersByTime(2000);


### PR DESCRIPTION
## Summary
- verify animated diff text for `GeneratedJson`
- keep service worker test formatted

## Testing
- `npm test --silent`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686da947bbc48325a3eb82f6c7ba798a