### PR TITLE
Add constants unit test

### DIFF
--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -1,0 +1,30 @@
+import {
+  MOBILE_BREAKPOINT,
+  SINGLE_COLUMN_BREAKPOINT,
+} from '../breakpoints';
+import {
+  DARK_MODE,
+  SORA_TOOLS_ENABLED,
+  HEADER_BUTTONS_ENABLED,
+  LOGO_ENABLED,
+  ACTION_LABELS_ENABLED,
+  TRACKING_ENABLED,
+  LOCALE,
+} from '../storage-keys';
+
+describe('constants', () => {
+  test('breakpoints', () => {
+    expect(MOBILE_BREAKPOINT).toBe(768);
+    expect(SINGLE_COLUMN_BREAKPOINT).toBe(1024);
+  });
+
+  test('storage keys', () => {
+    expect(DARK_MODE).toBe('darkMode');
+    expect(SORA_TOOLS_ENABLED).toBe('soraToolsEnabled');
+    expect(HEADER_BUTTONS_ENABLED).toBe('headerButtonsEnabled');
+    expect(LOGO_ENABLED).toBe('logoEnabled');
+    expect(ACTION_LABELS_ENABLED).toBe('actionLabelsEnabled');
+    expect(TRACKING_ENABLED).toBe('trackingEnabled');
+    expect(LOCALE).toBe('locale');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for constant values

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874129e815c8325b7fca042c2b37ac1