### PR TITLE
Add fallback test

### DIFF
--- a/src/__tests__/i18n.test.tsx
+++ b/src/__tests__/i18n.test.tsx
@@ -2,6 +2,10 @@ import { render, screen } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '../i18n';
 
+afterEach(() => {
+  i18n.changeLanguage('en');
+});
+
 test('renders spanish translation', () => {
   i18n.changeLanguage('es');
   render(
@@ -10,4 +14,14 @@ test('renders spanish translation', () => {
     </I18nextProvider>,
   );
   expect(screen.getByText('Copiar')).toBeTruthy();
+});
+
+test('falls back to english when language unsupported', () => {
+  i18n.changeLanguage('fr');
+  render(
+    <I18nextProvider i18n={i18n}>
+      <span>{i18n.t('copy')}</span>
+    </I18nextProvider>,
+  );
+  expect(screen.getByText('Copy')).toBeTruthy();
 });


### PR DESCRIPTION
## Summary
- verify i18n falls back to English

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877af67d7e48325b04bab7d1db1517c