### PR TITLE
Add flag icons to language menu

### DIFF
--- a/public/flags/es.svg
+++ b/public/flags/es.svg
@@ -1,0 +1,23 @@
+<svg id="emoji" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+  <g id="color">
+    <rect x="5" y="17" width="62" height="38" fill="#f1b31c"/>
+    <path fill="#d22f27" d="M23,33v7a2.0059,2.0059,0,0,1-2,2H17a2.0059,2.0059,0,0,1-2-2V33"/>
+    <rect x="5" y="17" width="62" height="9" fill="#d22f27"/>
+    <rect x="5" y="46" width="62" height="9" fill="#d22f27"/>
+    <rect x="19" y="33" width="4" height="4" fill="#f1b31c"/>
+    <circle cx="19" cy="37" r="1.5" fill="#6a462f"/>
+    <g>
+      <line x1="27" x2="27" y1="33" y2="42" fill="none" stroke="#6a462f" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      <line x1="11" x2="11" y1="33" y2="42" fill="none" stroke="#6a462f" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      <path fill="none" stroke="#6a462f" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15,30a8.5678,8.5678,0,0,1,4-1"/>
+      <path fill="none" stroke="#6a462f" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M23,30a8.5678,8.5678,0,0,0-4-1"/>
+      <line x1="15" x2="23" y1="33" y2="33" fill="none" stroke="#6a462f" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      <path fill="none" stroke="#6a462f" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M23,33v7a2.0059,2.0059,0,0,1-2,2H17a2.0059,2.0059,0,0,1-2-2V33"/>
+      <line x1="10" x2="12" y1="42" y2="42" fill="none" stroke="#6a462f" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      <line x1="26" x2="28" y1="42" y2="42" fill="none" stroke="#6a462f" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    </g>
+  </g>
+  <g id="line">
+    <rect x="5" y="17" width="62" height="38" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+  </g>
+</svg>

--- a/public/flags/pt-PT.svg
+++ b/public/flags/pt-PT.svg
@@ -1,0 +1,20 @@
+<svg id="emoji" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+  <g id="color">
+    <rect x="5" y="17" width="62" height="38" fill="#d22f27"/>
+    <rect x="5" y="17" width="21" height="38" fill="#5c9e31"/>
+    <circle cx="26" cy="36" r="12" fill="none" stroke="#fcea2b" stroke-miterlimit="10" stroke-width="2"/>
+    <line x1="26" x2="26" y1="24" y2="48" fill="none" stroke="#fcea2b" stroke-linecap="round" stroke-linejoin="round"/>
+    <polygon fill="none" stroke="#fcea2b" stroke-linecap="round" stroke-linejoin="round" points="26 39.5 17 44 35 44 26 39.5"/>
+    <polygon fill="none" stroke="#fcea2b" stroke-linecap="round" stroke-linejoin="round" points="26 33.5 35 28 26.5 29.5 17 28 26 33.5"/>
+    <polygon fill="none" stroke="#fcea2b" stroke-linecap="round" stroke-linejoin="round" points="38 36 26 41 14 36 26 31 38 36"/>
+    <path fill="#fff" stroke="#d22f27" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.2,29H31.8V39.1c0,2.5-2.6,4.6-5.8,4.6h0c-3.2,0-5.8-2.1-5.8-4.6V29Z"/>
+    <circle cx="26" cy="32.8" r="0.7" fill="#1e50a0" stroke="#1e50a0" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="26" cy="38.7" r="0.7" fill="#1e50a0" stroke="#1e50a0" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="26" cy="35.7" r="0.7" fill="#1e50a0" stroke="#1e50a0" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="29" cy="35.7" r="0.7" fill="#1e50a0" stroke="#1e50a0" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="23" cy="35.7" r="0.7" fill="#1e50a0" stroke="#1e50a0" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <g id="line">
+    <rect x="5" y="17" width="62" height="38" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+  </g>
+</svg>

--- a/public/flags/ru.svg
+++ b/public/flags/ru.svg
@@ -1,0 +1,10 @@
+<svg id="emoji" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+  <g id="color">
+    <rect x="5" y="17" width="62" height="38" fill="#d22f27"/>
+    <rect x="5" y="17" width="62" height="13" fill="#fff"/>
+    <rect x="5" y="30" width="62" height="12" fill="#1e50a0"/>
+  </g>
+  <g id="line">
+    <rect x="5" y="17" width="62" height="38" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+  </g>
+</svg>

--- a/public/flags/us.svg
+++ b/public/flags/us.svg
@@ -1,0 +1,28 @@
+<svg id="emoji" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+  <g id="color">
+    <rect x="5" y="17" width="62" height="38" fill="#fff"/>
+    <rect x="5" y="17" width="62" height="5" fill="#d22f27"/>
+    <rect x="5" y="26" width="62" height="4" fill="#d22f27"/>
+    <rect x="5" y="34" width="62" height="4" fill="#d22f27"/>
+    <rect x="5" y="17" width="32" height="21" fill="#1e50a0"/>
+    <rect x="5" y="42" width="62" height="4" fill="#d22f27"/>
+    <circle cx="9.5" cy="22" r="1.75" fill="#fff"/>
+    <circle cx="17.5" cy="22" r="1.75" fill="#fff"/>
+    <circle cx="25.5" cy="22" r="1.75" fill="#fff"/>
+    <circle cx="33.5" cy="22" r="1.75" fill="#fff"/>
+    <circle cx="29.5" cy="26" r="1.75" fill="#fff"/>
+    <circle cx="21.5" cy="26" r="1.75" fill="#fff"/>
+    <circle cx="13.5" cy="26" r="1.75" fill="#fff"/>
+    <circle cx="9.5" cy="30" r="1.75" fill="#fff"/>
+    <circle cx="17.5" cy="30" r="1.75" fill="#fff"/>
+    <circle cx="25.5" cy="30" r="1.75" fill="#fff"/>
+    <circle cx="33.5" cy="30" r="1.75" fill="#fff"/>
+    <circle cx="29.5" cy="34" r="1.75" fill="#fff"/>
+    <circle cx="21.5" cy="34" r="1.75" fill="#fff"/>
+    <circle cx="13.5" cy="34" r="1.75" fill="#fff"/>
+    <rect x="5" y="50" width="62" height="5" fill="#d22f27"/>
+  </g>
+  <g id="line">
+    <rect x="5" y="17" width="62" height="38" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+  </g>
+</svg>

--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -35,6 +35,7 @@ import {
   Trash2,
   Send,
   Cog,
+  Languages,
   ChevronDown,
   ChevronUp,
   MoveDown,
@@ -284,21 +285,22 @@ export const ActionBar: React.FC<ActionBarProps> = ({
             size="sm"
             className={cn({ 'gap-2': actionLabelsEnabled })}
           >
-            {t('language')}
+            <Languages className="w-4 h-4" />
+            {actionLabelsEnabled && t('language')}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
-          <DropdownMenuItem onSelect={() => setLocale('en')}>
-            English
+          <DropdownMenuItem onSelect={() => setLocale('en')} className="gap-2">
+            <img src="/flags/us.svg" alt="English" className="w-4 h-4" /> English
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('es')}>
-            Español
+          <DropdownMenuItem onSelect={() => setLocale('es')} className="gap-2">
+            <img src="/flags/es.svg" alt="Español" className="w-4 h-4" /> Español
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('pt-PT')}>
-            Português
+          <DropdownMenuItem onSelect={() => setLocale('pt-PT')} className="gap-2">
+            <img src="/flags/pt-PT.svg" alt="Português" className="w-4 h-4" /> Português
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('ru')}>
-            Русский
+          <DropdownMenuItem onSelect={() => setLocale('ru')} className="gap-2">
+            <img src="/flags/ru.svg" alt="Русский" className="w-4 h-4" /> Русский
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
## Summary
- include language icon on the selector button
- add flag icons for each language option

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880dcdc61a083259b85497422a4a516