### PR TITLE
Add ui component tests

### DIFF
--- a/src/components/ui/__tests__/popover.test.tsx
+++ b/src/components/ui/__tests__/popover.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Popover, PopoverTrigger, PopoverContent } from '../popover';
+
+describe('Popover component', () => {
+  test('content toggles on trigger click', () => {
+    const handleChange = jest.fn();
+    render(
+      <Popover onOpenChange={handleChange}>
+        <PopoverTrigger>Toggle</PopoverTrigger>
+        <PopoverContent>Popover text</PopoverContent>
+      </Popover>,
+    );
+
+    expect(screen.queryByText('Popover text')).toBeNull();
+
+    fireEvent.click(screen.getByText('Toggle'));
+
+    expect(screen.getByText('Popover text')).toBeDefined();
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/components/ui/__tests__/select.test.tsx
+++ b/src/components/ui/__tests__/select.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '../select';
+
+describe('Select component', () => {
+  test('renders trigger', () => {
+    render(
+      <Select>
+        <SelectTrigger>Open</SelectTrigger>
+        <SelectContent />
+      </Select>,
+    );
+    expect(screen.getByText('Open')).toBeDefined();
+  });
+
+  test('calls onValueChange when item selected', () => {
+    const handleChange = jest.fn();
+    render(
+      <Select onValueChange={handleChange}>
+        <SelectTrigger data-testid="trigger">
+          <SelectValue placeholder="choose" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="one">One</SelectItem>
+          <SelectItem value="two">Two</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+
+    fireEvent.click(screen.getByTestId('trigger'));
+    fireEvent.click(screen.getByText('Two'));
+
+    expect(handleChange).toHaveBeenCalledWith('two');
+  });
+});

--- a/src/components/ui/__tests__/slider.test.tsx
+++ b/src/components/ui/__tests__/slider.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Slider } from '../slider';
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('Slider component', () => {
+  test('renders with role slider', () => {
+    render(<Slider defaultValue={[50]} />);
+    expect(screen.getByRole('slider')).toBeDefined();
+  });
+
+  test('calls onValueChange when value changes', () => {
+    const handleChange = jest.fn();
+    render(<Slider defaultValue={[0]} onValueChange={handleChange} step={1} />);
+
+    const thumb = screen.getByRole('slider');
+    fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+
+    expect(handleChange).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- test Slider for render and onValueChange
- test Select for render and item callbacks
- test Popover toggle logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686efbff4b9083259efc309981719225