### PR TITLE
centralize userscript version

### DIFF
--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JSON Prompt Crafter Integration Sora Integration
 // @namespace    supermarsx
-// @version      1.3
+// @version      __USERSCRIPT_VERSION__
 // @description  Inject JSON prompt from external tab into Sora textarea
 // @match *://*/*
 // @grant        none
@@ -9,7 +9,7 @@
 // ==/UserScript==
 
 (() => {
-  const VERSION = '1.3';
+  const VERSION = '__USERSCRIPT_VERSION__';
   const DEBUG = true;
   const SESSION_KEY = 'sora_json_payload';
   console.log(`[Sora Injector] Loaded v${VERSION}`);

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -39,7 +39,7 @@ import { loadOptionsFromJson } from '@/lib/loadOptionsFromJson';
 import { OPTION_FLAG_MAP } from '@/lib/optionFlagMap';
 import { isValidOptions } from '@/lib/validateOptions';
 import { safeGet, safeSet } from '@/lib/storage';
-import { USERSCRIPT_VERSION } from '@/lib/config';
+import { USERSCRIPT_VERSION } from '@/version';
 import { useGithubStats } from '@/hooks/use-github-stats';
 import { useClipboard } from '@/hooks/use-clipboard';
 import { useTranslation } from 'react-i18next';

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -25,4 +25,4 @@ export const DISABLE_STATS = disableStats === 'true' || disableStats === '1';
 const gtagDebug = getEnvVar('VITE_GTAG_DEBUG');
 export const GTAG_DEBUG = gtagDebug === 'true' || gtagDebug === '1';
 
-export const USERSCRIPT_VERSION = '1.3';
+export { USERSCRIPT_VERSION } from '../version';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const USERSCRIPT_VERSION = '1.3';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,8 @@ import path from 'path';
 import { componentTagger } from 'lovable-tagger';
 import { execSync } from 'child_process';
 import { VitePWA } from 'vite-plugin-pwa';
+import fs from 'fs';
+import { USERSCRIPT_VERSION } from './src/version';
 
 let commitHash = 'dev';
 let commitDate = 'dev';
@@ -33,6 +35,18 @@ export default defineConfig(({ mode }) => ({
       includeManifestIcons: false,
     }),
     mode === 'development' && componentTagger(),
+    {
+      name: 'inject-userscript-version',
+      apply: 'build',
+      writeBundle() {
+        const file = path.resolve(__dirname, 'dist/sora-userscript.user.js');
+        if (fs.existsSync(file)) {
+          let code = fs.readFileSync(file, 'utf8');
+          code = code.replace(/__USERSCRIPT_VERSION__/g, USERSCRIPT_VERSION);
+          fs.writeFileSync(file, code);
+        }
+      },
+    },
   ].filter(Boolean),
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- create `src/version.ts` and export `USERSCRIPT_VERSION`
- import the constant from config and dashboard
- replace hard-coded version in userscript with build-time placeholder
- inject userscript version into the built file in Vite config

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874338e249c8325b873b9dc32c05a19