### PR TITLE
Fix disclaimer fetch retry

### DIFF
--- a/src/components/DisclaimerModal.tsx
+++ b/src/components/DisclaimerModal.tsx
@@ -89,16 +89,12 @@ const DisclaimerModal: React.FC<DisclaimerModalProps> = ({
             } catch {
               // ignore localStorage errors
             }
+            setHasFetched(true);
           }
         })
         .catch((err) => {
           if (err.name !== 'AbortError') {
             setText('Failed to load disclaimer.');
-          }
-        })
-        .finally(() => {
-          if (!signal.aborted) {
-            setHasFetched(true);
           }
         });
     })();


### PR DESCRIPTION
## Summary
- update DisclaimerModal to only set `hasFetched` when text is retrieved
- avoid preventing future fetches after a failure

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687433ac3aec83258dbeb1e010103d35