### PR TITLE
Increase integration test timeout

### DIFF
--- a/src/__tests__/app.integration.test.tsx
+++ b/src/__tests__/app.integration.test.tsx
@@ -57,8 +57,10 @@ function openStylePreset() {
 }
 
 describe('App integration flow', () => {
-  test('updates JSON and history after user actions', async () => {
-    render(<App />);
+  test(
+    'updates JSON and history after user actions',
+    async () => {
+      render(<App />);
 
     const promptInput = await screen.findByLabelText(
       'Prompt',
@@ -91,5 +93,7 @@ describe('App integration flow', () => {
 
     const dialog = await screen.findByRole('dialog');
     expect(within(dialog).getByText('Integration test prompt')).toBeTruthy();
-  });
+    },
+    10000,
+  );
 });


### PR DESCRIPTION
## Summary
- extend the `App` integration test timeout to 10s

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ede8024348325a655f826d68c4a3a