### PR TITLE
Fix React Router future flag warning

### DIFF
--- a/scripts/__tests__/accessibilityCheck.test.ts
+++ b/scripts/__tests__/accessibilityCheck.test.ts
@@ -57,11 +57,11 @@ describe('accessibilityCheck', () => {
       throw new Error('no file');
     });
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const exitSpy = jest
-      .spyOn(process, 'exit')
-      .mockImplementation(((code?: number) => {
-        throw new Error(`exit:${code}`);
-      }) as never);
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
     await expect(import('../accessibilityCheck.js')).rejects.toThrow('exit:1');
     expect(errorSpy).toHaveBeenCalledWith(
       'Build output not found:',

--- a/scripts/__tests__/generateCoverageBadge.test.ts
+++ b/scripts/__tests__/generateCoverageBadge.test.ts
@@ -41,12 +41,14 @@ describe('generateCoverageBadge', () => {
       throw new Error('no file');
     });
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const exitSpy = jest
-      .spyOn(process, 'exit')
-      .mockImplementation(((code?: number) => {
-        throw new Error(`exit:${code}`);
-      }) as never);
-    await expect(import('../generateCoverageBadge.js')).rejects.toThrow('exit:1');
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    await expect(import('../generateCoverageBadge.js')).rejects.toThrow(
+      'exit:1',
+    );
     expect(errorSpy).toHaveBeenCalledWith(
       'Coverage file not found:',
       'coverage/clover.xml',
@@ -59,12 +61,14 @@ describe('generateCoverageBadge', () => {
   test('exits with code 1 when coverage xml cannot be parsed', async () => {
     readFileSyncMock.mockReturnValueOnce('<coverage></coverage>');
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const exitSpy = jest
-      .spyOn(process, 'exit')
-      .mockImplementation(((code?: number) => {
-        throw new Error(`exit:${code}`);
-      }) as never);
-    await expect(import('../generateCoverageBadge.js')).rejects.toThrow('exit:1');
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    await expect(import('../generateCoverageBadge.js')).rejects.toThrow(
+      'exit:1',
+    );
     expect(errorSpy).toHaveBeenCalledWith('Unable to parse coverage metrics');
     expect(exitSpy).toHaveBeenCalledWith(1);
     errorSpy.mockRestore();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ const App = () => {
           <TooltipProvider>
             <Toaster />
             <Sonner />
-            <BrowserRouter>
+            <BrowserRouter future={{ v7_startTransition: true }}>
               <Suspense fallback={null}>
                 <Routes>
                   <Route path="/" element={<Index />} />


### PR DESCRIPTION
## Summary
- suppress React Router warnings by enabling the v7 `startTransition` flag
- update formatted tests after running prettier

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_686ede84a1a48325ae399720030cdf7b