### PR TITLE
Add comprehensive tests for validateOptions

### DIFF
--- a/src/lib/__tests__/validateOptions.test.ts
+++ b/src/lib/__tests__/validateOptions.test.ts
@@ -12,4 +12,21 @@ describe('isValidOptions', () => {
   test('rejects wrong types', () => {
     expect(isValidOptions({ steps: 'ten' })).toBe(false);
   });
+
+  test('accepts arrays, null, and nested objects', () => {
+    const result = isValidOptions({
+      special_effects: ['glow'],
+      seed: null,
+      style_preset: { category: 'foo', style: 'bar' },
+    });
+    expect(result).toBe(true);
+  });
+
+  test('rejects invalid keys or incorrect value types', () => {
+    expect(isValidOptions({ unknown: 1 })).toBe(false);
+    expect(isValidOptions({ special_effects: 'glow' })).toBe(false);
+    expect(
+      isValidOptions({ style_preset: { category: 1 as unknown as string, style: 'bar' } })
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- expand validateOptions tests to cover arrays, nulls and nested objects
- test failure cases for invalid keys and types

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f05425ad48325bdb4c51bf61336c8