### PR TITLE
Make language menu scrollable

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -319,7 +319,7 @@ export const ActionBar: React.FC<ActionBarProps> = ({
             {actionLabelsEnabled && t('language')}
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent>
+        <DropdownMenuContent className="max-h-screen sm:max-h-[50vh] overflow-y-auto">
           <DropdownMenuItem
             onSelect={() => setLocale('en-US')}
             className="gap-2"


### PR DESCRIPTION
## Summary
- limit language dropdown height and allow vertical scrolling

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68890a2454e08325a0a38ab0ca0a961d