### PR TITLE
Add shorten buttons translation

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -268,7 +268,7 @@ export const ActionBar: React.FC<ActionBarProps> = ({
           >
             {actionLabelsEnabled ? (
               <>
-                <EyeOff className="w-4 h-4" /> {t('hideLabels')}
+                <EyeOff className="w-4 h-4" /> {t('shortenButtons')}
               </>
             ) : (
               <>

--- a/src/locales/bn-IN.json
+++ b/src/locales/bn-IN.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "ভাষা",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/da-DK.json
+++ b/src/locales/da-DK.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Sprog",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/de-AT.json
+++ b/src/locales/de-AT.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Sprache",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Sprache",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/el-GR.json
+++ b/src/locales/el-GR.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Γλώσσα",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Language",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/en-PR.json
+++ b/src/locales/en-PR.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Lingo",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Language",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/es-AR.json
+++ b/src/locales/es-AR.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe lo que quieres evitar...",
   "showLabels": "Mostrar Etiquetas",
   "hideLabels": "Ocultar Etiquetas",
+  "shortenButtons": "Shorten Buttons",
   "language": "Idioma",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configura tus ajustes de Sora y obtén el JSON perfecto para un contenido generado por IA impresionante.",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe lo que quieres evitar...",
   "showLabels": "Mostrar Etiquetas",
   "hideLabels": "Ocultar Etiquetas",
+  "shortenButtons": "Shorten Buttons",
   "language": "Idioma",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configura tus ajustes de Sora y obtén el JSON perfecto para un contenido generado por IA impresionante.",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe lo que quieres evitar...",
   "showLabels": "Mostrar Etiquetas",
   "hideLabels": "Ocultar Etiquetas",
+  "shortenButtons": "Shorten Buttons",
   "language": "Idioma",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configura tus ajustes de Sora y obtén el JSON perfecto para un contenido generado por IA impresionante.",

--- a/src/locales/et-EE.json
+++ b/src/locales/et-EE.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Keel",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/fi-FI.json
+++ b/src/locales/fi-FI.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Kieli",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/fr-BE.json
+++ b/src/locales/fr-BE.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Langue",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Décrivez ce que vous voulez éviter ...",
   "showLabels": "Montrer les étiquettes",
   "hideLabels": "Masquer les étiquettes",
+  "shortenButtons": "Shorten Buttons",
   "language": "Langue",
   "appName": "Sora JSON Invite Crafter",
   "tagline": "Configurez vos paramètres de génération Sora et obtenez l'invite JSON parfaite pour un contenu superbe généré par AI.",

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Lingua",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "あなたが避けたいものを説明してください...",
   "showLabels": "ラベルを表示します",
   "hideLabels": "ラベルを非表示にします",
+  "shortenButtons": "Shorten Buttons",
   "language": "言語",
   "appName": "ソラJSONプロンプトクラフター",
   "tagline": "SORA生成設定を構成し、見事なAIで生成されたコンテンツの完璧なJSONプロンプトを取得します。",

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "언어",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/ne-NP.json
+++ b/src/locales/ne-NP.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "भाषा",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Descreva o que você deseja evitar ...",
   "showLabels": "Mostrar rótulos",
   "hideLabels": "Ocultar rótulos",
+  "shortenButtons": "Shorten Buttons",
   "language": "Linguagem",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Definir suas configurações de geração Sora e obtenha o prompt JSON perfeito para um conteúdo impressionante gerado pela IA.",

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Descreve o que queres evitar...",
   "showLabels": "Mostrar Etiquetas",
   "hideLabels": "Ocultar Etiquetas",
+  "shortenButtons": "Shorten Buttons",
   "language": "Idioma",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure as definições de Sora e obtenha o JSON perfeito para um conteúdo gerado por IA impressionante.",

--- a/src/locales/ro-RO.json
+++ b/src/locales/ro-RO.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Limbă",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Опишите, чего следует избегать...",
   "showLabels": "Показать метки",
   "hideLabels": "Скрыть метки",
+  "shortenButtons": "Shorten Buttons",
   "language": "Язык",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Настройте параметры Sora и получите идеальный JSON для впечатляющего контента, созданного ИИ.",

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Språk",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/th-TH.json
+++ b/src/locales/th-TH.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "ภาษา",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/uk-UA.json
+++ b/src/locales/uk-UA.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "Describe what you want to avoid...",
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
+  "shortenButtons": "Shorten Buttons",
   "language": "Мова",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -37,6 +37,7 @@
   "negativePromptPlaceholder": "描述您要避免的...",
   "showLabels": "显示标签",
   "hideLabels": "隐藏标签",
+  "shortenButtons": "Shorten Buttons",
   "language": "语言",
   "appName": "Sora Json提示手工艺者",
   "tagline": "配置您的Sora生成设置，并获得完美的JSON提示，以获得令人惊叹的AI生成的内容。",


### PR DESCRIPTION
## Summary
- add `shortenButtons` text in locale files
- use new translation in the manage menu

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68812682c08c83258550252683030e9d