### PR TITLE
Extract strings into translation keys

### DIFF
--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -543,13 +543,13 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
         open={showClipboard}
         onOpenChange={setShowClipboard}
         onImport={onImport}
-        title="Import from Clipboard"
+        title={t('importFromClipboard')}
       />
       <ClipboardImportModal
         open={showBulkClipboard}
         onOpenChange={setShowBulkClipboard}
         onImport={onImport}
-        title="Bulk Import from Clipboard"
+        title={t('bulkImportFromClipboard')}
       />
       <BulkFileImportModal
         open={showBulkFile}

--- a/src/components/__tests__/BulkFileImportModal.test.tsx
+++ b/src/components/__tests__/BulkFileImportModal.test.tsx
@@ -53,7 +53,7 @@ describe('BulkFileImportModal', () => {
     fireEvent.change(input, {
       target: { files: [file] },
     });
-    fireEvent.click(screen.getByRole('button', { name: /import/i }));
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('import') }));
     await waitFor(() =>
       expect(onImport).toHaveBeenCalledWith(['{"prompt":"test"}']),
     );
@@ -87,7 +87,7 @@ describe('BulkFileImportModal', () => {
     fireEvent.change(input, {
       target: { files: [file] },
     });
-    fireEvent.click(screen.getByRole('button', { name: /import/i }));
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('import') }));
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(i18n.t('failedImportFile')),
     );
@@ -107,7 +107,7 @@ describe('BulkFileImportModal', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /import/i }));
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('import') }));
 
     expect(toast.error).toHaveBeenCalledWith(i18n.t('pleaseSelectFile'));
     expect(onImport).not.toHaveBeenCalled();

--- a/src/components/__tests__/ClipboardImportModal.test.tsx
+++ b/src/components/__tests__/ClipboardImportModal.test.tsx
@@ -37,12 +37,14 @@ describe('ClipboardImportModal', () => {
         open={true}
         onOpenChange={onOpenChange}
         onImport={onImport}
-        title="Import"
+        title={i18n.t('importFromClipboard')}
       />,
     );
-    const textarea = screen.getByPlaceholderText(/paste json/i);
+    const textarea = screen.getByPlaceholderText(
+      i18n.t('pasteJsonPlaceholder'),
+    );
     fireEvent.change(textarea, { target: { value: '{"prompt":"test"}' } });
-    const button = screen.getByRole('button', { name: /import/i });
+    const button = screen.getByRole('button', { name: i18n.t('import') });
     fireEvent.click(button);
 
     expect(onImport).toHaveBeenCalledWith(['{"prompt":"test"}']);
@@ -60,15 +62,17 @@ describe('ClipboardImportModal', () => {
         open={true}
         onOpenChange={onOpenChange}
         onImport={onImport}
-        title="Import"
+        title={i18n.t('importFromClipboard')}
       />,
     );
-    const textarea = screen.getByPlaceholderText(/paste json/i);
+    const textarea = screen.getByPlaceholderText(
+      i18n.t('pasteJsonPlaceholder'),
+    );
     const arrayText = JSON.stringify(['{"prompt":"one"}', '{"prompt":"two"}']);
     fireEvent.change(textarea, {
       target: { value: arrayText },
     });
-    const button = screen.getByRole('button', { name: /import/i });
+    const button = screen.getByRole('button', { name: i18n.t('import') });
     fireEvent.click(button);
 
     expect(onImport).toHaveBeenCalledWith([
@@ -89,10 +93,12 @@ describe('ClipboardImportModal', () => {
         open={true}
         onOpenChange={onOpenChange}
         onImport={onImport}
-        title="Import"
+        title={i18n.t('importFromClipboard')}
       />,
     );
-    const textarea = screen.getByPlaceholderText(/paste json/i);
+    const textarea = screen.getByPlaceholderText(
+      i18n.t('pasteJsonPlaceholder'),
+    );
     const objectArrayText = JSON.stringify([
       { json: '{"prompt":"one"}' },
       { json: '{"prompt":"two"}' },
@@ -100,7 +106,7 @@ describe('ClipboardImportModal', () => {
     fireEvent.change(textarea, {
       target: { value: objectArrayText },
     });
-    const button = screen.getByRole('button', { name: /import/i });
+    const button = screen.getByRole('button', { name: i18n.t('import') });
     fireEvent.click(button);
 
     expect(onImport).toHaveBeenCalledWith([
@@ -121,12 +127,14 @@ describe('ClipboardImportModal', () => {
         open={true}
         onOpenChange={onOpenChange}
         onImport={onImport}
-        title="Import"
+        title={i18n.t('importFromClipboard')}
       />,
     );
-    const textarea = screen.getByPlaceholderText(/paste json/i);
+    const textarea = screen.getByPlaceholderText(
+      i18n.t('pasteJsonPlaceholder'),
+    );
     fireEvent.change(textarea, { target: { value: '{bad json' } });
-    const button = screen.getByRole('button', { name: /import/i });
+    const button = screen.getByRole('button', { name: i18n.t('import') });
     fireEvent.click(button);
 
     expect(toast.error).toHaveBeenCalledWith(i18n.t('invalidJson'));

--- a/src/components/__tests__/ImportModal.test.tsx
+++ b/src/components/__tests__/ImportModal.test.tsx
@@ -19,9 +19,11 @@ describe('ImportModal', () => {
     const onImport = jest.fn();
     const onClose = jest.fn();
     render(<ImportModal isOpen={true} onClose={onClose} onImport={onImport} />);
-    const textarea = screen.getByPlaceholderText(/paste json/i);
+    const textarea = screen.getByPlaceholderText(
+      i18n.t('pasteJsonPlaceholder'),
+    );
     fireEvent.change(textarea, { target: { value: '{"prompt":"test"}' } });
-    const button = screen.getByRole('button', { name: /import/i });
+    const button = screen.getByRole('button', { name: i18n.t('import') });
     fireEvent.click(button);
 
     expect(onImport).toHaveBeenCalledWith('{"prompt":"test"}');
@@ -49,7 +51,7 @@ describe('ImportModal', () => {
       'input[type="file"]',
     ) as HTMLInputElement;
     const textarea = screen.getByPlaceholderText(
-      /paste json/i,
+      i18n.t('pasteJsonPlaceholder'),
     ) as HTMLTextAreaElement;
     fireEvent.change(input, {
       target: {
@@ -59,7 +61,7 @@ describe('ImportModal', () => {
 
     await waitFor(() => expect(textarea.value).toBe(fileContent));
 
-    const button = screen.getByRole('button', { name: /import/i });
+    const button = screen.getByRole('button', { name: i18n.t('import') });
     fireEvent.click(button);
 
     expect(onImport).toHaveBeenCalledWith(fileContent);
@@ -70,9 +72,11 @@ describe('ImportModal', () => {
     const onImport = jest.fn();
     const onClose = jest.fn();
     render(<ImportModal isOpen={true} onClose={onClose} onImport={onImport} />);
-    const textarea = screen.getByPlaceholderText(/paste json/i);
+    const textarea = screen.getByPlaceholderText(
+      i18n.t('pasteJsonPlaceholder'),
+    );
     fireEvent.change(textarea, { target: { value: '{bad json' } });
-    const button = screen.getByRole('button', { name: /import/i });
+    const button = screen.getByRole('button', { name: i18n.t('import') });
     fireEvent.click(button);
 
     expect(toast.error).toHaveBeenCalledWith(i18n.t('invalidJson'));

--- a/src/components/__tests__/clipboardFallback.test.tsx
+++ b/src/components/__tests__/clipboardFallback.test.tsx
@@ -91,7 +91,7 @@ describe('clipboard fallback', () => {
         open={true}
         onOpenChange={() => {}}
         onImport={() => {}}
-        title="Import"
+        title={i18n.t('importFromClipboard')}
       />,
     );
     await waitFor(() =>

--- a/src/locales/bn-IN.json
+++ b/src/locales/bn-IN.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/da-DK.json
+++ b/src/locales/da-DK.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/de-AT.json
+++ b/src/locales/de-AT.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/el-GR.json
+++ b/src/locales/el-GR.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/en-PR.json
+++ b/src/locales/en-PR.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -828,5 +828,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/es-AR.json
+++ b/src/locales/es-AR.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -828,5 +828,7 @@
       "sensual": "sensual",
       "alluring": "atractivo"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/et-EE.json
+++ b/src/locales/et-EE.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/fi-FI.json
+++ b/src/locales/fi-FI.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/fr-BE.json
+++ b/src/locales/fr-BE.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/ne-NP.json
+++ b/src/locales/ne-NP.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/ro-RO.json
+++ b/src/locales/ro-RO.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/th-TH.json
+++ b/src/locales/th-TH.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/uk-UA.json
+++ b/src/locales/uk-UA.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -821,5 +821,7 @@
       "sensual": "sensual",
       "alluring": "alluring"
     }
-  }
+  },
+  "importFromClipboard": "Import from clipboard",
+  "bulkImportFromClipboard": "Bulk import from clipboard"
 }


### PR DESCRIPTION
## Summary
- internationalize clipboard import titles
- add i18n keys `importFromClipboard` and `bulkImportFromClipboard`
- update ImportModal/ClipboardImportModal tests to use translations

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_688bda82ea58832593629e326766f291