### PR TITLE
Fix safeGet logging

### DIFF
--- a/src/lib/__tests__/storage.test.ts
+++ b/src/lib/__tests__/storage.test.ts
@@ -11,8 +11,10 @@ describe('storage utils', () => {
   });
 
   test('safeGet returns default when JSON.parse throws', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     localStorage.setItem('bad', '{oops');
     expect(safeGet('bad', 'fallback', true)).toBe('fallback');
+    expect(warnSpy).toHaveBeenCalled();
   });
 
   test('safeGet parses JSON when present', () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -8,7 +8,8 @@ export function safeGet<T = string>(
     if (value === null) return defaultValue;
     if (parse) return JSON.parse(value) as T;
     return value;
-  } catch {
+  } catch (err) {
+    console.warn('safeGet failed', key, err);
     return defaultValue;
   }
 }


### PR DESCRIPTION
## Summary
- log a warning when `safeGet` fails
- test that safeGet warns if JSON parsing fails

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_687f6663174083258bd57ac33501b399