### PR TITLE
Disable userscript debug by default

### DIFF
--- a/__tests__/sora-userscript.test.ts
+++ b/__tests__/sora-userscript.test.ts
@@ -38,10 +38,6 @@ describe('sora-userscript', () => {
       { type: 'SORA_USERSCRIPT_READY', version: expect.any(String) },
       '*',
     );
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      { type: 'SORA_DEBUG_PING' },
-      '*',
-    );
   });
 
   test('fills textarea on INSERT_SORA_JSON and acknowledges', async () => {
@@ -75,9 +71,7 @@ describe('sora-userscript', () => {
 
     await import(USERSCRIPT_PATH);
 
-    expect(debugSpy).toHaveBeenCalledWith(
-      `[Sora Injector] Not a Sora or Crafter page on host ${window.location.hostname}, exiting`,
-    );
+    expect(debugSpy).not.toHaveBeenCalled();
     debugSpy.mockRestore();
   });
 
@@ -115,10 +109,10 @@ describe('sora-userscript', () => {
 
     await import(USERSCRIPT_PATH);
 
-    expect(mockPostMessage).toHaveBeenCalledTimes(2);
+    expect(mockPostMessage).toHaveBeenCalledTimes(1);
 
     jest.advanceTimersByTime(250);
-    expect(mockPostMessage).toHaveBeenCalledTimes(4);
+    expect(mockPostMessage).toHaveBeenCalledTimes(2);
 
     window.dispatchEvent(
       new MessageEvent('message', {
@@ -131,7 +125,7 @@ describe('sora-userscript', () => {
     expect(clearSpy).toHaveBeenCalled();
 
     jest.advanceTimersByTime(250);
-    expect(mockPostMessage).toHaveBeenCalledTimes(4);
+    expect(mockPostMessage).toHaveBeenCalledTimes(2);
 
     clearSpy.mockRestore();
   });
@@ -156,7 +150,7 @@ describe('sora-userscript', () => {
       { type: 'SORA_DEBUG_PONG' },
       '*',
     );
-    expect(debugSpy).toHaveBeenCalledWith('[Sora Injector] Debug ping received');
+    expect(debugSpy).not.toHaveBeenCalled();
   });
 
   test('logs debug pong message', async () => {
@@ -173,8 +167,6 @@ describe('sora-userscript', () => {
       }),
     );
 
-    expect(debugSpy).toHaveBeenCalledWith(
-      '[Sora Injector] Debug pong received',
-    );
+    expect(debugSpy).not.toHaveBeenCalled();
   });
 });

--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -10,7 +10,7 @@
 
 (() => {
   const VERSION = '__USERSCRIPT_VERSION__';
-  const DEBUG = true;
+  const DEBUG = false;
   const SESSION_KEY = 'sora_json_payload';
   console.log(`[Sora Injector] Loaded v${VERSION}`);
   if (DEBUG) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,13 +36,18 @@ export default defineConfig(({ mode }) => ({
     }),
     mode === 'development' && componentTagger(),
     {
-      name: 'inject-userscript-version',
+      name: 'inject-userscript-meta',
       apply: 'build',
       writeBundle() {
         const file = path.resolve(__dirname, 'dist/sora-userscript.user.js');
         if (fs.existsSync(file)) {
           let code = fs.readFileSync(file, 'utf8');
-          code = code.replace(/__USERSCRIPT_VERSION__/g, USERSCRIPT_VERSION);
+          code = code
+            .replace(/__USERSCRIPT_VERSION__/g, USERSCRIPT_VERSION)
+            .replace(
+              /const DEBUG = false;/,
+              `const DEBUG = ${mode === 'development' ? 'true' : 'false'};`,
+            );
           fs.writeFileSync(file, code);
         }
       },


### PR DESCRIPTION
## Summary
- stop logging in the Sora userscript unless in dev mode
- inject DEBUG flag during dev builds
- adjust tests for DEBUG being disabled by default

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874facf9e08832594bf0d8abadb5e78