### PR TITLE
Fix integration test timing

### DIFF
--- a/src/__tests__/app.integration.test.tsx
+++ b/src/__tests__/app.integration.test.tsx
@@ -60,7 +60,13 @@ describe('App integration flow', () => {
   test('updates JSON and history after user actions', async () => {
     render(<App />);
 
-    const promptInput = await screen.findByLabelText('Prompt');
+    const promptInput = await screen.findByLabelText(
+      'Prompt',
+      {},
+      {
+        timeout: 2000,
+      },
+    );
     fireEvent.change(promptInput, {
       target: { value: 'Integration test prompt' },
     });


### PR DESCRIPTION
## Summary
- increase wait time for the app integration test so lazy-loaded components render reliably

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686ed48c5e548325a93d564237062e5a