### PR TITLE
Ensure noopener on window.open

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -158,7 +158,7 @@ const Dashboard = () => {
   };
 
   const sendToSora = () => {
-    const win = window.open('https://sora.chatgpt.com', '_blank');
+    const win = window.open('https://sora.chatgpt.com', '_blank', 'noopener');
     if (!win) return;
     const payload = { type: 'INSERT_SORA_JSON', json: JSON.parse(jsonString) };
     const start = () => {

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -35,7 +35,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
   const [trackingEnabled] = useTracking();
   const shareToFacebook = () => {
     const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}&quote=${encodeURIComponent('Check out my Sora prompt configuration!')}`;
-    window.open(url, '_blank', 'width=600,height=400');
+    window.open(url, '_blank', 'noopener,width=600,height=400');
     toast.success('Shared to Facebook!');
     trackEvent(trackingEnabled, 'share_facebook');
   };
@@ -45,7 +45,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
       'Check out my Sora prompt configuration! #SoraAI #AIGeneration',
     );
     const url = `https://twitter.com/intent/tweet?text=${text}&url=${encodeURIComponent(window.location.href)}`;
-    window.open(url, '_blank', 'width=600,height=400');
+    window.open(url, '_blank', 'noopener,width=600,height=400');
     toast.success('Shared to Twitter!');
     trackEvent(trackingEnabled, 'share_twitter');
   };
@@ -55,7 +55,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
       `Check out my Sora prompt configuration!\n\n${jsonContent}`,
     );
     const url = `https://wa.me/?text=${text}`;
-    window.open(url, '_blank');
+    window.open(url, '_blank', 'noopener');
     toast.success('Shared to WhatsApp!');
     trackEvent(trackingEnabled, 'share_whatsapp');
   };
@@ -65,7 +65,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
       `Check out my Sora prompt configuration!\n\n${jsonContent}`,
     );
     const url = `https://t.me/share/url?url=${encodeURIComponent(window.location.href)}&text=${text}`;
-    window.open(url, '_blank');
+    window.open(url, '_blank', 'noopener');
     toast.success('Shared to Telegram!');
     trackEvent(trackingEnabled, 'share_telegram');
   };

--- a/src/components/__tests__/Dashboard.sendToSoraTimeout.test.tsx
+++ b/src/components/__tests__/Dashboard.sendToSoraTimeout.test.tsx
@@ -120,6 +120,11 @@ describe('sendToSora timeout', () => {
     act(() => {
       sendFn!();
     });
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://sora.chatgpt.com',
+      '_blank',
+      'noopener',
+    );
 
     act(() => {
       jest.advanceTimersByTime(500);

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -302,6 +302,11 @@ describe('Dashboard interactions', () => {
     act(() => {
       fireEvent.click(sendButton);
     });
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://sora.chatgpt.com',
+      '_blank',
+      'noopener',
+    );
 
     act(() => {
       jest.advanceTimersByTime(500);

--- a/src/components/__tests__/ShareModal.test.tsx
+++ b/src/components/__tests__/ShareModal.test.tsx
@@ -52,7 +52,11 @@ describe('ShareModal', () => {
     renderModal();
     const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}&quote=${encodeURIComponent('Check out my Sora prompt configuration!')}`;
     fireEvent.click(screen.getByRole('button', { name: /facebook/i }));
-    expect(openSpy).toHaveBeenCalledWith(url, '_blank', 'width=600,height=400');
+    expect(openSpy).toHaveBeenCalledWith(
+      url,
+      '_blank',
+      'noopener,width=600,height=400',
+    );
     expect(trackEvent).toHaveBeenCalledWith(true, 'share_facebook');
   });
 
@@ -63,7 +67,11 @@ describe('ShareModal', () => {
     );
     const url = `https://twitter.com/intent/tweet?text=${text}&url=${encodeURIComponent(window.location.href)}`;
     fireEvent.click(screen.getByRole('button', { name: /twitter\/x/i }));
-    expect(openSpy).toHaveBeenCalledWith(url, '_blank', 'width=600,height=400');
+    expect(openSpy).toHaveBeenCalledWith(
+      url,
+      '_blank',
+      'noopener,width=600,height=400',
+    );
     expect(trackEvent).toHaveBeenCalledWith(true, 'share_twitter');
   });
 
@@ -74,7 +82,7 @@ describe('ShareModal', () => {
     );
     const url = `https://wa.me/?text=${text}`;
     fireEvent.click(screen.getByRole('button', { name: /whatsapp/i }));
-    expect(openSpy).toHaveBeenCalledWith(url, '_blank');
+    expect(openSpy).toHaveBeenCalledWith(url, '_blank', 'noopener');
     expect(trackEvent).toHaveBeenCalledWith(true, 'share_whatsapp');
   });
 
@@ -85,7 +93,7 @@ describe('ShareModal', () => {
     );
     const url = `https://t.me/share/url?url=${encodeURIComponent(window.location.href)}&text=${text}`;
     fireEvent.click(screen.getByRole('button', { name: /telegram/i }));
-    expect(openSpy).toHaveBeenCalledWith(url, '_blank');
+    expect(openSpy).toHaveBeenCalledWith(url, '_blank', 'noopener');
     expect(trackEvent).toHaveBeenCalledWith(true, 'share_telegram');
   });
 


### PR DESCRIPTION
## Summary
- add `noopener` to all `window.open` calls
- verify noopener in ShareModal and Dashboard tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687433a358008325ba1ecb332ccd1ecf