### PR TITLE
Add checkbox and dropdown tests

### DIFF
--- a/src/components/sections/__tests__/EnhancementsSection.test.tsx
+++ b/src/components/sections/__tests__/EnhancementsSection.test.tsx
@@ -62,4 +62,26 @@ describe('EnhancementsSection', () => {
     dropdown = within(section).getByRole('button');
     expect(dropdown.hasAttribute('disabled')).toBe(true);
   });
+
+  test('other checkbox toggles update options', () => {
+    const updateOptions = jest.fn();
+    render(
+      <EnhancementsSection
+        options={DEFAULT_OPTIONS}
+        updateOptions={updateOptions}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+
+    const toggles = [
+      { label: /prevent deformities/i, flag: 'prevent_deformities' },
+      { label: /keep key details/i, flag: 'keep_key_details' },
+    ] as const;
+
+    toggles.forEach(({ label, flag }) => {
+      fireEvent.click(screen.getByLabelText(label));
+      expect(updateOptions).toHaveBeenCalledWith({ [flag]: true });
+    });
+  });
 });

--- a/src/components/sections/__tests__/FaceSection.test.tsx
+++ b/src/components/sections/__tests__/FaceSection.test.tsx
@@ -50,4 +50,71 @@ describe('FaceSection', () => {
     dropdown = within(section).getByRole('button');
     expect(dropdown.hasAttribute('disabled')).toBe(true);
   });
+
+  test('makeup style flag toggles and dropdown updates', () => {
+    const updateOptions = jest.fn();
+    let options = {
+      ...DEFAULT_OPTIONS,
+      use_face_enhancements: true,
+      use_makeup_style: false,
+    };
+
+    const { rerender } = render(
+      <FaceSection options={options} updateOptions={updateOptions} />,
+    );
+
+    let section = screen.getByText('Makeup Style').parentElement as HTMLElement;
+    let dropdown = within(section).getByRole('button');
+    expect(dropdown.hasAttribute('disabled')).toBe(true);
+
+    fireEvent.click(screen.getByLabelText(/use makeup style/i));
+    expect(updateOptions).toHaveBeenCalledWith({ use_makeup_style: true });
+
+    options = {
+      ...options,
+      use_makeup_style: true,
+      makeup_style: 'default (no specific makeup)',
+    };
+    rerender(<FaceSection options={options} updateOptions={updateOptions} />);
+
+    section = screen.getByText('Makeup Style').parentElement as HTMLElement;
+    dropdown = within(section).getByRole('button');
+    fireEvent.click(dropdown);
+    fireEvent.click(screen.getByRole('button', { name: /^bold glam$/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ makeup_style: 'bold glam' });
+  });
+
+  test('character mood flag toggles and dropdown updates', () => {
+    const updateOptions = jest.fn();
+    let options = {
+      ...DEFAULT_OPTIONS,
+      use_face_enhancements: true,
+      use_character_mood: false,
+    };
+
+    const { rerender } = render(
+      <FaceSection options={options} updateOptions={updateOptions} />,
+    );
+
+    let section = screen.getByText('Character Mood')
+      .parentElement as HTMLElement;
+    let dropdown = within(section).getByRole('button');
+    expect(dropdown.hasAttribute('disabled')).toBe(true);
+
+    fireEvent.click(screen.getByLabelText(/use character mood/i));
+    expect(updateOptions).toHaveBeenCalledWith({ use_character_mood: true });
+
+    options = {
+      ...options,
+      use_character_mood: true,
+      character_mood: 'default (neutral mood)',
+    };
+    rerender(<FaceSection options={options} updateOptions={updateOptions} />);
+
+    section = screen.getByText('Character Mood').parentElement as HTMLElement;
+    dropdown = within(section).getByRole('button');
+    fireEvent.click(dropdown);
+    fireEvent.click(screen.getByRole('button', { name: /^happy$/i }));
+    expect(updateOptions).toHaveBeenCalledWith({ character_mood: 'happy' });
+  });
 });


### PR DESCRIPTION
## Summary
- cover prevent deformities & keep key details checkboxes in `EnhancementsSection`
- test makeup style and character mood flags and dropdowns in `FaceSection`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68724961248c8325992dd83afd2b32c2