### PR TITLE
Add undo/redo history

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -29,6 +29,8 @@ import {
   History,
   RotateCcw,
   RefreshCw,
+  Undo2,
+  Redo2,
   Shuffle,
   Eye,
   EyeOff,
@@ -42,6 +44,10 @@ import {
 } from 'lucide-react';
 
 interface ActionBarProps {
+  onUndo: () => void;
+  onRedo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
   onCopy: () => void;
   onClear: () => void;
   onShare: () => void;
@@ -68,6 +74,10 @@ interface ActionBarProps {
 }
 
 export const ActionBar: React.FC<ActionBarProps> = ({
+  onUndo,
+  onRedo,
+  canUndo,
+  canRedo,
   onCopy,
   onClear,
   onShare,
@@ -131,6 +141,26 @@ export const ActionBar: React.FC<ActionBarProps> = ({
           {actionLabelsEnabled && t('sendToSora')}
         </Button>
       )}
+      <Button
+        onClick={onUndo}
+        variant="outline"
+        size="sm"
+        disabled={!canUndo}
+        className={cn({ 'gap-2': actionLabelsEnabled })}
+      >
+        <Undo2 className="w-4 h-4" />
+        {actionLabelsEnabled && t('undo')}
+      </Button>
+      <Button
+        onClick={onRedo}
+        variant="outline"
+        size="sm"
+        disabled={!canRedo}
+        className={cn({ 'gap-2': actionLabelsEnabled })}
+      >
+        <Redo2 className="w-4 h-4" />
+        {actionLabelsEnabled && t('redo')}
+      </Button>
       <Button
         onClick={onCopy}
         variant="outline"

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Sun,
   Moon,
@@ -31,6 +31,7 @@ import { useLogo } from '@/hooks/use-logo';
 import { useActionLabels } from '@/hooks/use-action-labels';
 import { useSoraUserscript } from '@/hooks/use-sora-userscript';
 import { useActionHistory } from '@/hooks/use-action-history';
+import { useUndoRedo } from '@/hooks/use-undo-redo';
 import { trackEvent } from '@/lib/analytics';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { generateJson } from '@/lib/generateJson';
@@ -48,7 +49,14 @@ import { useLocale } from '@/hooks/use-locale';
 const Dashboard = () => {
   const { t } = useTranslation();
   useLocale();
-  const [options, setOptions] = useState<SoraOptions>(() => {
+  const {
+    state: options,
+    setState: setOptions,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+  } = useUndoRedo<SoraOptions>(() => {
     try {
       const stored = safeGet('currentJson');
       if (stored) {
@@ -560,6 +568,10 @@ const Dashboard = () => {
       </div>
 
       <ActionBar
+        onUndo={undo}
+        onRedo={redo}
+        canUndo={canUndo}
+        canRedo={canRedo}
         onCopy={copyToClipboard}
         onClear={clearJson}
         onShare={shareJson}

--- a/src/components/__tests__/ActionBar.test.tsx
+++ b/src/components/__tests__/ActionBar.test.tsx
@@ -80,6 +80,10 @@ function createProps(
   overrides: Partial<React.ComponentProps<typeof ActionBar>> = {},
 ) {
   return {
+    onUndo: jest.fn(),
+    onRedo: jest.fn(),
+    canUndo: true,
+    canRedo: true,
     onCopy: jest.fn(),
     onClear: jest.fn(),
     onShare: jest.fn(),
@@ -120,6 +124,24 @@ describe('ActionBar', () => {
     const { unmount } = render(<ActionBar {...props} />);
     fireEvent.click(screen.getByRole('button', { name: /copy/i }));
     expect(props.onCopy).toHaveBeenCalled();
+  });
+
+  test('Undo and redo buttons call handlers', () => {
+    const props = createProps();
+    render(<ActionBar {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /undo/i }));
+    expect(props.onUndo).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: /redo/i }));
+    expect(props.onRedo).toHaveBeenCalled();
+  });
+
+  test('undo/redo disabled states', () => {
+    const props = createProps({ canUndo: false, canRedo: false });
+    render(<ActionBar {...props} />);
+    const undoBtn = screen.getByRole('button', { name: /undo/i });
+    const redoBtn = screen.getByRole('button', { name: /redo/i });
+    expect(undoBtn.getAttribute('disabled')).not.toBeNull();
+    expect(redoBtn.getAttribute('disabled')).not.toBeNull();
   });
 
   test('Clear spins then resets', () => {

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -10,6 +10,7 @@ import Dashboard from '../Dashboard';
 import { toast } from '@/components/ui/sonner-toast';
 import { trackEvent } from '@/lib/analytics';
 import type { SoraOptions } from '@/lib/soraOptions';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { useSoraUserscript } from '@/hooks/use-sora-userscript';
 
 let copyFn: ((json: string) => void) | null = null;
@@ -274,6 +275,40 @@ describe('Dashboard interactions', () => {
       const history = JSON.parse(localStorage.getItem('jsonHistory') || '[]');
       expect(history).toHaveLength(1);
       expect(history[0].json).toContain('foo');
+    });
+  });
+
+  test('undo and redo revert option changes', async () => {
+    render(<Dashboard />);
+    await waitFor(() => expect(updateFn).not.toBeNull());
+
+    act(() => {
+      updateFn?.({ prompt: 'foo' });
+    });
+
+    await waitFor(() => {
+      const json = JSON.parse(localStorage.getItem('currentJson') || '{}');
+      expect(json.prompt).toBe('foo');
+    });
+
+    const undoButton = screen.getByRole('button', { name: /undo/i });
+    act(() => {
+      fireEvent.click(undoButton);
+    });
+
+    await waitFor(() => {
+      const json = JSON.parse(localStorage.getItem('currentJson') || '{}');
+      expect(json.prompt).toBe(DEFAULT_OPTIONS.prompt);
+    });
+
+    const redoButton = screen.getByRole('button', { name: /redo/i });
+    act(() => {
+      fireEvent.click(redoButton);
+    });
+
+    await waitFor(() => {
+      const json = JSON.parse(localStorage.getItem('currentJson') || '{}');
+      expect(json.prompt).toBe('foo');
     });
   });
 

--- a/src/hooks/__tests__/use-undo-redo.test.ts
+++ b/src/hooks/__tests__/use-undo-redo.test.ts
@@ -1,0 +1,39 @@
+import { renderHook, act } from '@testing-library/react';
+import { useUndoRedo } from '../use-undo-redo';
+
+describe('useUndoRedo', () => {
+  test('pushes state and undoes/redoes', () => {
+    const { result } = renderHook(() => useUndoRedo(0));
+    act(() => {
+      result.current.setState(1);
+      result.current.setState(2);
+    });
+    expect(result.current.state).toBe(2);
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.state).toBe(1);
+    act(() => {
+      result.current.redo();
+    });
+    expect(result.current.state).toBe(2);
+  });
+
+  test('caps history size', () => {
+    const { result } = renderHook(() => useUndoRedo(0, 3));
+    act(() => {
+      result.current.setState(1);
+      result.current.setState(2);
+      result.current.setState(3);
+      result.current.setState(4);
+    });
+    expect(result.current.canUndo).toBe(true);
+    act(() => {
+      result.current.undo();
+      result.current.undo();
+      result.current.undo();
+    });
+    // Only last 3 states kept -> after three undos we reach state 2
+    expect(result.current.state).toBe(2);
+  });
+});

--- a/src/hooks/use-undo-redo.ts
+++ b/src/hooks/use-undo-redo.ts
@@ -1,0 +1,48 @@
+import { Dispatch, SetStateAction, useRef, useState } from 'react';
+
+export function useUndoRedo<T>(
+  initialValue: T | (() => T),
+  limit = 50,
+) {
+  const init = typeof initialValue === 'function'
+    ? (initialValue as () => T)()
+    : initialValue;
+  const historyRef = useRef<T[]>([init]);
+  const indexRef = useRef(0);
+  const [state, setState] = useState<T>(init);
+
+  const push: Dispatch<SetStateAction<T>> = (value) => {
+    setState((prev) => {
+      const next = typeof value === 'function' ? (value as (p: T) => T)(prev) : value;
+      let hist = historyRef.current.slice(0, indexRef.current + 1);
+      hist.push(next);
+      if (hist.length > limit) hist = hist.slice(hist.length - limit);
+      historyRef.current = hist;
+      indexRef.current = hist.length - 1;
+      return next;
+    });
+  };
+
+  const undo = () => {
+    if (indexRef.current > 0) {
+      indexRef.current -= 1;
+      setState(historyRef.current[indexRef.current]);
+    }
+  };
+
+  const redo = () => {
+    if (indexRef.current < historyRef.current.length - 1) {
+      indexRef.current += 1;
+      setState(historyRef.current[indexRef.current]);
+    }
+  };
+
+  return {
+    state,
+    setState: push,
+    undo,
+    redo,
+    canUndo: indexRef.current > 0,
+    canRedo: indexRef.current < historyRef.current.length - 1,
+  } as const;
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -13,6 +13,8 @@
   "reset": "Reset",
   "regenerate": "Regenerate",
   "randomize": "Randomize",
+  "undo": "Undo",
+  "redo": "Redo",
   "enableTracking": "Enable Tracking",
   "disableTracking": "Disable Tracking",
   "showHeaderButtons": "Show Header Buttons",


### PR DESCRIPTION
## Summary
- add `useUndoRedo` hook for local undo stack
- integrate undo stack with Dashboard state
- expose undo/redo controls in ActionBar
- add undo/redo text strings
- test new hook, dashboard integration and buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68812670c8208325b104f0f68ccd0dd7