### PR TITLE
feat: sync local storage state across tabs

### DIFF
--- a/src/hooks/__tests__/use-local-storage-state.test.ts
+++ b/src/hooks/__tests__/use-local-storage-state.test.ts
@@ -45,4 +45,39 @@ describe('useLocalStorageState', () => {
     expect(storage.safeSet).toHaveBeenLastCalledWith('obj', { a: 2 }, true);
     expect(result.current[0]).toEqual({ a: 2 });
   });
+
+  test('updates state when storage event fires for same key', () => {
+    (storage.safeGet as jest.Mock).mockReturnValue('one');
+    const { result } = renderHook(() => useLocalStorageState('key', 'default'));
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'key',
+          newValue: 'two',
+          storageArea: window.localStorage,
+        }),
+      );
+    });
+
+    expect(result.current[0]).toBe('two');
+  });
+
+  test('cleans up storage listener on unmount', () => {
+    (storage.safeGet as jest.Mock).mockReturnValue('init');
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useLocalStorageState('key', 'default'));
+
+    const handler = addSpy.mock.calls.find((c) => c[0] === 'storage')?.[1];
+    expect(addSpy).toHaveBeenCalledWith('storage', expect.any(Function));
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('storage', handler);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
 });

--- a/src/hooks/use-local-storage-state.ts
+++ b/src/hooks/use-local-storage-state.ts
@@ -20,5 +20,25 @@ export function useLocalStorageState<T>(
     }
   }, [key, state, isString]);
 
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.storageArea !== window.localStorage || e.key !== key) return;
+      if (e.newValue === null) {
+        setState(defaultValue);
+        return;
+      }
+      try {
+        const value = isString
+          ? (e.newValue as unknown as T)
+          : (JSON.parse(e.newValue) as T);
+        setState(value);
+      } catch (err) {
+        console.warn('useLocalStorageState: failed to parse storage event', err);
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, [key, isString, defaultValue]);
+
   return [state, setState];
 }


### PR DESCRIPTION
## Summary
- update `useLocalStorageState` with a storage event listener and cleanup to sync across tabs
- add tests covering cross-tab updates and listener cleanup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689be718cd9083259d60c0b7d334841b