### PR TITLE
Add failure tests for scripts

### DIFF
--- a/scripts/__tests__/accessibilityCheck.test.ts
+++ b/scripts/__tests__/accessibilityCheck.test.ts
@@ -21,6 +21,22 @@ jest.mock('fs', () => ({ __esModule: true, readFileSync: readFileSyncMock }));
 jest.mock('jsdom', () => ({ __esModule: true, JSDOM: JSDOMMock }));
 jest.mock('axe-core', () => ({ __esModule: true, default: { run: runMock } }));
 
+beforeEach(() => {
+  jest.resetModules();
+});
+
+afterEach(() => {
+  // clean globals modified by the script
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (global as any).window;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (global as any).document;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (global as any).Node;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (global as any).Element;
+});
+
 describe('accessibilityCheck', () => {
   test('reports violations and exits with code 1', async () => {
     process.exitCode = 0;
@@ -34,5 +50,25 @@ describe('accessibilityCheck', () => {
     );
     expect(process.exitCode).toBe(1);
     logSpy.mockRestore();
+  });
+
+  test('exits with code 1 when HTML file cannot be read', async () => {
+    readFileSyncMock.mockImplementationOnce(() => {
+      throw new Error('no file');
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`exit:${code}`);
+      }) as never);
+    await expect(import('../accessibilityCheck.js')).rejects.toThrow('exit:1');
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Build output not found:',
+      'dist/index.html',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
   });
 });

--- a/scripts/__tests__/generateCoverageBadge.test.ts
+++ b/scripts/__tests__/generateCoverageBadge.test.ts
@@ -1,11 +1,12 @@
 import { jest } from '@jest/globals';
 
 const sampleXml = `<?xml version="1.0"?><coverage><project><metrics statements="20" coveredstatements="17"/></project></coverage>`;
+const readFileSyncMock = jest.fn(() => sampleXml);
 const writeFileSyncMock = jest.fn();
 
 jest.mock('fs', () => ({
   __esModule: true,
-  readFileSync: jest.fn(() => sampleXml),
+  readFileSync: readFileSyncMock,
   writeFileSync: writeFileSyncMock,
 }));
 
@@ -14,6 +15,11 @@ jest.mock('badge-maker', () => ({
   __esModule: true,
   makeBadge: makeBadgeMock,
 }));
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
 
 describe('generateCoverageBadge', () => {
   test('creates badge with correct percent and color', async () => {
@@ -28,5 +34,40 @@ describe('generateCoverageBadge', () => {
       'coverage.svg',
       '<svg>badge</svg>',
     );
+  });
+
+  test('exits with code 1 when coverage file is missing', async () => {
+    readFileSyncMock.mockImplementationOnce(() => {
+      throw new Error('no file');
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`exit:${code}`);
+      }) as never);
+    await expect(import('../generateCoverageBadge.js')).rejects.toThrow('exit:1');
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Coverage file not found:',
+      'coverage/clover.xml',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  test('exits with code 1 when coverage xml cannot be parsed', async () => {
+    readFileSyncMock.mockReturnValueOnce('<coverage></coverage>');
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`exit:${code}`);
+      }) as never);
+    await expect(import('../generateCoverageBadge.js')).rejects.toThrow('exit:1');
+    expect(errorSpy).toHaveBeenCalledWith('Unable to parse coverage metrics');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- expand `accessibilityCheck` tests with read error handling
- ensure `generateCoverageBadge` handles missing/malformed coverage reports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ed172e1cc8325b570120a1b04f5b9