### PR TITLE
Add test for debug flag behavior

### DIFF
--- a/src/hooks/__tests__/use-sora-userscript.test.ts
+++ b/src/hooks/__tests__/use-sora-userscript.test.ts
@@ -59,6 +59,24 @@ describe('useSoraUserscript', () => {
     expect(debugSpy).toHaveBeenCalledWith('[Sora Loader] Debug ping received');
   });
 
+  test('does not log debug when debug disabled', () => {
+    const postSpy = jest.spyOn(window, 'postMessage');
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    renderHook(() => useSoraUserscript(false));
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type: 'SORA_DEBUG_PING' },
+          source: window,
+        }),
+      );
+    });
+
+    expect(postSpy).toHaveBeenCalledWith({ type: 'SORA_DEBUG_PONG' }, '*');
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
   test('logs when debug pong received', () => {
     const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
     renderHook(() => useSoraUserscript());


### PR DESCRIPTION
## Summary
- verify that useSoraUserscript does not log when debug is disabled

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877af9a7334832586c138973684fc1e