### PR TITLE
Add tests for section inputs

### DIFF
--- a/src/components/sections/__tests__/DimensionsFormatSection.test.tsx
+++ b/src/components/sections/__tests__/DimensionsFormatSection.test.tsx
@@ -47,4 +47,29 @@ describe('DimensionsFormatSection', () => {
     fireEvent.click(screen.getByRole('option', { name: /ultra/i }));
     expect(updateOptions).toHaveBeenCalledWith({ quality: 'ultra' });
   });
+
+  test('output format and dynamic range selections update', () => {
+    const updateOptions = jest.fn();
+    render(
+      <DimensionsFormatSection
+        options={{
+          ...DEFAULT_OPTIONS,
+          use_dimensions_format: true,
+          output_format: 'png',
+          dynamic_range: 'SDR',
+        }}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    const comboboxes = screen.getAllByRole('combobox');
+    fireEvent.click(comboboxes[2]);
+    fireEvent.click(screen.getByRole('option', { name: /jpg/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ output_format: 'jpg' });
+
+    fireEvent.click(comboboxes[3]);
+    fireEvent.click(screen.getByRole('option', { name: /hdr/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ dynamic_range: 'HDR' });
+  });
 });

--- a/src/components/sections/__tests__/MaterialSection.test.tsx
+++ b/src/components/sections/__tests__/MaterialSection.test.tsx
@@ -60,4 +60,25 @@ describe('MaterialSection', () => {
     dropdown = within(section).getByRole('button');
     expect(dropdown.hasAttribute('disabled')).toBe(true);
   });
+
+  test('made out of dropdown updates value', () => {
+    const updateOptions = jest.fn();
+    render(
+      <MaterialSection
+        options={{
+          ...DEFAULT_OPTIONS,
+          use_material: true,
+          made_out_of: 'default',
+        }}
+        updateOptions={updateOptions}
+      />,
+    );
+
+    const section = screen.getByText('Made Out Of')
+      .parentElement as HTMLElement;
+    const dropdown = within(section).getByRole('button');
+    fireEvent.click(dropdown);
+    fireEvent.click(screen.getByRole('button', { name: /^wood$/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ made_out_of: 'wood' });
+  });
 });

--- a/src/components/sections/__tests__/PromptSection.test.tsx
+++ b/src/components/sections/__tests__/PromptSection.test.tsx
@@ -29,4 +29,34 @@ describe('PromptSection', () => {
       negative_prompt: 'new negative',
     });
   });
+
+  test('negative prompt toggle enables textarea', () => {
+    const updateOptions = jest.fn();
+    const options = { ...DEFAULT_OPTIONS, use_negative_prompt: false };
+    const { rerender } = render(
+      <PromptSection
+        options={options}
+        updateOptions={updateOptions}
+        trackingEnabled={false}
+      />,
+    );
+
+    const textarea = screen.getByLabelText(/^negative prompt$/i);
+    expect(textarea.hasAttribute('disabled')).toBe(true);
+
+    const checkbox = screen.getByRole('checkbox');
+    fireEvent.click(checkbox);
+    expect(updateOptions).toHaveBeenCalledWith({ use_negative_prompt: true });
+
+    rerender(
+      <PromptSection
+        options={{ ...options, use_negative_prompt: true }}
+        updateOptions={updateOptions}
+        trackingEnabled={false}
+      />,
+    );
+    expect(
+      screen.getByLabelText(/^negative prompt$/i).hasAttribute('disabled'),
+    ).toBe(false);
+  });
 });

--- a/src/components/sections/__tests__/StyleSection.test.tsx
+++ b/src/components/sections/__tests__/StyleSection.test.tsx
@@ -31,4 +31,26 @@ describe('StyleSection', () => {
       'film still',
     );
   });
+
+  test('changing style category updates nested options', () => {
+    const updateNestedOptions = jest.fn();
+    const updateOptions = jest.fn();
+    const options = { ...DEFAULT_OPTIONS, use_style_preset: true };
+    render(
+      <StyleSection
+        options={options}
+        updateNestedOptions={updateNestedOptions}
+        updateOptions={updateOptions}
+      />,
+    );
+    const categoryDropdown = screen.getAllByRole('combobox')[0];
+    fireEvent.click(categoryDropdown);
+    fireEvent.click(
+      screen.getByRole('option', { name: /modern digital & illustration/i }),
+    );
+    expect(updateNestedOptions).toHaveBeenCalledWith(
+      'style_preset.category',
+      'Modern Digital & Illustration',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- expand tests for negative prompt toggle
- test Material section dropdown for main material
- test additional format dropdowns
- cover style preset category select

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f24b36ed883258fe9e0686825754c