### PR TITLE
Fix router warning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,9 @@ const App = () => {
           <TooltipProvider>
             <Toaster />
             <Sonner />
-            <BrowserRouter future={{ v7_startTransition: true }}>
+            <BrowserRouter
+              future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+            >
               <Suspense fallback={null}>
                 <Routes>
                   <Route path="/" element={<Index />} />


### PR DESCRIPTION
## Summary
- opt into `v7_relativeSplatPath` future flag to remove React Router warning

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ef99dc1d88325b58850318b50a0fd