### PR TITLE
Fix integration test prompt label query

### DIFF
--- a/src/__tests__/app.integration.test.tsx
+++ b/src/__tests__/app.integration.test.tsx
@@ -63,7 +63,7 @@ describe('App integration flow', () => {
       render(<App />);
 
     const promptInput = await screen.findByLabelText(
-      'Prompt',
+      /^prompt$/i,
       {},
       {
         timeout: 2000,


### PR DESCRIPTION
## Summary
- fix the label query in `app.integration.test.tsx`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686ef2b06a048325bfefd0afb57f0331