### PR TITLE
Add analytics assertions to bulk import tests

### DIFF
--- a/src/components/__tests__/BulkFileImportModal.test.tsx
+++ b/src/components/__tests__/BulkFileImportModal.test.tsx
@@ -56,6 +56,9 @@ describe('BulkFileImportModal', () => {
     await waitFor(() =>
       expect(onImport).toHaveBeenCalledWith(['{"prompt":"test"}']),
     );
+    expect(trackEvent).toHaveBeenCalledWith(true, 'history_import', {
+      type: 'bulk_file',
+    });
     expect(toast.success).toHaveBeenCalledWith('File imported!');
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
@@ -88,6 +91,7 @@ describe('BulkFileImportModal', () => {
       expect(toast.error).toHaveBeenCalledWith('Failed to import file'),
     );
     expect(onImport).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
   });
 
   test('shows error toast when no file selected', () => {


### PR DESCRIPTION
## Summary
- update bulk import modal tests to cover analytics tracking

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f018497fc8325b92854455581eaf6