### PR TITLE
Remove disclaimer filenames from locale list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -189,33 +189,33 @@ your own path pattern.
 
 ### Supported Languages
 
-- English (US) (`disclaimer.en-US.txt`)
-- Spanish (Spain) (`disclaimer.es-ES.txt`)
-- Portuguese (Portugal) (`disclaimer.pt-PT.txt`)
-- Russian (`disclaimer.ru-RU.txt`)
-- Portuguese (Brazil) (`disclaimer.pt-BR.txt`)
-- French (`disclaimer.fr-FR.txt`)
-- German (Germany) (`disclaimer.de-DE.txt`)
-- Chinese (Simplified) (`disclaimer.zh-CN.txt`)
-- Italian (`disclaimer.it-IT.txt`)
-- Spanish (Mexico) (`disclaimer.es-MX.txt`)
-- English (UK) (`disclaimer.en-GB.txt`)
-- Bengali (`disclaimer.bn-IN.txt`)
-- Japanese (`disclaimer.ja-JP.txt`)
-- English (Pirate) (`disclaimer.en-PR.txt`)
-- Korean (`disclaimer.ko-KR.txt`)
-- Romanian (`disclaimer.ro-RO.txt`)
-- Swedish (`disclaimer.sv-SE.txt`)
-- Ukrainian (`disclaimer.uk-UA.txt`)
-- Nepali (`disclaimer.ne-NP.txt`)
-- Danish (`disclaimer.da-DK.txt`)
-- Estonian (`disclaimer.et-EE.txt`)
-- Finnish (`disclaimer.fi-FI.txt`)
-- Greek (`disclaimer.el-GR.txt`)
-- Thai (`disclaimer.th-TH.txt`)
-- German (Austria) (`disclaimer.de-AT.txt`)
-- French (Belgium) (`disclaimer.fr-BE.txt`)
-- Spanish (Argentina) (`disclaimer.es-AR.txt`)
+- English (US)
+- Spanish (Spain)
+- Portuguese (Portugal)
+- Russian
+- Portuguese (Brazil)
+- French
+- German (Germany)
+- Chinese (Simplified)
+- Italian
+- Spanish (Mexico)
+- English (UK)
+- Bengali
+- Japanese
+- English (Pirate)
+- Korean
+- Romanian
+- Swedish
+- Ukrainian
+- Nepali
+- Danish
+- Estonian
+- Finnish
+- Greek
+- Thai
+- German (Austria)
+- French (Belgium)
+- Spanish (Argentina)
 
 To add a new language:
 


### PR DESCRIPTION
## Summary
- update README to clean up locales list by removing the disclaimer filenames

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688cb6648f708325b52ab63f7d1b040a