### PR TITLE
Localize ShareModal messages

### DIFF
--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { trackEvent } from '@/lib/analytics';
 import { useTracking } from '@/hooks/use-tracking';
+import { useTranslation } from 'react-i18next';
 import {
   Dialog,
   DialogContent,
@@ -33,10 +34,11 @@ export const ShareModal: React.FC<ShareModalProps> = ({
 }) => {
   const [copied, setCopied] = useState(false);
   const [trackingEnabled] = useTracking();
+  const { t } = useTranslation();
   const shareToFacebook = () => {
     const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}&quote=${encodeURIComponent('Check out my Sora prompt configuration!')}`;
     window.open(url, '_blank', 'noopener,width=600,height=400');
-    toast.success('Shared to Facebook!');
+    toast.success(t('sharedToFacebook'));
     trackEvent(trackingEnabled, 'share_facebook');
   };
 
@@ -46,7 +48,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
     );
     const url = `https://twitter.com/intent/tweet?text=${text}&url=${encodeURIComponent(window.location.href)}`;
     window.open(url, '_blank', 'noopener,width=600,height=400');
-    toast.success('Shared to Twitter!');
+    toast.success(t('sharedToTwitter'));
     trackEvent(trackingEnabled, 'share_twitter');
   };
 
@@ -56,7 +58,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
     );
     const url = `https://wa.me/?text=${text}`;
     window.open(url, '_blank', 'noopener');
-    toast.success('Shared to WhatsApp!');
+    toast.success(t('sharedToWhatsApp'));
     trackEvent(trackingEnabled, 'share_whatsapp');
   };
 
@@ -66,23 +68,23 @@ export const ShareModal: React.FC<ShareModalProps> = ({
     );
     const url = `https://t.me/share/url?url=${encodeURIComponent(window.location.href)}&text=${text}`;
     window.open(url, '_blank', 'noopener');
-    toast.success('Shared to Telegram!');
+    toast.success(t('sharedToTelegram'));
     trackEvent(trackingEnabled, 'share_telegram');
   };
 
   const copyLink = async () => {
     if (!('clipboard' in navigator)) {
-      toast.error('Clipboard not supported');
+      toast.error(t('clipboardUnsupported'));
       return;
     }
     try {
       await navigator.clipboard.writeText(window.location.href);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
-      toast.success('Link copied to clipboard!');
+      toast.success(t('linkCopied'));
       trackEvent(trackingEnabled, 'copy_link');
     } catch (err) {
-      toast.error('Failed to copy link');
+      toast.error(t('copyFailed'));
     }
   };
 
@@ -90,27 +92,25 @@ export const ShareModal: React.FC<ShareModalProps> = ({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Share your JSON prompt</DialogTitle>
-          <DialogDescription>
-            Choose a platform below or copy a direct link.
-          </DialogDescription>
+          <DialogTitle>{t('shareTitle')}</DialogTitle>
+          <DialogDescription>{t('shareDescription')}</DialogDescription>
         </DialogHeader>
         <div className="grid grid-cols-2 gap-4 py-4">
           <Button onClick={shareToFacebook} variant="outline" className="gap-2">
             <Facebook className="w-4 h-4 text-blue-600" />
-            Facebook
+            {t('shareFacebook')}
           </Button>
           <Button onClick={shareToTwitter} variant="outline" className="gap-2">
             <Twitter className="w-4 h-4 text-blue-400" />
-            Twitter/X
+            {t('shareTwitter')}
           </Button>
           <Button onClick={shareToWhatsApp} variant="outline" className="gap-2">
             <MessageCircle className="w-4 h-4 text-green-600" />
-            WhatsApp
+            {t('shareWhatsApp')}
           </Button>
           <Button onClick={shareToTelegram} variant="outline" className="gap-2">
             <Send className="w-4 h-4 text-blue-500" />
-            Telegram
+            {t('shareTelegram')}
           </Button>
         </div>
         <div className="flex justify-center pt-4 border-t">
@@ -120,7 +120,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
             ) : (
               <Copy className="w-4 h-4" />
             )}
-            Copy Link
+            {t('copyLink')}
           </Button>
         </div>
       </DialogContent>

--- a/src/components/__tests__/ShareModal.test.tsx
+++ b/src/components/__tests__/ShareModal.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { ShareModal } from '../ShareModal';
+import i18n from '@/i18n';
 import { trackEvent } from '@/lib/analytics';
 import { useTracking } from '@/hooks/use-tracking';
 import { toast } from '@/components/ui/sonner-toast';
@@ -120,7 +121,7 @@ describe('ShareModal', () => {
     await waitFor(() =>
       expect(writeText).toHaveBeenCalledWith(window.location.href),
     );
-    expect(toast.success).toHaveBeenCalledWith('Link copied to clipboard!');
+    expect(toast.success).toHaveBeenCalledWith(i18n.t('linkCopied'));
     expect(trackEvent).toHaveBeenCalledWith(true, 'copy_link');
     await waitFor(() =>
       expect(btn.querySelector('svg')?.getAttribute('class')).toContain(
@@ -144,7 +145,7 @@ describe('ShareModal', () => {
     delete nav.clipboard;
     renderModal();
     fireEvent.click(screen.getByRole('button', { name: /copy link/i }));
-    expect(toast.error).toHaveBeenCalledWith('Clipboard not supported');
+    expect(toast.error).toHaveBeenCalledWith(i18n.t('clipboardUnsupported'));
     expect(trackEvent).not.toHaveBeenCalled();
     if (original !== undefined) {
       Object.defineProperty(navigator, 'clipboard', {
@@ -164,7 +165,7 @@ describe('ShareModal', () => {
     renderModal();
     fireEvent.click(screen.getByRole('button', { name: /copy link/i }));
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith('Failed to copy link'),
+      expect(toast.error).toHaveBeenCalledWith(i18n.t('copyFailed')),
     );
     expect(trackEvent).not.toHaveBeenCalled();
     Object.defineProperty(navigator, 'clipboard', {

--- a/src/components/__tests__/clipboardFallback.test.tsx
+++ b/src/components/__tests__/clipboardFallback.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import i18n from '@/i18n';
 import Dashboard from '../Dashboard';
 jest.mock('../Footer', () => ({ __esModule: true, default: () => null }));
 import { ShareModal } from '../ShareModal';
@@ -79,7 +80,7 @@ describe('clipboard fallback', () => {
     render(<ShareModal isOpen={true} onClose={() => {}} jsonContent="{}" />);
     const btn = screen.getByRole('button', { name: /copy link/i });
     fireEvent.click(btn);
-    expect(toast.error).toHaveBeenCalledWith('Clipboard not supported');
+    expect(toast.error).toHaveBeenCalledWith(i18n.t('clipboardUnsupported'));
     restore();
   });
 
@@ -94,7 +95,7 @@ describe('clipboard fallback', () => {
       />,
     );
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith('Clipboard not supported'),
+      expect(toast.error).toHaveBeenCalledWith(i18n.t('clipboardUnsupported')),
     );
     restore();
   });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -87,5 +87,19 @@
   "clearHistoryDescription": "This will remove all entries permanently.",
   "clearActionsTitle": "Clear latest actions?",
   "clearActionsDescription": "This will remove all action entries permanently.",
-  "entryDeleted": "Entry deleted!"
+  "entryDeleted": "Entry deleted!",
+  "shareTitle": "Share your JSON prompt",
+  "shareDescription": "Choose a platform below or copy a direct link.",
+  "shareFacebook": "Facebook",
+  "shareTwitter": "Twitter/X",
+  "shareWhatsApp": "WhatsApp",
+  "shareTelegram": "Telegram",
+  "copyLink": "Copy Link",
+  "sharedToFacebook": "Shared to Facebook!",
+  "sharedToTwitter": "Shared to Twitter!",
+  "sharedToWhatsApp": "Shared to WhatsApp!",
+  "sharedToTelegram": "Shared to Telegram!",
+  "linkCopied": "Link copied to clipboard!",
+  "copyFailed": "Failed to copy link",
+  "clipboardUnsupported": "Clipboard not supported"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -87,5 +87,19 @@
   "clearHistoryDescription": "Esto eliminará todas las entradas permanentemente.",
   "clearActionsTitle": "¿Limpiar acciones recientes?",
   "clearActionsDescription": "Esto eliminará todas las acciones permanentemente.",
-  "entryDeleted": "¡Entrada eliminada!"
+  "entryDeleted": "¡Entrada eliminada!",
+  "shareTitle": "Comparte tu JSON prompt",
+  "shareDescription": "Elige una plataforma o copia un enlace directo.",
+  "shareFacebook": "Facebook",
+  "shareTwitter": "Twitter/X",
+  "shareWhatsApp": "WhatsApp",
+  "shareTelegram": "Telegram",
+  "copyLink": "Copiar enlace",
+  "sharedToFacebook": "¡Compartido en Facebook!",
+  "sharedToTwitter": "¡Compartido en Twitter!",
+  "sharedToWhatsApp": "¡Compartido en WhatsApp!",
+  "sharedToTelegram": "¡Compartido en Telegram!",
+  "linkCopied": "¡Enlace copiado al portapapeles!",
+  "copyFailed": "Error al copiar el enlace",
+  "clipboardUnsupported": "Portapapeles no soportado"
 }

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -87,5 +87,19 @@
   "clearHistoryDescription": "Isto vai remover todas as entradas permanentemente.",
   "clearActionsTitle": "Limpar ações recentes?",
   "clearActionsDescription": "Isto vai remover todas as ações permanentemente.",
-  "entryDeleted": "Entrada removida!"
+  "entryDeleted": "Entrada removida!",
+  "shareTitle": "Partilhar o seu JSON",
+  "shareDescription": "Escolha uma plataforma ou copie um link direto.",
+  "shareFacebook": "Facebook",
+  "shareTwitter": "Twitter/X",
+  "shareWhatsApp": "WhatsApp",
+  "shareTelegram": "Telegram",
+  "copyLink": "Copiar link",
+  "sharedToFacebook": "Partilhado no Facebook!",
+  "sharedToTwitter": "Partilhado no Twitter!",
+  "sharedToWhatsApp": "Partilhado no WhatsApp!",
+  "sharedToTelegram": "Partilhado no Telegram!",
+  "linkCopied": "Link copiado para a área de transferência!",
+  "copyFailed": "Falha ao copiar o link",
+  "clipboardUnsupported": "Área de transferência não suportada"
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -87,5 +87,19 @@
   "clearHistoryDescription": "Все записи будут удалены безвозвратно.",
   "clearActionsTitle": "Очистить последние действия?",
   "clearActionsDescription": "Все записи действий будут удалены безвозвратно.",
-  "entryDeleted": "Запись удалена!"
+  "entryDeleted": "Запись удалена!",
+  "shareTitle": "Поделиться JSON-промптом",
+  "shareDescription": "Выберите платформу или скопируйте прямую ссылку.",
+  "shareFacebook": "Facebook",
+  "shareTwitter": "Twitter/X",
+  "shareWhatsApp": "WhatsApp",
+  "shareTelegram": "Telegram",
+  "copyLink": "Скопировать ссылку",
+  "sharedToFacebook": "Поделились в Facebook!",
+  "sharedToTwitter": "Поделились в Twitter!",
+  "sharedToWhatsApp": "Поделились в WhatsApp!",
+  "sharedToTelegram": "Поделились в Telegram!",
+  "linkCopied": "Ссылка скопирована в буфер обмена!",
+  "copyFailed": "Не удалось скопировать ссылку",
+  "clipboardUnsupported": "Буфер обмена не поддерживается"
 }


### PR DESCRIPTION
## Summary
- use i18next translations throughout `ShareModal`
- add share dialog strings to locale files
- adjust ShareModal tests for new translations
- ensure clipboard fallback tests load i18n

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880f8e24f2083258cecc649b0b0ea38