### PR TITLE
Add analytics truncation and failure limit tests

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -62,7 +62,7 @@ export function trackEvent(
     if (trackingFailures <= 5) {
       console.error('Tracking Analytics: There was an error.');
     }
-    if (!trackingDead) {
+    if (trackingFailures > 5 && !trackingDead) {
       trackingDead = true;
       console.error(
         'Tracking Analytics: Too many errors, tracking permanently failed.',


### PR DESCRIPTION
## Summary
- improve analytics failure handling logic to disable tracking after five errors
- expand analytics tests for history truncation and repeated failure scenarios

## Testing
- `npm test -- src/lib/__tests__/analytics.test.ts`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686f24aee8e08325b7fc12b8e0feb340