### PR TITLE
Fix disclaimer cache check

### DIFF
--- a/src/components/DisclaimerModal.tsx
+++ b/src/components/DisclaimerModal.tsx
@@ -56,18 +56,20 @@ const DisclaimerModal: React.FC<DisclaimerModalProps> = ({
 
     (async () => {
       try {
-        const cachedResponse = await caches.match(url);
-        if (cachedResponse) {
-          const txt = await cachedResponse.text();
-          if (!signal.aborted) {
-            setText(txt);
-            try {
-              localStorage.setItem(STORAGE_KEY, txt);
-            } catch {
-              // ignore localStorage errors
+        if (typeof window !== 'undefined' && window.caches) {
+          const cachedResponse = await window.caches.match(url);
+          if (cachedResponse) {
+            const txt = await cachedResponse.text();
+            if (!signal.aborted) {
+              setText(txt);
+              try {
+                localStorage.setItem(STORAGE_KEY, txt);
+              } catch {
+                // ignore localStorage errors
+              }
+              setHasFetched(true);
+              return;
             }
-            setHasFetched(true);
-            return;
           }
         }
       } catch {

--- a/src/components/__tests__/DisclaimerModal.test.tsx
+++ b/src/components/__tests__/DisclaimerModal.test.tsx
@@ -121,7 +121,7 @@ describe('DisclaimerModal', () => {
     const matchMock = jest.fn().mockResolvedValue({
       text: () => Promise.resolve('cache text'),
     } as Response);
-    (global as unknown as { caches: CacheStorage }).caches = {
+    (window as unknown as { caches: CacheStorage }).caches = {
       match: matchMock,
     } as unknown as CacheStorage;
 
@@ -136,7 +136,7 @@ describe('DisclaimerModal', () => {
     expect(matchMock).toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
 
-    delete (global as unknown as { caches?: CacheStorage }).caches;
+    delete (window as unknown as { caches?: CacheStorage }).caches;
   });
 
   test('no state update after unmount', async () => {


### PR DESCRIPTION
## Summary
- check for `window.caches` before using it in `DisclaimerModal`
- adjust tests to define `window.caches`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_6874fac44728832586a11976e0e5d388