### PR TITLE
Add timeout case for Sora userscript hook

### DIFF
--- a/src/hooks/__tests__/use-sora-userscript.test.ts
+++ b/src/hooks/__tests__/use-sora-userscript.test.ts
@@ -71,4 +71,23 @@ describe('useSoraUserscript', () => {
 
     expect(debugSpy).toHaveBeenCalledWith('[Sora Loader] Debug pong received');
   });
+
+  test('resets when READY never arrives', () => {
+    jest.useFakeTimers();
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    const { result } = renderHook(() => useSoraUserscript(true));
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(result.current[0]).toBe(false);
+    expect(result.current[1]).toBeNull();
+    expect(debugSpy).toHaveBeenCalledWith(
+      '[Sora Loader] No response, resetting state',
+    );
+
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary
- test userscript hook timeout handling with fake timers

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687248c83f5c832598f302a4cb725d30