### PR TITLE
Add toast UI test

### DIFF
--- a/src/components/ui/__tests__/toast.test.tsx
+++ b/src/components/ui/__tests__/toast.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  ToastProvider,
+  Toast,
+  ToastViewport,
+  ToastClose,
+} from '../toast';
+
+function ToastExample() {
+  const [open, setOpen] = React.useState(true);
+  return (
+    <ToastProvider>
+      <Toast open={open} onOpenChange={setOpen}>
+        <div>Toast message</div>
+        <ToastClose />
+      </Toast>
+      <ToastViewport />
+    </ToastProvider>
+  );
+}
+
+describe('Toast component', () => {
+  test('renders and dismisses', () => {
+    render(<ToastExample />);
+
+    expect(screen.getByText('Toast message')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.queryByText('Toast message')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- test ToastProvider render and dismiss logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f24b5e7c88325a06648a740b75265