### PR TITLE
Fix integration test timeout

### DIFF
--- a/scripts/__tests__/accessibilityCheck.test.ts
+++ b/scripts/__tests__/accessibilityCheck.test.ts
@@ -57,11 +57,11 @@ describe('accessibilityCheck', () => {
       throw new Error('no file');
     });
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const exitSpy = jest
-      .spyOn(process, 'exit')
-      .mockImplementation(((code?: number) => {
-        throw new Error(`exit:${code}`);
-      }) as never);
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
     await expect(import('../accessibilityCheck.js')).rejects.toThrow('exit:1');
     expect(errorSpy).toHaveBeenCalledWith(
       'Build output not found:',

--- a/scripts/__tests__/generateCoverageBadge.test.ts
+++ b/scripts/__tests__/generateCoverageBadge.test.ts
@@ -41,12 +41,14 @@ describe('generateCoverageBadge', () => {
       throw new Error('no file');
     });
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const exitSpy = jest
-      .spyOn(process, 'exit')
-      .mockImplementation(((code?: number) => {
-        throw new Error(`exit:${code}`);
-      }) as never);
-    await expect(import('../generateCoverageBadge.js')).rejects.toThrow('exit:1');
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    await expect(import('../generateCoverageBadge.js')).rejects.toThrow(
+      'exit:1',
+    );
     expect(errorSpy).toHaveBeenCalledWith(
       'Coverage file not found:',
       'coverage/clover.xml',
@@ -59,12 +61,14 @@ describe('generateCoverageBadge', () => {
   test('exits with code 1 when coverage xml cannot be parsed', async () => {
     readFileSyncMock.mockReturnValueOnce('<coverage></coverage>');
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const exitSpy = jest
-      .spyOn(process, 'exit')
-      .mockImplementation(((code?: number) => {
-        throw new Error(`exit:${code}`);
-      }) as never);
-    await expect(import('../generateCoverageBadge.js')).rejects.toThrow('exit:1');
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    await expect(import('../generateCoverageBadge.js')).rejects.toThrow(
+      'exit:1',
+    );
     expect(errorSpy).toHaveBeenCalledWith('Unable to parse coverage metrics');
     expect(exitSpy).toHaveBeenCalledWith(1);
     errorSpy.mockRestore();

--- a/src/__tests__/app.integration.test.tsx
+++ b/src/__tests__/app.integration.test.tsx
@@ -4,6 +4,7 @@ import {
   fireEvent,
   waitFor,
   within,
+  act,
 } from '@testing-library/react';
 import App from '../App';
 import '@/i18n';
@@ -58,13 +59,15 @@ function openStylePreset() {
 
 describe('App integration flow', () => {
   test('updates JSON and history after user actions', async () => {
-    render(<App />);
+    await act(async () => {
+      render(<App />);
+    });
 
     const promptInput = await screen.findByLabelText(
       'Prompt',
       {},
       {
-        timeout: 2000,
+        timeout: 5000,
       },
     );
     fireEvent.change(promptInput, {


### PR DESCRIPTION
## Summary
- stabilize the app integration test to handle slower coverage runs
- expand wait time for loading the prompt input
- apply formatting fixes to script tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_686ed9ca27f083258d748607a9f09b02