### PR TITLE
feat: add referral param to share links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ go "my eyes!" when there's bright white lights.
 - Advanced specialized prompting options
 - Artifact and defect correction presets
 - No-fuss tracking toggle
+- Shared links append `?ref=share` for referral tracking
 - Internationalization support for English, Spanish and other 2 dozens of locales
 - Works offline thanks to service worker caching of assets
 

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { trackEvent } from '@/lib/analytics';
 import { useTracking } from '@/hooks/use-tracking';
 import { useTranslation } from 'react-i18next';
@@ -36,8 +36,13 @@ export const ShareModal: React.FC<ShareModalProps> = ({
   const [trackingEnabled] = useTracking();
   const { t } = useTranslation();
   const shareCaption = t('shareCaption');
+  const shareUrl = useMemo(() => {
+    const url = new URL(window.location.href);
+    url.searchParams.set('ref', 'share');
+    return url.toString();
+  }, []);
   const shareToFacebook = () => {
-    const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}&quote=${encodeURIComponent(shareCaption)}`;
+    const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}&quote=${encodeURIComponent(shareCaption)}`;
     window.open(url, '_blank', 'noopener,width=600,height=400');
     toast.success(t('sharedToFacebook'));
     trackEvent(trackingEnabled, 'share_facebook');
@@ -45,14 +50,14 @@ export const ShareModal: React.FC<ShareModalProps> = ({
 
   const shareToTwitter = () => {
     const text = encodeURIComponent(`${shareCaption} #SoraAI #AIGeneration`);
-    const url = `https://twitter.com/intent/tweet?text=${text}&url=${encodeURIComponent(window.location.href)}`;
+    const url = `https://twitter.com/intent/tweet?text=${text}&url=${encodeURIComponent(shareUrl)}`;
     window.open(url, '_blank', 'noopener,width=600,height=400');
     toast.success(t('sharedToTwitter'));
     trackEvent(trackingEnabled, 'share_twitter');
   };
 
   const shareToWhatsApp = () => {
-    const text = encodeURIComponent(`${shareCaption}\n\n${jsonContent}`);
+    const text = encodeURIComponent(`${shareCaption}\n\n${jsonContent}\n${shareUrl}`);
     const url = `https://wa.me/?text=${text}`;
     window.open(url, '_blank', 'noopener');
     toast.success(t('sharedToWhatsApp'));
@@ -61,7 +66,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
 
   const shareToTelegram = () => {
     const text = encodeURIComponent(`${shareCaption}\n\n${jsonContent}`);
-    const url = `https://t.me/share/url?url=${encodeURIComponent(window.location.href)}&text=${text}`;
+    const url = `https://t.me/share/url?url=${encodeURIComponent(shareUrl)}&text=${text}`;
     window.open(url, '_blank', 'noopener');
     toast.success(t('sharedToTelegram'));
     trackEvent(trackingEnabled, 'share_telegram');
@@ -73,7 +78,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
       return;
     }
     try {
-      await navigator.clipboard.writeText(window.location.href);
+      await navigator.clipboard.writeText(shareUrl);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
       toast.success(t('linkCopied'));

--- a/src/components/__tests__/ShareModal.test.tsx
+++ b/src/components/__tests__/ShareModal.test.tsx
@@ -61,7 +61,9 @@ describe('ShareModal', () => {
 
   test('shares to Facebook', () => {
     renderModal();
-    const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}&quote=${encodeURIComponent(i18n.t('shareCaption'))}`;
+    const shareUrl = new URL(window.location.href);
+    shareUrl.searchParams.set('ref', 'share');
+    const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl.toString())}&quote=${encodeURIComponent(i18n.t('shareCaption'))}`;
     fireEvent.click(screen.getByRole('button', { name: /facebook/i }));
     expect(openSpy).toHaveBeenCalledWith(
       url,
@@ -76,7 +78,9 @@ describe('ShareModal', () => {
     const text = encodeURIComponent(
       `${i18n.t('shareCaption')} #SoraAI #AIGeneration`,
     );
-    const url = `https://twitter.com/intent/tweet?text=${text}&url=${encodeURIComponent(window.location.href)}`;
+    const shareUrl = new URL(window.location.href);
+    shareUrl.searchParams.set('ref', 'share');
+    const url = `https://twitter.com/intent/tweet?text=${text}&url=${encodeURIComponent(shareUrl.toString())}`;
     fireEvent.click(screen.getByRole('button', { name: /twitter\/x/i }));
     expect(openSpy).toHaveBeenCalledWith(
       url,
@@ -88,7 +92,9 @@ describe('ShareModal', () => {
 
   test('shares to WhatsApp', () => {
     renderModal();
-    const text = encodeURIComponent(`${i18n.t('shareCaption')}\n\nmyjson`);
+    const shareUrl = new URL(window.location.href);
+    shareUrl.searchParams.set('ref', 'share');
+    const text = encodeURIComponent(`${i18n.t('shareCaption')}\n\nmyjson\n${shareUrl.toString()}`);
     const url = `https://wa.me/?text=${text}`;
     fireEvent.click(screen.getByRole('button', { name: /whatsapp/i }));
     expect(openSpy).toHaveBeenCalledWith(url, '_blank', 'noopener');
@@ -98,7 +104,9 @@ describe('ShareModal', () => {
   test('shares to Telegram', () => {
     renderModal();
     const text = encodeURIComponent(`${i18n.t('shareCaption')}\n\nmyjson`);
-    const url = `https://t.me/share/url?url=${encodeURIComponent(window.location.href)}&text=${text}`;
+    const shareUrl = new URL(window.location.href);
+    shareUrl.searchParams.set('ref', 'share');
+    const url = `https://t.me/share/url?url=${encodeURIComponent(shareUrl.toString())}&text=${text}`;
     fireEvent.click(screen.getByRole('button', { name: /telegram/i }));
     expect(openSpy).toHaveBeenCalledWith(url, '_blank', 'noopener');
     expect(trackEvent).toHaveBeenCalledWith(true, 'share_telegram');
@@ -114,8 +122,10 @@ describe('ShareModal', () => {
     renderModal();
     const btn = screen.getByRole('button', { name: /copy link/i });
     fireEvent.click(btn);
+    const shareUrl = new URL(window.location.href);
+    shareUrl.searchParams.set('ref', 'share');
     await waitFor(() =>
-      expect(writeText).toHaveBeenCalledWith(window.location.href),
+      expect(writeText).toHaveBeenCalledWith(shareUrl.toString()),
     );
     expect(toast.success).toHaveBeenCalledWith(i18n.t('linkCopied'));
     expect(trackEvent).toHaveBeenCalledWith(true, 'copy_link');


### PR DESCRIPTION
## Summary
- append `?ref=share` to generated share URLs
- update ShareModal tests for new referral links
- document referral parameter in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dc887840883258beec475913c6b6b