### PR TITLE
Fix debug default in Sora userscript hook

### DIFF
--- a/src/hooks/__tests__/use-sora-userscript.test.ts
+++ b/src/hooks/__tests__/use-sora-userscript.test.ts
@@ -15,7 +15,7 @@ describe('useSoraUserscript', () => {
 
   test('updates state on message event', () => {
     const postSpy = jest.spyOn(window, 'postMessage');
-    const { result } = renderHook(() => useSoraUserscript());
+    const { result } = renderHook(() => useSoraUserscript(true));
     act(() => {
       window.dispatchEvent(
         new MessageEvent('message', {
@@ -44,7 +44,7 @@ describe('useSoraUserscript', () => {
   test('responds to debug ping with pong', () => {
     const postSpy = jest.spyOn(window, 'postMessage');
     const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
-    renderHook(() => useSoraUserscript());
+    renderHook(() => useSoraUserscript(true));
 
     act(() => {
       window.dispatchEvent(
@@ -79,7 +79,7 @@ describe('useSoraUserscript', () => {
 
   test('logs when debug pong received', () => {
     const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
-    renderHook(() => useSoraUserscript());
+    renderHook(() => useSoraUserscript(true));
 
     act(() => {
       window.dispatchEvent(

--- a/src/hooks/use-sora-userscript.ts
+++ b/src/hooks/use-sora-userscript.ts
@@ -6,7 +6,7 @@ import { useEffect, useRef, useState } from 'react';
  * @param debug - When true, verbose debug messages are logged to the console.
  * @returns A tuple with installation status and the detected version.
  */
-export function useSoraUserscript(debug = true) {
+export function useSoraUserscript(debug = false) {
   const [installed, setInstalled] = useState(false);
   const [version, setVersion] = useState<string | null>(null);
   const timeoutRef = useRef<number>();


### PR DESCRIPTION
## Summary
- disable debug output in `useSoraUserscript` by default
- pass `true` explicitly in tests that rely on debug behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f7f80a9c48325a16531ab5bc90a99