### PR TITLE
Switch to SearchableDropdown for style selection

### DIFF
--- a/src/components/__tests__/StyleSection.test.tsx
+++ b/src/components/__tests__/StyleSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { StyleSection } from '../sections/StyleSection';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 
@@ -23,9 +23,12 @@ describe('StyleSection', () => {
         updateOptions={updateOptions}
       />,
     );
-    const comboboxes = screen.getAllByRole('combobox');
-    fireEvent.click(comboboxes[1]);
-    fireEvent.click(screen.getByRole('option', { name: /film still/i }));
+    const section = screen.getByText('Style').parentElement as HTMLElement;
+    const dropdown = within(section).getByRole('button');
+    fireEvent.click(dropdown);
+    const input = screen.getByPlaceholderText('Search options...');
+    fireEvent.change(input, { target: { value: 'film' } });
+    fireEvent.click(screen.getByRole('button', { name: /film still/i }));
     expect(updateNestedOptions).toHaveBeenCalledWith(
       'style_preset.style',
       'film still',

--- a/src/components/sections/StyleSection.tsx
+++ b/src/components/sections/StyleSection.tsx
@@ -8,6 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { SearchableDropdown } from '../SearchableDropdown';
 import { CollapsibleSection } from '../CollapsibleSection';
 import type { SoraOptions } from '@/lib/soraOptions';
 import { stylePresets } from '@/data/stylePresets';
@@ -62,25 +63,19 @@ export const StyleSection: React.FC<StyleSectionProps> = ({
 
         <div>
           <Label htmlFor="style_preset">{t('style')}</Label>
-          <Select
+          <SearchableDropdown
+            options={
+              stylePresets[
+                options.style_preset.category as keyof typeof stylePresets
+              ] ?? []
+            }
             value={options.style_preset.style}
             onValueChange={(value) =>
               updateNestedOptions('style_preset.style', value)
             }
-          >
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {stylePresets[
-                options.style_preset.category as keyof typeof stylePresets
-              ]?.map((style) => (
-                <SelectItem key={style} value={style}>
-                  {formatLabel(style)}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            label="Style Options"
+            placeholder="Select style..."
+          />
         </div>
       </div>
     </CollapsibleSection>

--- a/src/components/sections/__tests__/StyleSection.test.tsx
+++ b/src/components/sections/__tests__/StyleSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { StyleSection } from '../StyleSection';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import i18n from '@/i18n';
@@ -24,9 +24,14 @@ describe('StyleSection', () => {
         updateOptions={updateOptions}
       />,
     );
-    const comboboxes = screen.getAllByRole('combobox');
-    fireEvent.click(comboboxes[1]);
-    fireEvent.click(screen.getByRole('option', { name: /film still/i }));
+    const section = screen.getByText(i18n.t('style')).parentElement as HTMLElement;
+    const dropdown = within(section).getByRole('button');
+    fireEvent.click(dropdown);
+    const input = screen.getByPlaceholderText(
+      i18n.t('searchOptionsPlaceholder'),
+    );
+    fireEvent.change(input, { target: { value: 'film' } });
+    fireEvent.click(screen.getByRole('button', { name: /film still/i }));
     expect(updateNestedOptions).toHaveBeenCalledWith(
       'style_preset.style',
       'film still',


### PR DESCRIPTION
## Summary
- switch StyleSection style selector to `SearchableDropdown`
- update section tests to drive the new searchable UI

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d334c7f6c8325bcab733f36edbbc7