### PR TITLE
Add clipboard array import tests

### DIFF
--- a/src/components/__tests__/ClipboardImportModal.test.tsx
+++ b/src/components/__tests__/ClipboardImportModal.test.tsx
@@ -51,6 +51,67 @@ describe('ClipboardImportModal', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  test('imports array of JSON strings', () => {
+    const onImport = jest.fn();
+    const onOpenChange = jest.fn();
+    render(
+      <ClipboardImportModal
+        open={true}
+        onOpenChange={onOpenChange}
+        onImport={onImport}
+        title="Import"
+      />,
+    );
+    const textarea = screen.getByPlaceholderText(/paste json/i);
+    const arrayText = JSON.stringify(['{"prompt":"one"}', '{"prompt":"two"}']);
+    fireEvent.change(textarea, {
+      target: { value: arrayText },
+    });
+    const button = screen.getByRole('button', { name: /import/i });
+    fireEvent.click(button);
+
+    expect(onImport).toHaveBeenCalledWith([
+      '{"prompt":"one"}',
+      '{"prompt":"two"}',
+    ]);
+    expect(trackEvent).toHaveBeenCalledWith(true, 'history_import', {
+      type: 'clipboard',
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  test('imports array of objects with json property', () => {
+    const onImport = jest.fn();
+    const onOpenChange = jest.fn();
+    render(
+      <ClipboardImportModal
+        open={true}
+        onOpenChange={onOpenChange}
+        onImport={onImport}
+        title="Import"
+      />,
+    );
+    const textarea = screen.getByPlaceholderText(/paste json/i);
+    const objectArrayText = JSON.stringify([
+      { json: '{"prompt":"one"}' },
+      { json: '{"prompt":"two"}' },
+    ]);
+    fireEvent.change(textarea, {
+      target: { value: objectArrayText },
+    });
+    const button = screen.getByRole('button', { name: /import/i });
+    fireEvent.click(button);
+
+    expect(onImport).toHaveBeenCalledWith([
+      '{"prompt":"one"}',
+      '{"prompt":"two"}',
+    ]);
+    expect(trackEvent).toHaveBeenCalledWith(true, 'history_import', {
+      type: 'clipboard',
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   test('shows error and closes on invalid JSON', () => {
     const onImport = jest.fn();
     const onOpenChange = jest.fn();


### PR DESCRIPTION
## Summary
- add tests for ClipboardImportModal handling arrays of JSON strings or objects with a `json` field

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eefe6147c83259aac8212327d05f9