### PR TITLE
feat: check for service worker updates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ go "my eyes!" when there's bright white lights.
 - Shared links append `?ref=share` for referral tracking
 - Internationalization support for English, Spanish and other 2 dozens of locales
 - Works offline thanks to service worker caching of assets
+- Automatically checks for service worker updates on load and when opening the Settings panel
 
 Example JSON output:
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import i18n from './i18n';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { useEffect, lazy, Suspense } from 'react';
 import { safeGet } from '@/lib/storage';
+import { useUpdateCheck } from '@/hooks/use-update-check';
 const Index = lazy(() => import('./pages/Index'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 import ErrorBoundary from './components/ErrorBoundary';
@@ -26,6 +27,11 @@ const App = () => {
       document.documentElement.classList.add('dark');
     }
   }, []);
+
+  const checkForUpdate = useUpdateCheck();
+  useEffect(() => {
+    checkForUpdate();
+  }, [checkForUpdate]);
 
   return (
     <I18nextProvider i18n={i18n}>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -29,6 +29,7 @@ import {
 import { toast } from '@/components/ui/sonner-toast';
 import { trackEvent } from '@/lib/analytics';
 import { purgeCache } from '@/lib/purgeCache';
+import { useUpdateCheck } from '@/hooks/use-update-check';
 
 interface SettingsPanelProps {
   open: boolean;
@@ -70,12 +71,14 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const { t } = useTranslation();
   const [confirmDisableTracking, setConfirmDisableTracking] = useState(false);
   const [confirmEnableTracking, setConfirmEnableTracking] = useState(false);
+  const checkForUpdate = useUpdateCheck();
 
   useEffect(() => {
     if (open) {
       trackEvent(trackingEnabled, 'settings_open');
+      checkForUpdate();
     }
-  }, [open, trackingEnabled]);
+  }, [open, trackingEnabled, checkForUpdate]);
 
   return (
     <>

--- a/src/hooks/__tests__/use-update-check.test.ts
+++ b/src/hooks/__tests__/use-update-check.test.ts
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react';
+import { useUpdateCheck } from '../use-update-check';
+
+describe('useUpdateCheck', () => {
+  const originalSW = navigator.serviceWorker;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: originalSW,
+    });
+    jest.clearAllMocks();
+  });
+
+  it('calls update on registration', async () => {
+    const update = jest.fn().mockResolvedValue(undefined);
+    const getRegistration = jest.fn().mockResolvedValue({ update });
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: { getRegistration },
+    });
+    const { result } = renderHook(() => useUpdateCheck());
+    await act(async () => {
+      await result.current();
+    });
+    expect(getRegistration).toHaveBeenCalled();
+    expect(update).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/use-update-check.ts
+++ b/src/hooks/use-update-check.ts
@@ -1,0 +1,19 @@
+import { useCallback } from 'react';
+
+export function useUpdateCheck() {
+  return useCallback(async () => {
+    if (!('serviceWorker' in navigator)) return;
+    try {
+      const registration = await navigator.serviceWorker.getRegistration();
+      if (!registration) return;
+      await registration.update();
+      if (registration.waiting) {
+        window.location.reload();
+      }
+    } catch (error) {
+      console.error('Service worker update check failed', error);
+    }
+  }, []);
+}
+
+export default useUpdateCheck;


### PR DESCRIPTION
## Summary
- add `useUpdateCheck` hook to refresh service worker and reload when a new version is waiting
- run update checks on app start and when Settings panel is opened
- document automatic update checks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e165bcd1c8325bdac85ecc1cb87f4