### PR TITLE
feat: improve dark mode initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,10 @@
         document.documentElement.lang = 'en';
       }
     </script>
-    <script>
+    <script type="module">
+      import { DARK_MODE } from './src/lib/storage-keys.ts';
       try {
-        const val = localStorage.getItem('darkMode');
+        const val = localStorage.getItem(DARK_MODE);
         if (val === null || val === 'true') {
           document.documentElement.classList.add('dark');
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,8 @@ import { I18nextProvider } from 'react-i18next';
 import i18n from './i18n';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { useEffect, lazy, Suspense } from 'react';
-import { safeGet } from '@/lib/storage';
 import { useUpdateCheck } from '@/hooks/use-update-check';
+import { useDarkMode } from '@/hooks/use-dark-mode';
 const Index = lazy(() => import('./pages/Index'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 import ErrorBoundary from './components/ErrorBoundary';
@@ -22,12 +22,7 @@ const queryClient = new QueryClient({
 });
 
 const App = () => {
-  useEffect(() => {
-    if (safeGet('darkMode') === null) {
-      document.documentElement.classList.add('dark');
-    }
-  }, []);
-
+  useDarkMode();
   const checkForUpdate = useUpdateCheck();
   useEffect(() => {
     checkForUpdate();

--- a/src/__tests__/AppDarkMode.test.tsx
+++ b/src/__tests__/AppDarkMode.test.tsx
@@ -12,34 +12,29 @@ jest.mock('../components/Dashboard', () => ({
 }));
 
 import App from '../App';
-import { safeGet } from '@/lib/storage';
 import '../i18n';
-
-jest.mock('@/lib/storage', () => ({
-  __esModule: true,
-  safeGet: jest.fn(),
-}));
+import { DARK_MODE } from '@/lib/storage-keys';
 
 describe('App dark mode handling', () => {
   beforeEach(() => {
     document.documentElement.classList.remove('dark');
-    (safeGet as jest.Mock).mockReset();
+    localStorage.clear();
     window.matchMedia = jest.fn().mockReturnValue({
+      matches: true,
       addEventListener: jest.fn(),
       removeEventListener: jest.fn(),
     }) as unknown as typeof window.matchMedia;
   });
 
-  test('adds dark class when safeGet returns null', async () => {
-    (safeGet as jest.Mock).mockReturnValueOnce(null);
+  test('adds dark class when matchMedia prefers dark', async () => {
     await act(async () => {
       render(<App />);
     });
     expect(document.documentElement.classList.contains('dark')).toBe(true);
   });
 
-  test('does not add dark class when safeGet returns value', async () => {
-    (safeGet as jest.Mock).mockReturnValueOnce('true');
+  test('respects localStorage value over matchMedia', async () => {
+    localStorage.setItem(DARK_MODE, 'false');
     await act(async () => {
       render(<App />);
     });

--- a/src/hooks/__tests__/use-dark-mode.test.ts
+++ b/src/hooks/__tests__/use-dark-mode.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { useDarkMode } from '../use-dark-mode';
+import { DARK_MODE } from '@/lib/storage-keys';
 
 function hasDarkClass() {
   return document.documentElement.classList.contains('dark');
@@ -10,11 +11,12 @@ describe('useDarkMode', () => {
     localStorage.clear();
     jest.restoreAllMocks();
     document.documentElement.classList.remove('dark');
+    window.matchMedia = jest.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia;
   });
 
   test('reads and writes localStorage', () => {
     const setSpy = jest.spyOn(Storage.prototype, 'setItem');
-    localStorage.setItem('darkMode', 'false');
+    localStorage.setItem(DARK_MODE, 'false');
     const { result } = renderHook(() => useDarkMode());
     expect(result.current[0]).toBe(false);
     expect(hasDarkClass()).toBe(false);
@@ -23,8 +25,15 @@ describe('useDarkMode', () => {
       result.current[1](true);
     });
 
-    expect(localStorage.getItem('darkMode')).toBe('true');
-    expect(setSpy).toHaveBeenCalledWith('darkMode', 'true');
+    expect(localStorage.getItem(DARK_MODE)).toBe('true');
+    expect(setSpy).toHaveBeenCalledWith(DARK_MODE, 'true');
     expect(hasDarkClass()).toBe(true);
+  });
+
+  test('initializes from matchMedia when localStorage unset', () => {
+    (window.matchMedia as jest.Mock).mockReturnValueOnce({ matches: false });
+    const { result } = renderHook(() => useDarkMode());
+    expect(result.current[0]).toBe(false);
+    expect(hasDarkClass()).toBe(false);
   });
 });

--- a/src/hooks/use-dark-mode.ts
+++ b/src/hooks/use-dark-mode.ts
@@ -3,7 +3,11 @@ import { useLocalStorageState } from './use-local-storage-state';
 import { DARK_MODE } from '@/lib/storage-keys';
 
 export function useDarkMode() {
-  const [isDark, setIsDark] = useLocalStorageState(DARK_MODE, true);
+  const prefersDark =
+    typeof window !== 'undefined' && 'matchMedia' in window
+      ? window.matchMedia('(prefers-color-scheme: dark)').matches
+      : true;
+  const [isDark, setIsDark] = useLocalStorageState(DARK_MODE, prefersDark);
 
   useEffect(() => {
     const root = document.documentElement;


### PR DESCRIPTION
## Summary
- derive dark mode from system preference when no stored value exists
- centralize dark mode storage key usage
- remove redundant dark mode check from app startup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689be37d50688325842cbc602fe81c95