### PR TITLE
Add accessible headings to CommandDialog

### DIFF
--- a/src/components/ui/__tests__/command-dialog.test.tsx
+++ b/src/components/ui/__tests__/command-dialog.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CommandDialog, CommandInput } from '../command';
+
+describe('CommandDialog accessibility', () => {
+  test('renders without console warnings', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <CommandDialog open onOpenChange={() => {}}>
+        <CommandInput placeholder="search" />
+      </CommandDialog>
+    );
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -4,7 +4,12 @@ import { Command as CommandPrimitive } from 'cmdk';
 import { Search } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
-import { Dialog, DialogContent } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -27,6 +32,10 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <DialogTitle className="sr-only">Command Palette</DialogTitle>
+        <DialogDescription className="sr-only">
+          Choose a command
+        </DialogDescription>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>


### PR DESCRIPTION
## Summary
- include hidden dialog title and description for accessibility
- add regression test ensuring CommandDialog logs no warnings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68743603adb883258eff5bb977d82679