### PR TITLE
Add tests for optionFlagMap

### DIFF
--- a/src/lib/__tests__/optionFlagMap.test.ts
+++ b/src/lib/__tests__/optionFlagMap.test.ts
@@ -1,0 +1,20 @@
+import { OPTION_FLAG_MAP } from '../optionFlagMap';
+
+describe('OPTION_FLAG_MAP', () => {
+  test('returns correct flag for lighting', () => {
+    expect(OPTION_FLAG_MAP.lighting).toBe('use_lighting');
+  });
+
+  test('returns correct flag for secondary_material', () => {
+    expect(OPTION_FLAG_MAP.secondary_material).toBe('use_secondary_material');
+  });
+
+  test('returns correct flag for camera_angle', () => {
+    expect(OPTION_FLAG_MAP.camera_angle).toBe('use_camera_composition');
+  });
+
+  test('returns undefined for nonexistent key', () => {
+    // @ts-expect-error - property does not exist
+    expect(OPTION_FLAG_MAP.nonexistent).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test verifying OPTION_FLAG_MAP mappings

## Testing
- `npm run lint`
- `npm test -- -t OPTION_FLAG_MAP`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686eefec5a0c8325861c5c39764fc237