### PR TITLE
Localize toast messages in hooks

### DIFF
--- a/src/hooks/__tests__/use-clipboard.test.tsx
+++ b/src/hooks/__tests__/use-clipboard.test.tsx
@@ -41,9 +41,11 @@ describe('useClipboard', () => {
       value: { writeText },
     });
     const { result } = renderHook(() => useClipboard(), { wrapper });
-    await expect(result.current.copy('foo', 'ok')).resolves.toBe(true);
+    await expect(result.current.copy('foo', i18n.t('copied'))).resolves.toBe(
+      true,
+    );
     expect(writeText).toHaveBeenCalledWith('foo');
-    expect(toast.success).toHaveBeenCalledWith('ok');
+    expect(toast.success).toHaveBeenCalledWith(i18n.t('copied'));
   });
 
   test('shows error when API missing', async () => {

--- a/src/hooks/__tests__/use-github-stats.test.tsx
+++ b/src/hooks/__tests__/use-github-stats.test.tsx
@@ -1,6 +1,8 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { useGithubStats } from '../use-github-stats';
 import { toast } from '@/components/ui/sonner-toast';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '@/i18n';
 
 jest.mock('@/components/ui/sonner-toast', () => ({
   __esModule: true,
@@ -17,6 +19,10 @@ describe('useGithubStats', () => {
     global.fetch = originalFetch;
   });
 
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+  );
+
   test('uses cache when fresh', () => {
     localStorage.setItem(
       'githubStats',
@@ -25,7 +31,7 @@ describe('useGithubStats', () => {
     localStorage.setItem('githubStatsTimestamp', JSON.stringify(Date.now()));
     const fetchMock = jest.fn();
     global.fetch = fetchMock as unknown as typeof fetch;
-    const { result } = renderHook(() => useGithubStats());
+    const { result } = renderHook(() => useGithubStats(), { wrapper });
     expect(result.current).toEqual({ stars: 1, forks: 2, issues: 3 });
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -45,7 +51,7 @@ describe('useGithubStats', () => {
         ok: true,
         json: () => Promise.resolve({ total_count: 6 }),
       }) as unknown as typeof fetch;
-    const { result } = renderHook(() => useGithubStats());
+    const { result } = renderHook(() => useGithubStats(), { wrapper });
     await waitFor(() =>
       expect(result.current).toEqual({ stars: 4, forks: 5, issues: 6 }),
     );
@@ -55,9 +61,9 @@ describe('useGithubStats', () => {
     global.fetch = jest
       .fn()
       .mockRejectedValue(new Error('fail')) as unknown as typeof fetch;
-    renderHook(() => useGithubStats());
+    renderHook(() => useGithubStats(), { wrapper });
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith('Failed to load GitHub stats'),
+      expect(toast.error).toHaveBeenCalledWith(i18n.t('githubStatsError')),
     );
   });
 
@@ -68,7 +74,7 @@ describe('useGithubStats', () => {
       return new Promise(() => {});
     });
     global.fetch = fetchMock as unknown as typeof fetch;
-    const { unmount } = renderHook(() => useGithubStats());
+    const { unmount } = renderHook(() => useGithubStats(), { wrapper });
     expect(fetchMock).toHaveBeenCalled();
     unmount();
     expect(signal?.aborted).toBe(true);

--- a/src/hooks/use-github-stats.ts
+++ b/src/hooks/use-github-stats.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { toast } from '@/components/ui/sonner-toast';
+import { useTranslation } from 'react-i18next';
 import { DISABLE_STATS } from '@/lib/config';
 import { safeGet, safeSet } from '@/lib/storage';
 
@@ -10,6 +11,7 @@ export interface GithubStats {
 }
 
 export function useGithubStats() {
+  const { t } = useTranslation();
   const [stats, setStats] = useState<GithubStats>();
 
   useEffect(() => {
@@ -54,13 +56,13 @@ export function useGithubStats() {
         }
       } catch (err) {
         if ((err as Error).name !== 'AbortError') {
-          toast.error('Failed to load GitHub stats');
+          toast.error(t('githubStatsError'));
         }
       }
     };
     void load();
     return () => controller.abort();
-  }, []);
+  }, [t]);
 
   return stats;
 }

--- a/src/locales/bn-IN.json
+++ b/src/locales/bn-IN.json
@@ -107,6 +107,7 @@
   "copyFailed": "লিংক কপি ব্যর্থ হয়েছে",
   "clipboardNotSupported": "ক্লিপবোর্ড সমর্থিত নয়",
   "clipboardUnsupported": "ক্লিপবোর্ড সমর্থিত নয়",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "JSON আমদানি করুন",
   "importJsonDescription": "প্রম্পট আমদানির জন্য JSON পেস্ট করুন অথবা ফাইল নির্বাচন করুন।",
   "pasteJsonPlaceholder": "এখানে JSON পেস্ট করুন",

--- a/src/locales/da-DK.json
+++ b/src/locales/da-DK.json
@@ -107,6 +107,7 @@
   "copyFailed": "Kopiering af link mislykkedes",
   "clipboardNotSupported": "Udklipsholder understøttes ikke",
   "clipboardUnsupported": "Udklipsholder understøttes ikke",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Importer JSON",
   "importJsonDescription": "Indsæt JSON eller vælg en fil for at importere prompten.",
   "pasteJsonPlaceholder": "Indsæt JSON her",

--- a/src/locales/de-AT.json
+++ b/src/locales/de-AT.json
@@ -107,6 +107,7 @@
   "copyFailed": "Link konnte nicht kopiert werden",
   "clipboardNotSupported": "Zwischenablage wird nicht unterstützt",
   "clipboardUnsupported": "Zwischenablage wird nicht unterstützt",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "JSON importieren",
   "importJsonDescription": "Füge JSON ein oder wähle eine Datei, um den Prompt zu importieren.",
   "pasteJsonPlaceholder": "JSON hier einfügen",

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -107,6 +107,7 @@
   "copyFailed": "Kopieren des Links fehlgeschlagen",
   "clipboardNotSupported": "Zwischenablage wird nicht unterstützt",
   "clipboardUnsupported": "Zwischenablage wird nicht unterstützt",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "JSON importieren",
   "importJsonDescription": "Füge JSON ein oder wähle eine Datei, um den Prompt zu importieren.",
   "pasteJsonPlaceholder": "JSON hier einfügen",

--- a/src/locales/el-GR.json
+++ b/src/locales/el-GR.json
@@ -107,6 +107,7 @@
   "copyFailed": "Η αντιγραφή του συνδέσμου απέτυχε",
   "clipboardNotSupported": "Το πρόχειρο δεν υποστηρίζεται",
   "clipboardUnsupported": "Το πρόχειρο δεν υποστηρίζεται",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Εισαγωγή JSON",
   "importJsonDescription": "Επικολλήστε JSON ή επιλέξτε αρχείο για εισαγωγή prompt.",
   "pasteJsonPlaceholder": "Επικολλήστε JSON εδώ",

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -107,6 +107,7 @@
   "copyFailed": "Failed to copy link",
   "clipboardNotSupported": "Clipboard not supported",
   "clipboardUnsupported": "Clipboard not supported",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Import JSON",
   "importJsonDescription": "Paste JSON or choose a file to import a prompt.",
   "pasteJsonPlaceholder": "Paste JSON here",

--- a/src/locales/en-PR.json
+++ b/src/locales/en-PR.json
@@ -107,6 +107,7 @@
   "copyFailed": "Copyin' link failed",
   "clipboardNotSupported": "Clipboard not supported, matey",
   "clipboardUnsupported": "Clipboard not supported, matey",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Import JSON",
   "importJsonDescription": "Paste JSON or choose a file to smuggle a prompt aboard.",
   "pasteJsonPlaceholder": "Paste JSON here",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -116,6 +116,7 @@
   "copyFailed": "Failed to copy link",
   "clipboardNotSupported": "Clipboard not supported",
   "clipboardUnsupported": "Clipboard not supported",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Import JSON",
   "importJsonDescription": "Paste JSON or choose a file to import your prompt.",
   "pasteJsonPlaceholder": "Paste JSON here",

--- a/src/locales/es-AR.json
+++ b/src/locales/es-AR.json
@@ -107,6 +107,7 @@
   "copyFailed": "Falló la copia del enlace",
   "clipboardNotSupported": "El portapapeles no está soportado",
   "clipboardUnsupported": "El portapapeles no está soportado",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Importar JSON",
   "importJsonDescription": "Pegá JSON o elegí un archivo para importar un prompt.",
   "pasteJsonPlaceholder": "Pegá JSON acá",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -107,6 +107,7 @@
   "copyFailed": "Fallo al copiar el enlace",
   "clipboardNotSupported": "El portapapeles no está soportado",
   "clipboardUnsupported": "El portapapeles no está soportado",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Importar JSON",
   "importJsonDescription": "Pega JSON o elige un archivo para importar un prompt.",
   "pasteJsonPlaceholder": "Pega JSON aquí",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -107,6 +107,7 @@
   "copyFailed": "Error al copiar el enlace",
   "clipboardNotSupported": "El portapapeles no es compatible",
   "clipboardUnsupported": "El portapapeles no es compatible",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Importar JSON",
   "importJsonDescription": "Pega JSON o elige un archivo para importar un prompt.",
   "pasteJsonPlaceholder": "Pega JSON aquí",

--- a/src/locales/et-EE.json
+++ b/src/locales/et-EE.json
@@ -107,6 +107,7 @@
   "copyFailed": "Lingi kopeerimine ebaõnnestus",
   "clipboardNotSupported": "Lõikepuhvrit ei toetata",
   "clipboardUnsupported": "Lõikepuhvrit ei toetata",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Impordi JSON",
   "importJsonDescription": "Kleebi JSON või vali fail, et importida prompt.",
   "pasteJsonPlaceholder": "Kleebi JSON siia",

--- a/src/locales/fi-FI.json
+++ b/src/locales/fi-FI.json
@@ -107,6 +107,7 @@
   "copyFailed": "Linkin kopiointi epäonnistui",
   "clipboardNotSupported": "Leikepöytää ei tueta",
   "clipboardUnsupported": "Leikepöytää ei tueta",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Tuo JSON",
   "importJsonDescription": "Liitä JSON tai valitse tiedosto kehotteen tuomista varten.",
   "pasteJsonPlaceholder": "Liitä JSON tähän",

--- a/src/locales/fr-BE.json
+++ b/src/locales/fr-BE.json
@@ -107,6 +107,7 @@
   "copyFailed": "Échec de la copie du lien",
   "clipboardNotSupported": "Le presse-papiers n’est pas pris en charge",
   "clipboardUnsupported": "Le presse-papiers n’est pas pris en charge",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Importer JSON",
   "importJsonDescription": "Collez du JSON ou choisissez un fichier pour importer un prompt.",
   "pasteJsonPlaceholder": "Collez du JSON ici",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -107,6 +107,7 @@
   "copyFailed": "Échec de la copie du lien",
   "clipboardNotSupported": "Presse-papiers non pris en charge",
   "clipboardUnsupported": "Presse-papiers non pris en charge",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Importer le JSON",
   "importJsonDescription": "Collez le JSON ou sélectionnez un fichier pour importer votre invite.",
   "pasteJsonPlaceholder": "Collez le JSON ici",

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -107,6 +107,7 @@
   "copyFailed": "Copia link non riuscita",
   "clipboardNotSupported": "Appunti non supportati",
   "clipboardUnsupported": "Appunti non supportati",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Importa JSON",
   "importJsonDescription": "Incolla il JSON o seleziona un file per importare il tuo prompt.",
   "pasteJsonPlaceholder": "Incolla qui il JSON",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -107,6 +107,7 @@
   "copyFailed": "リンクのコピーに失敗しました",
   "clipboardNotSupported": "クリップボードはサポートされていません",
   "clipboardUnsupported": "クリップボードはサポートされていません",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "JSONをインポート",
   "importJsonDescription": "JSONを貼り付けるか、ファイルを選択してプロンプトをインポートしてください。",
   "pasteJsonPlaceholder": "ここにJSONを貼り付け",

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -107,6 +107,7 @@
   "copyFailed": "링크 복사 실패",
   "clipboardNotSupported": "클립보드가 지원되지 않습니다",
   "clipboardUnsupported": "클립보드가 지원되지 않습니다",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "JSON 가져오기",
   "importJsonDescription": "프롬프트를 가져오기 위해 JSON을 붙여넣거나 파일을 선택하세요.",
   "pasteJsonPlaceholder": "여기에 JSON을 붙여넣기",

--- a/src/locales/ne-NP.json
+++ b/src/locales/ne-NP.json
@@ -107,6 +107,7 @@
   "copyFailed": "लिङ्क प्रतिलिपि असफल",
   "clipboardNotSupported": "क्लिपबोर्ड समर्थन छैन",
   "clipboardUnsupported": "क्लिपबोर्ड समर्थन छैन",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "JSON आयात गर्नुहोस्",
   "importJsonDescription": "प्रम्प्ट आयात गर्न JSON पेस्ट गर्नुहोस् वा फाइल छान्नुहोस्।",
   "pasteJsonPlaceholder": "यहाँ JSON पेस्ट गर्नुहोस्",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -107,6 +107,7 @@
   "copyFailed": "Falha ao copiar link",
   "clipboardNotSupported": "Área de transferência não suportada",
   "clipboardUnsupported": "Área de transferência não suportada",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Importar JSON",
   "importJsonDescription": "Cole o JSON ou selecione um arquivo para importar seu prompt.",
   "pasteJsonPlaceholder": "Cole o JSON aqui",

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -107,6 +107,7 @@
   "copyFailed": "Falha ao copiar a ligação",
   "clipboardNotSupported": "Área de transferência não suportada",
   "clipboardUnsupported": "Área de transferência não suportada",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Importar JSON",
   "importJsonDescription": "Cole o JSON ou escolha um ficheiro para importar o seu prompt.",
   "pasteJsonPlaceholder": "Cole o JSON aqui",

--- a/src/locales/ro-RO.json
+++ b/src/locales/ro-RO.json
@@ -107,6 +107,7 @@
   "copyFailed": "Copiere link eșuată",
   "clipboardNotSupported": "Clipboard neacceptat",
   "clipboardUnsupported": "Clipboard neacceptat",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Importă JSON",
   "importJsonDescription": "Lipește JSON sau selectează un fișier pentru importul promptului tău.",
   "pasteJsonPlaceholder": "Lipește JSON aici",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -107,6 +107,7 @@
   "copyFailed": "Не удалось скопировать ссылку",
   "clipboardNotSupported": "Буфер обмена не поддерживается",
   "clipboardUnsupported": "Буфер обмена не поддерживается",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Импортировать JSON",
   "importJsonDescription": "Вставьте JSON или выберите файл, чтобы импортировать промпт.",
   "pasteJsonPlaceholder": "Вставьте JSON сюда",

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -107,6 +107,7 @@
   "copyFailed": "Misslyckades kopiera länk",
   "clipboardNotSupported": "Urklipp stöds inte",
   "clipboardUnsupported": "Urklipp stöds inte",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Importera JSON",
   "importJsonDescription": "Klistra in JSON eller välj en fil för att importera en prompt.",
   "pasteJsonPlaceholder": "Klistra in JSON här",

--- a/src/locales/th-TH.json
+++ b/src/locales/th-TH.json
@@ -107,6 +107,7 @@
   "copyFailed": "คัดลอกลิงก์ไม่สำเร็จ",
   "clipboardNotSupported": "คลิปบอร์ดไม่รองรับ",
   "clipboardUnsupported": "คลิปบอร์ดไม่รองรับ",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "นำเข้า JSON",
   "importJsonDescription": "วาง JSON หรือเลือกไฟล์เพื่อนำเข้าพรอมต์ของคุณ",
   "pasteJsonPlaceholder": "วาง JSON ที่นี่",

--- a/src/locales/uk-UA.json
+++ b/src/locales/uk-UA.json
@@ -107,6 +107,7 @@
   "copyFailed": "Не вдалося скопіювати посилання",
   "clipboardNotSupported": "Буфер обміну не підтримується",
   "clipboardUnsupported": "Буфер обміну не підтримується",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "Імпортувати JSON",
   "importJsonDescription": "Вставте JSON або оберіть файл для імпорту промпту.",
   "pasteJsonPlaceholder": "Вставте JSON тут",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -107,6 +107,7 @@
   "copyFailed": "复制链接失败",
   "clipboardNotSupported": "剪贴板不受支持",
   "clipboardUnsupported": "剪贴板不受支持",
+  "githubStatsError": "Failed to load GitHub stats",
   "importJsonTitle": "导入 JSON",
   "importJsonDescription": "粘贴 JSON 或选择文件导入您的提示。",
   "pasteJsonPlaceholder": "在此处粘贴 JSON",


### PR DESCRIPTION
## Summary
- localize GitHub stats load failure toast and integrate `useTranslation`
- exercise toast translation paths in clipboard and GitHub stats tests
- add `githubStatsError` to all locale files

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bf1c403fc8325813cc58cbb9fd9af