### PR TITLE
Add schemaFor branch coverage tests

### DIFF
--- a/src/lib/__tests__/validateOptions.test.ts
+++ b/src/lib/__tests__/validateOptions.test.ts
@@ -49,4 +49,25 @@ describe('isValidOptions', () => {
     );
     expect(isValidOptions({ seed: '123' as unknown as number })).toBe(false);
   });
+
+  test('rejects arrays for string fields', () => {
+    expect(isValidOptions({ prompt: ['foo'] as unknown as string })).toBe(false);
+  });
+
+  test('rejects objects for string fields', () => {
+    expect(isValidOptions({ prompt: { text: 'foo' } as unknown as string })).toBe(
+      false,
+    );
+  });
+
+  test('rejects null for non-nullable fields', () => {
+    expect(isValidOptions({ prompt: null as unknown as string })).toBe(false);
+  });
+
+  test('rejects unknown value types', () => {
+    // Symbol is not supported by the schema and should fail validation
+    expect(isValidOptions({ prompt: Symbol('foo') as unknown as string })).toBe(
+      false,
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- expand `isValidOptions` test suite with additional edge cases
- reject arrays, objects, null and unknown types when used inappropriately

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873b158be5083259ef9452646137850