### PR TITLE
Fix and localize i18n resources

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -290,86 +290,294 @@ export const ActionBar: React.FC<ActionBarProps> = ({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
-          <DropdownMenuItem onSelect={() => setLocale('en-US')} className="gap-2">
-            <img src="/flags/en-US.svg" alt="English (US)" className="w-4 h-4" /> English (US)
+          <DropdownMenuItem
+            onSelect={() => setLocale('en-US')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/en-US.svg"
+              alt="English (United States)"
+              className="w-4 h-4"
+            />{' '}
+            English (United States)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('es-ES')} className="gap-2">
-            <img src="/flags/es-ES.svg" alt="Español (ES)" className="w-4 h-4" /> Español (ES)
+          <DropdownMenuItem
+            onSelect={() => setLocale('es-ES')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/es-ES.svg"
+              alt="Español (España)"
+              className="w-4 h-4"
+            />{' '}
+            Español (España)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('pt-PT')} className="gap-2">
-            <img src="/flags/pt-PT.svg" alt="Português (PT)" className="w-4 h-4" /> Português (PT)
+          <DropdownMenuItem
+            onSelect={() => setLocale('pt-PT')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/pt-PT.svg"
+              alt="Português (Portugal)"
+              className="w-4 h-4"
+            />{' '}
+            Português (Portugal)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('ru-RU')} className="gap-2">
-            <img src="/flags/ru-RU.svg" alt="Русский" className="w-4 h-4" /> Русский
+          <DropdownMenuItem
+            onSelect={() => setLocale('ru-RU')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/ru-RU.svg"
+              alt="Русский (Россия)"
+              className="w-4 h-4"
+            />{' '}
+            Русский (Россия)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('pt-BR')} className="gap-2">
-            <img src="/flags/pt-BR.svg" alt="Português (BR)" className="w-4 h-4" /> Português (BR)
+          <DropdownMenuItem
+            onSelect={() => setLocale('pt-BR')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/pt-BR.svg"
+              alt="Português (Brasil)"
+              className="w-4 h-4"
+            />{' '}
+            Português (Brasil)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('fr-FR')} className="gap-2">
-            <img src="/flags/fr-FR.svg" alt="Français" className="w-4 h-4" /> Français
+          <DropdownMenuItem
+            onSelect={() => setLocale('fr-FR')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/fr-FR.svg"
+              alt="Français (France)"
+              className="w-4 h-4"
+            />{' '}
+            Français (France)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('de-DE')} className="gap-2">
-            <img src="/flags/de-DE.svg" alt="Deutsch" className="w-4 h-4" /> Deutsch
+          <DropdownMenuItem
+            onSelect={() => setLocale('de-DE')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/de-DE.svg"
+              alt="Deutsch (Deutschland)"
+              className="w-4 h-4"
+            />{' '}
+            Deutsch (Deutschland)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('zh-CN')} className="gap-2">
-            <img src="/flags/zh-CN.svg" alt="中文" className="w-4 h-4" /> 中文
+          <DropdownMenuItem
+            onSelect={() => setLocale('zh-CN')}
+            className="gap-2"
+          >
+            <img src="/flags/zh-CN.svg" alt="中文 (中国)" className="w-4 h-4" />{' '}
+            中文 (中国)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('it-IT')} className="gap-2">
-            <img src="/flags/it-IT.svg" alt="Italiano" className="w-4 h-4" /> Italiano
+          <DropdownMenuItem
+            onSelect={() => setLocale('it-IT')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/it-IT.svg"
+              alt="Italiano (Italia)"
+              className="w-4 h-4"
+            />{' '}
+            Italiano (Italia)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('es-MX')} className="gap-2">
-            <img src="/flags/es-MX.svg" alt="Español (MX)" className="w-4 h-4" /> Español (MX)
+          <DropdownMenuItem
+            onSelect={() => setLocale('es-MX')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/es-MX.svg"
+              alt="Español (México)"
+              className="w-4 h-4"
+            />{' '}
+            Español (México)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('en-GB')} className="gap-2">
-            <img src="/flags/en-GB.svg" alt="English (UK)" className="w-4 h-4" /> English (UK)
+          <DropdownMenuItem
+            onSelect={() => setLocale('en-GB')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/en-GB.svg"
+              alt="English (United Kingdom)"
+              className="w-4 h-4"
+            />{' '}
+            English (United Kingdom)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('bn-IN')} className="gap-2">
-            <img src="/flags/bn-IN.svg" alt="বাংলা" className="w-4 h-4" /> বাংলা
+          <DropdownMenuItem
+            onSelect={() => setLocale('bn-IN')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/bn-IN.svg"
+              alt="বাংলা (ভারত)"
+              className="w-4 h-4"
+            />{' '}
+            বাংলা (ভারত)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('ja-JP')} className="gap-2">
-            <img src="/flags/ja-JP.svg" alt="日本語" className="w-4 h-4" /> 日本語
+          <DropdownMenuItem
+            onSelect={() => setLocale('ja-JP')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/ja-JP.svg"
+              alt="日本語 (日本)"
+              className="w-4 h-4"
+            />{' '}
+            日本語 (日本)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('en-PR')} className="gap-2">
-            <img src="/flags/en-PR.svg" alt="Pirate" className="w-4 h-4" /> Pirate
+          <DropdownMenuItem
+            onSelect={() => setLocale('en-PR')}
+            className="gap-2"
+          >
+            <img src="/flags/en-PR.svg" alt="Pirate" className="w-4 h-4" />{' '}
+            Pirate
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('ko-KR')} className="gap-2">
-            <img src="/flags/ko-KR.svg" alt="한국어" className="w-4 h-4" /> 한국어
+          <DropdownMenuItem
+            onSelect={() => setLocale('ko-KR')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/ko-KR.svg"
+              alt="한국어 (대한민국)"
+              className="w-4 h-4"
+            />{' '}
+            한국어 (대한민국)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('ro-RO')} className="gap-2">
-            <img src="/flags/ro-RO.svg" alt="Română" className="w-4 h-4" /> Română
+          <DropdownMenuItem
+            onSelect={() => setLocale('ro-RO')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/ro-RO.svg"
+              alt="Română (România)"
+              className="w-4 h-4"
+            />{' '}
+            Română (România)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('sv-SE')} className="gap-2">
-            <img src="/flags/sv-SE.svg" alt="Svenska" className="w-4 h-4" /> Svenska
+          <DropdownMenuItem
+            onSelect={() => setLocale('sv-SE')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/sv-SE.svg"
+              alt="Svenska (Sverige)"
+              className="w-4 h-4"
+            />{' '}
+            Svenska (Sverige)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('uk-UA')} className="gap-2">
-            <img src="/flags/uk-UA.svg" alt="Українська" className="w-4 h-4" /> Українська
+          <DropdownMenuItem
+            onSelect={() => setLocale('uk-UA')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/uk-UA.svg"
+              alt="Українська (Україна)"
+              className="w-4 h-4"
+            />{' '}
+            Українська (Україна)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('ne-NP')} className="gap-2">
-            <img src="/flags/ne-NP.svg" alt="नेपाली" className="w-4 h-4" /> नेपाली
+          <DropdownMenuItem
+            onSelect={() => setLocale('ne-NP')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/ne-NP.svg"
+              alt="नेपाली (नेपाल)"
+              className="w-4 h-4"
+            />{' '}
+            नेपाली (नेपाल)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('da-DK')} className="gap-2">
-            <img src="/flags/da-DK.svg" alt="Dansk" className="w-4 h-4" /> Dansk
+          <DropdownMenuItem
+            onSelect={() => setLocale('da-DK')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/da-DK.svg"
+              alt="Dansk (Danmark)"
+              className="w-4 h-4"
+            />{' '}
+            Dansk (Danmark)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('et-EE')} className="gap-2">
-            <img src="/flags/et-EE.svg" alt="Eesti" className="w-4 h-4" /> Eesti
+          <DropdownMenuItem
+            onSelect={() => setLocale('et-EE')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/et-EE.svg"
+              alt="Eesti (Eesti)"
+              className="w-4 h-4"
+            />{' '}
+            Eesti (Eesti)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('fi-FI')} className="gap-2">
-            <img src="/flags/fi-FI.svg" alt="Suomi" className="w-4 h-4" /> Suomi
+          <DropdownMenuItem
+            onSelect={() => setLocale('fi-FI')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/fi-FI.svg"
+              alt="Suomi (Suomi)"
+              className="w-4 h-4"
+            />{' '}
+            Suomi (Suomi)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('el-GR')} className="gap-2">
-            <img src="/flags/el-GR.svg" alt="Ελληνικά" className="w-4 h-4" /> Ελληνικά
+          <DropdownMenuItem
+            onSelect={() => setLocale('el-GR')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/el-GR.svg"
+              alt="Ελληνικά (Ελλάδα)"
+              className="w-4 h-4"
+            />{' '}
+            Ελληνικά (Ελλάδα)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('th-TH')} className="gap-2">
-            <img src="/flags/th-TH.svg" alt="ไทย" className="w-4 h-4" /> ไทย
+          <DropdownMenuItem
+            onSelect={() => setLocale('th-TH')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/th-TH.svg"
+              alt="ไทย (ประเทศไทย)"
+              className="w-4 h-4"
+            />{' '}
+            ไทย (ประเทศไทย)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('de-AT')} className="gap-2">
-            <img src="/flags/de-AT.svg" alt="Deutsch (AT)" className="w-4 h-4" /> Deutsch (AT)
+          <DropdownMenuItem
+            onSelect={() => setLocale('de-AT')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/de-AT.svg"
+              alt="Deutsch (Österreich)"
+              className="w-4 h-4"
+            />{' '}
+            Deutsch (Österreich)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('fr-BE')} className="gap-2">
-            <img src="/flags/fr-BE.svg" alt="Français (BE)" className="w-4 h-4" /> Français (BE)
+          <DropdownMenuItem
+            onSelect={() => setLocale('fr-BE')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/fr-BE.svg"
+              alt="Français (Belgique)"
+              className="w-4 h-4"
+            />{' '}
+            Français (Belgique)
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setLocale('es-AR')} className="gap-2">
-            <img src="/flags/es-AR.svg" alt="Español (AR)" className="w-4 h-4" /> Español (AR)
+          <DropdownMenuItem
+            onSelect={() => setLocale('es-AR')}
+            className="gap-2"
+          >
+            <img
+              src="/flags/es-AR.svg"
+              alt="Español (Argentina)"
+              className="w-4 h-4"
+            />{' '}
+            Español (Argentina)
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -27,8 +27,6 @@ import thTH from './locales/th-TH.json';
 import deAT from './locales/de-AT.json';
 import frBE from './locales/fr-BE.json';
 import esAR from './locales/es-AR.json';
-import jaJP from './locales/ja-JP.json';
-import zhCN from './locales/zh-CN.json';
 
 const resources = {
   'en-US': { translation: enUS },
@@ -58,8 +56,6 @@ const resources = {
   'de-AT': { translation: deAT },
   'fr-BE': { translation: frBE },
   'es-AR': { translation: esAR },
-  'ja-JP': { translation: jaJP },
-  'zh-CN': { translation: zhCN },
 };
 
 i18n.use(initReactI18next).init({

--- a/src/locales/bn-IN.json
+++ b/src/locales/bn-IN.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "ভাষা",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/da-DK.json
+++ b/src/locales/da-DK.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "Sprog",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/de-AT.json
+++ b/src/locales/de-AT.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "Sprache",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "Sprache",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/el-GR.json
+++ b/src/locales/el-GR.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "Γλώσσα",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/en-PR.json
+++ b/src/locales/en-PR.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "Lingo",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/et-EE.json
+++ b/src/locales/et-EE.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "Keel",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/fi-FI.json
+++ b/src/locales/fi-FI.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "Kieli",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/fr-BE.json
+++ b/src/locales/fr-BE.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "Langue",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "Lingua",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "언어",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/ne-NP.json
+++ b/src/locales/ne-NP.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "भाषा",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/ro-RO.json
+++ b/src/locales/ro-RO.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "Limbă",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "Språk",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/th-TH.json
+++ b/src/locales/th-TH.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "ภาษา",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",

--- a/src/locales/uk-UA.json
+++ b/src/locales/uk-UA.json
@@ -37,7 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
-  "language": "Language",
+  "language": "Мова",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",
   "sponsor": "Sponsor",


### PR DESCRIPTION
## Summary
- fix duplicate language resources
- localize "language" string in several locale files
- display locale names as `Language (Country)` in the language menu

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68811a6d5d888325832e17fc674f334d