### PR TITLE
Add loader skeleton to DisclaimerModal

### DIFF
--- a/src/components/DisclaimerModal.tsx
+++ b/src/components/DisclaimerModal.tsx
@@ -8,6 +8,7 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { Skeleton } from '@/components/ui/skeleton';
 
 interface DisclaimerModalProps {
   open: boolean;
@@ -125,7 +126,11 @@ const DisclaimerModal: React.FC<DisclaimerModalProps> = ({
           </DialogDescription>
         </DialogHeader>
         <ScrollArea className="h-[60vh] px-1">
-          <p className="whitespace-pre-wrap text-sm">{text}</p>
+          {text === '' && !hasFetched ? (
+            <Skeleton data-testid="disclaimer-loader" className="h-24 w-full" />
+          ) : (
+            <p className="whitespace-pre-wrap text-sm">{text}</p>
+          )}
         </ScrollArea>
       </DialogContent>
     </Dialog>

--- a/src/components/__tests__/DisclaimerModal.test.tsx
+++ b/src/components/__tests__/DisclaimerModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { jest } from '@jest/globals';
 import DisclaimerModal from '../DisclaimerModal';
 
@@ -56,6 +56,29 @@ describe('DisclaimerModal', () => {
     render(<DisclaimerModal open={false} onOpenChange={() => {}} />);
 
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('shows loader while fetching', async () => {
+    let resolveFetch: (value: Response) => void = () => {};
+    global.fetch = jest.fn().mockImplementation(
+      () =>
+        new Promise<Response>((res) => {
+          resolveFetch = res;
+        }),
+    );
+
+    render(<DisclaimerModal open={true} onOpenChange={() => {}} />);
+
+    expect(screen.getByTestId('disclaimer-loader')).toBeDefined();
+
+    await act(async () => {
+      resolveFetch({
+        ok: true,
+        text: () => Promise.resolve('loaded text'),
+      } as Response);
+    });
+
+    expect(await screen.findByText('loaded text')).toBeDefined();
   });
 
   test('fetches only when opened', async () => {


### PR DESCRIPTION
## Summary
- show a loading skeleton in DisclaimerModal while the disclaimer text is fetching
- test the loading state in DisclaimerModal

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d2974fd948325bcc5a9c346c995e1