### PR TITLE
Add share caption i18n key

### DIFF
--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -35,17 +35,16 @@ export const ShareModal: React.FC<ShareModalProps> = ({
   const [copied, setCopied] = useState(false);
   const [trackingEnabled] = useTracking();
   const { t } = useTranslation();
+  const shareCaption = t('shareCaption');
   const shareToFacebook = () => {
-    const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}&quote=${encodeURIComponent('Check out my Sora prompt configuration!')}`;
+    const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}&quote=${encodeURIComponent(shareCaption)}`;
     window.open(url, '_blank', 'noopener,width=600,height=400');
     toast.success(t('sharedToFacebook'));
     trackEvent(trackingEnabled, 'share_facebook');
   };
 
   const shareToTwitter = () => {
-    const text = encodeURIComponent(
-      'Check out my Sora prompt configuration! #SoraAI #AIGeneration',
-    );
+    const text = encodeURIComponent(`${shareCaption} #SoraAI #AIGeneration`);
     const url = `https://twitter.com/intent/tweet?text=${text}&url=${encodeURIComponent(window.location.href)}`;
     window.open(url, '_blank', 'noopener,width=600,height=400');
     toast.success(t('sharedToTwitter'));
@@ -53,9 +52,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
   };
 
   const shareToWhatsApp = () => {
-    const text = encodeURIComponent(
-      `Check out my Sora prompt configuration!\n\n${jsonContent}`,
-    );
+    const text = encodeURIComponent(`${shareCaption}\n\n${jsonContent}`);
     const url = `https://wa.me/?text=${text}`;
     window.open(url, '_blank', 'noopener');
     toast.success(t('sharedToWhatsApp'));
@@ -63,9 +60,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
   };
 
   const shareToTelegram = () => {
-    const text = encodeURIComponent(
-      `Check out my Sora prompt configuration!\n\n${jsonContent}`,
-    );
+    const text = encodeURIComponent(`${shareCaption}\n\n${jsonContent}`);
     const url = `https://t.me/share/url?url=${encodeURIComponent(window.location.href)}&text=${text}`;
     window.open(url, '_blank', 'noopener');
     toast.success(t('sharedToTelegram'));

--- a/src/components/__tests__/ShareModal.test.tsx
+++ b/src/components/__tests__/ShareModal.test.tsx
@@ -61,7 +61,7 @@ describe('ShareModal', () => {
 
   test('shares to Facebook', () => {
     renderModal();
-    const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}&quote=${encodeURIComponent('Check out my Sora prompt configuration!')}`;
+    const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}&quote=${encodeURIComponent(i18n.t('shareCaption'))}`;
     fireEvent.click(screen.getByRole('button', { name: /facebook/i }));
     expect(openSpy).toHaveBeenCalledWith(
       url,
@@ -74,7 +74,7 @@ describe('ShareModal', () => {
   test('shares to Twitter', () => {
     renderModal();
     const text = encodeURIComponent(
-      'Check out my Sora prompt configuration! #SoraAI #AIGeneration',
+      `${i18n.t('shareCaption')} #SoraAI #AIGeneration`,
     );
     const url = `https://twitter.com/intent/tweet?text=${text}&url=${encodeURIComponent(window.location.href)}`;
     fireEvent.click(screen.getByRole('button', { name: /twitter\/x/i }));
@@ -88,9 +88,7 @@ describe('ShareModal', () => {
 
   test('shares to WhatsApp', () => {
     renderModal();
-    const text = encodeURIComponent(
-      `Check out my Sora prompt configuration!\n\nmyjson`,
-    );
+    const text = encodeURIComponent(`${i18n.t('shareCaption')}\n\nmyjson`);
     const url = `https://wa.me/?text=${text}`;
     fireEvent.click(screen.getByRole('button', { name: /whatsapp/i }));
     expect(openSpy).toHaveBeenCalledWith(url, '_blank', 'noopener');
@@ -99,9 +97,7 @@ describe('ShareModal', () => {
 
   test('shares to Telegram', () => {
     renderModal();
-    const text = encodeURIComponent(
-      `Check out my Sora prompt configuration!\n\nmyjson`,
-    );
+    const text = encodeURIComponent(`${i18n.t('shareCaption')}\n\nmyjson`);
     const url = `https://t.me/share/url?url=${encodeURIComponent(window.location.href)}&text=${text}`;
     fireEvent.click(screen.getByRole('button', { name: /telegram/i }));
     expect(openSpy).toHaveBeenCalledWith(url, '_blank', 'noopener');

--- a/src/locales/bn-IN.json
+++ b/src/locales/bn-IN.json
@@ -142,5 +142,6 @@
   "timeOfYear": "বর্ষপঞ্জি সময়",
   "useAtmosphereMood": "পরিবেশের মুড ব্যবহার করুন",
   "atmosphereMood": "পরিবেশের মুড",
-  "atmosphereMoodOptions": "মুডের অপশনসমূহ"
+  "atmosphereMoodOptions": "মুডের অপশনসমূহ",
+  "shareCaption": "আমার Sora প্রম্পট কনফিগারেশন দেখুন!"
 }

--- a/src/locales/da-DK.json
+++ b/src/locales/da-DK.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Årstid",
   "useAtmosphereMood": "Brug stemning",
   "atmosphereMood": "Stemning",
-  "atmosphereMoodOptions": "Stemningsmuligheder"
+  "atmosphereMoodOptions": "Stemningsmuligheder",
+  "shareCaption": "Tjek min Sora promptkonfiguration!"
 }

--- a/src/locales/de-AT.json
+++ b/src/locales/de-AT.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Jahreszeit",
   "useAtmosphereMood": "Stimmung verwenden",
   "atmosphereMood": "Stimmung",
-  "atmosphereMoodOptions": "Stimmungsoptionen"
+  "atmosphereMoodOptions": "Stimmungsoptionen",
+  "shareCaption": "Schauen Sie sich meine SORA-Prompt-Konfiguration an!"
 }

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Jahreszeit",
   "useAtmosphereMood": "Stimmung verwenden",
   "atmosphereMood": "Stimmung",
-  "atmosphereMoodOptions": "Stimmungsoptionen"
+  "atmosphereMoodOptions": "Stimmungsoptionen",
+  "shareCaption": "Schauen Sie sich meine SORA-Prompt-Konfiguration an!"
 }

--- a/src/locales/el-GR.json
+++ b/src/locales/el-GR.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Περίοδος έτους",
   "useAtmosphereMood": "Χρήση ατμόσφαιρας",
   "atmosphereMood": "Ατμόσφαιρα",
-  "atmosphereMoodOptions": "Επιλογές ατμόσφαιρας"
+  "atmosphereMoodOptions": "Επιλογές ατμόσφαιρας",
+  "shareCaption": "Δείτε τη διαμόρφωση της προτροπής Sora!"
 }

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Time of Year",
   "useAtmosphereMood": "Use Atmosphere Mood",
   "atmosphereMood": "Atmosphere Mood",
-  "atmosphereMoodOptions": "Atmosphere Mood Options"
+  "atmosphereMoodOptions": "Atmosphere Mood Options",
+  "shareCaption": "Check out my Sora prompt configuration!"
 }

--- a/src/locales/en-PR.json
+++ b/src/locales/en-PR.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Time o' Year",
   "useAtmosphereMood": "Use Atmosphere Mood",
   "atmosphereMood": "Atmosphere Mood",
-  "atmosphereMoodOptions": "Atmosphere Mood Options"
+  "atmosphereMoodOptions": "Atmosphere Mood Options",
+  "shareCaption": "Check out my Sora prompt configuration!"
 }

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Time of Year",
   "useAtmosphereMood": "Use Atmosphere Mood",
   "atmosphereMood": "Atmosphere Mood",
-  "atmosphereMoodOptions": "Atmosphere Mood Options"
+  "atmosphereMoodOptions": "Atmosphere Mood Options",
+  "shareCaption": "Check out my Sora prompt configuration!"
 }

--- a/src/locales/es-AR.json
+++ b/src/locales/es-AR.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Época del año",
   "useAtmosphereMood": "Usar ambiente",
   "atmosphereMood": "Ambiente",
-  "atmosphereMoodOptions": "Opciones de ambiente"
+  "atmosphereMoodOptions": "Opciones de ambiente",
+  "shareCaption": "¡Echa un vistazo a mi configuración del indicador Sora!"
 }

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Época del año",
   "useAtmosphereMood": "Usar ambiente",
   "atmosphereMood": "Ambiente",
-  "atmosphereMoodOptions": "Opciones de ambiente"
+  "atmosphereMoodOptions": "Opciones de ambiente",
+  "shareCaption": "¡Echa un vistazo a mi configuración del indicador Sora!"
 }

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Época del año",
   "useAtmosphereMood": "Usar ambiente",
   "atmosphereMood": "Ambiente",
-  "atmosphereMoodOptions": "Opciones de ambiente"
+  "atmosphereMoodOptions": "Opciones de ambiente",
+  "shareCaption": "¡Echa un vistazo a mi configuración del indicador Sora!"
 }

--- a/src/locales/et-EE.json
+++ b/src/locales/et-EE.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Aasta aeg",
   "useAtmosphereMood": "Kasuta meeleolu",
   "atmosphereMood": "Meeleolu",
-  "atmosphereMoodOptions": "Meeleolu valikud"
+  "atmosphereMoodOptions": "Meeleolu valikud",
+  "shareCaption": "Vaadake minu Sora kiiret konfiguratsiooni!"
 }

--- a/src/locales/fi-FI.json
+++ b/src/locales/fi-FI.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Vuoden aika",
   "useAtmosphereMood": "Käytä tunnelmaa",
   "atmosphereMood": "Tunnelma",
-  "atmosphereMoodOptions": "Tunnelmavaihtoehdot"
+  "atmosphereMoodOptions": "Tunnelmavaihtoehdot",
+  "shareCaption": "Tutustu SORA-kehotekokoonpanooni!"
 }

--- a/src/locales/fr-BE.json
+++ b/src/locales/fr-BE.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Période de l’année",
   "useAtmosphereMood": "Utiliser l’ambiance",
   "atmosphereMood": "Ambiance",
-  "atmosphereMoodOptions": "Options d’ambiance"
+  "atmosphereMoodOptions": "Options d’ambiance",
+  "shareCaption": "Découvrez ma configuration d'invite Sora !"
 }

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Période de l'année",
   "useAtmosphereMood": "Utiliser l'ambiance",
   "atmosphereMood": "Ambiance",
-  "atmosphereMoodOptions": "Options d'ambiance"
+  "atmosphereMoodOptions": "Options d'ambiance",
+  "shareCaption": "Découvrez ma configuration d'invite Sora !"
 }

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Periodo dell'anno",
   "useAtmosphereMood": "Usa atmosfera",
   "atmosphereMood": "Atmosfera",
-  "atmosphereMoodOptions": "Opzioni atmosfera"
+  "atmosphereMoodOptions": "Opzioni atmosfera",
+  "shareCaption": "Dai un'occhiata alla mia configurazione prompt di Sora!"
 }

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -142,5 +142,6 @@
   "timeOfYear": "時期",
   "useAtmosphereMood": "雰囲気のムードを使用",
   "atmosphereMood": "雰囲気のムード",
-  "atmosphereMoodOptions": "雰囲気ムードオプション"
+  "atmosphereMoodOptions": "雰囲気ムードオプション",
+  "shareCaption": "私のSoraプロンプト設定をチェックしてください！"
 }

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -142,5 +142,6 @@
   "timeOfYear": "시기",
   "useAtmosphereMood": "분위기 사용",
   "atmosphereMood": "분위기",
-  "atmosphereMoodOptions": "분위기 옵션"
+  "atmosphereMoodOptions": "분위기 옵션",
+  "shareCaption": "내 Sora 프롬프트 구성을 확인하십시오!"
 }

--- a/src/locales/ne-NP.json
+++ b/src/locales/ne-NP.json
@@ -142,5 +142,6 @@
   "timeOfYear": "वर्षको समय",
   "useAtmosphereMood": "माहौल प्रयोग गर्नुहोस्",
   "atmosphereMood": "माहौल",
-  "atmosphereMoodOptions": "माहौल विकल्पहरू"
+  "atmosphereMoodOptions": "माहौल विकल्पहरू",
+  "shareCaption": "मेरो सोरा प्रोम्प्ट कन्फिगरेसन जाँच गर्नुहोस्!"
 }

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Período do ano",
   "useAtmosphereMood": "Usar clima atmosférico",
   "atmosphereMood": "Clima atmosférico",
-  "atmosphereMoodOptions": "Opções de clima atmosférico"
+  "atmosphereMoodOptions": "Opções de clima atmosférico",
+  "shareCaption": "Confira a minha configuração de prompt do Sora!"
 }

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Altura do Ano",
   "useAtmosphereMood": "Usar Atmosfera",
   "atmosphereMood": "Atmosfera",
-  "atmosphereMoodOptions": "Opções de Atmosfera"
+  "atmosphereMoodOptions": "Opções de Atmosfera",
+  "shareCaption": "Confira a minha configuração de prompt do Sora!"
 }

--- a/src/locales/ro-RO.json
+++ b/src/locales/ro-RO.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Perioada anului",
   "useAtmosphereMood": "Folosește atmosfera",
   "atmosphereMood": "Atmosferă",
-  "atmosphereMoodOptions": "Opțiuni atmosferă"
+  "atmosphereMoodOptions": "Opțiuni atmosferă",
+  "shareCaption": "Verificați configurația promptului meu Sora!"
 }

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Время года",
   "useAtmosphereMood": "Использовать атмосферу",
   "atmosphereMood": "Атмосфера",
-  "atmosphereMoodOptions": "Опции атмосферы"
+  "atmosphereMoodOptions": "Опции атмосферы",
+  "shareCaption": "Ознакомьтесь с моей конфигурацией подсказок Sora!"
 }

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Årstid",
   "useAtmosphereMood": "Använd stämning",
   "atmosphereMood": "Stämning",
-  "atmosphereMoodOptions": "Stämningsval"
+  "atmosphereMoodOptions": "Stämningsval",
+  "shareCaption": "Kolla in min Sora promptkonfiguration!"
 }

--- a/src/locales/th-TH.json
+++ b/src/locales/th-TH.json
@@ -142,5 +142,6 @@
   "timeOfYear": "ช่วงเวลาของปี",
   "useAtmosphereMood": "ใช้บรรยากาศ",
   "atmosphereMood": "บรรยากาศ",
-  "atmosphereMoodOptions": "ตัวเลือกบรรยากาศ"
+  "atmosphereMoodOptions": "ตัวเลือกบรรยากาศ",
+  "shareCaption": "ตรวจสอบการกำหนดค่า Sora prompt ของฉัน!"
 }

--- a/src/locales/uk-UA.json
+++ b/src/locales/uk-UA.json
@@ -142,5 +142,6 @@
   "timeOfYear": "Пора року",
   "useAtmosphereMood": "Використовувати атмосферу",
   "atmosphereMood": "Атмосфера",
-  "atmosphereMoodOptions": "Опції атмосфери"
+  "atmosphereMoodOptions": "Опції атмосфери",
+  "shareCaption": "Перегляньте мою конфігурацію підказки Sora!"
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -142,5 +142,6 @@
   "timeOfYear": "时间",
   "useAtmosphereMood": "使用氛围心情",
   "atmosphereMood": "氛围心情",
-  "atmosphereMoodOptions": "氛围心情选项"
+  "atmosphereMoodOptions": "氛围心情选项",
+  "shareCaption": "查看我的Sora提示配置！"
 }


### PR DESCRIPTION
## Summary
- introduce `shareCaption` translation key
- use the key in share link helpers
- update tests to use the new caption
- provide translated values across locales

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a20f2ed408325b7f3ebf4b2bc8418