### PR TITLE
Add test for invalid JSON preview

### DIFF
--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -274,6 +274,15 @@ describe('HistoryPanel', () => {
     expect(screen.getByText(/"prompt"/i)).toBeTruthy();
   });
 
+  test('preview dialog shows raw string for invalid json', () => {
+    const history = [{ id: 2, date: 'd', json: 'invalid json' }];
+    renderPanel({ history });
+    fireEvent.click(screen.getByRole('button', { name: /preview/i }));
+    expect(screen.getByText(/json preview/i)).toBeTruthy();
+    expect(screen.getByText('invalid json')).toBeTruthy();
+    expect(screen.queryByText(/"prompt"/i)).toBeNull();
+  });
+
   test('clearing history asks for confirmation', () => {
     const onClear = jest.fn();
     renderPanel({ onClear });


### PR DESCRIPTION
## Summary
- ensure HistoryPanel preview dialog shows raw JSON when invalid

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e5b64b79c83259b250b2c8db660ac