### PR TITLE
Remove duplicate festival option

### DIFF
--- a/src/data/faceOptions.ts
+++ b/src/data/faceOptions.ts
@@ -144,7 +144,6 @@ export const makeupStyleOptions = [
   'henna',
   'mehndi',
   'wedding',
-  'festival',
   'holiday',
   'avant-garde glitter',
 ] as const;


### PR DESCRIPTION
## Summary
- remove a repeated `festival` entry from makeupStyleOptions

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874fab630108325b3c61d89967985f4