### PR TITLE
feat(i18n): lazy-load translations

### DIFF
--- a/src/__tests__/i18n.test.tsx
+++ b/src/__tests__/i18n.test.tsx
@@ -2,12 +2,12 @@ import { render, screen } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '../i18n';
 
-afterEach(() => {
-  i18n.changeLanguage('en-US');
+afterEach(async () => {
+  await i18n.changeLanguage('en-US');
 });
 
-test('renders spanish translation', () => {
-  i18n.changeLanguage('es-ES');
+test('renders spanish translation', async () => {
+  await i18n.changeLanguage('es-ES');
   render(
     <I18nextProvider i18n={i18n}>
       <span>{i18n.t('copy')}</span>
@@ -16,8 +16,8 @@ test('renders spanish translation', () => {
   expect(screen.getByText('Copiar')).toBeTruthy();
 });
 
-test('falls back to english when language unsupported', () => {
-  i18n.changeLanguage('xx');
+test('falls back to english when language unsupported', async () => {
+  await i18n.changeLanguage('xx');
   render(
     <I18nextProvider i18n={i18n}>
       <span>{i18n.t('copy')}</span>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,68 +1,31 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import enUS from './locales/en-US.json';
-import esES from './locales/es-ES.json';
-import ptPT from './locales/pt-PT.json';
-import ruRU from './locales/ru-RU.json';
-import ptBR from './locales/pt-BR.json';
-import frFR from './locales/fr-FR.json';
-import deDE from './locales/de-DE.json';
-import zhCN from './locales/zh-CN.json';
-import itIT from './locales/it-IT.json';
-import esMX from './locales/es-MX.json';
-import enGB from './locales/en-GB.json';
-import bnIN from './locales/bn-IN.json';
-import jaJP from './locales/ja-JP.json';
-import enPR from './locales/en-PR.json';
-import koKR from './locales/ko-KR.json';
-import roRO from './locales/ro-RO.json';
-import svSE from './locales/sv-SE.json';
-import ukUA from './locales/uk-UA.json';
-import neNP from './locales/ne-NP.json';
-import daDK from './locales/da-DK.json';
-import etEE from './locales/et-EE.json';
-import fiFI from './locales/fi-FI.json';
-import elGR from './locales/el-GR.json';
-import thTH from './locales/th-TH.json';
-import deAT from './locales/de-AT.json';
-import frBE from './locales/fr-BE.json';
-import esAR from './locales/es-AR.json';
 
-const resources = {
-  'en-US': { translation: enUS },
-  'es-ES': { translation: esES },
-  'pt-PT': { translation: ptPT },
-  'ru-RU': { translation: ruRU },
-  'pt-BR': { translation: ptBR },
-  'fr-FR': { translation: frFR },
-  'de-DE': { translation: deDE },
-  'zh-CN': { translation: zhCN },
-  'it-IT': { translation: itIT },
-  'es-MX': { translation: esMX },
-  'en-GB': { translation: enGB },
-  'bn-IN': { translation: bnIN },
-  'ja-JP': { translation: jaJP },
-  'en-PR': { translation: enPR },
-  'ko-KR': { translation: koKR },
-  'ro-RO': { translation: roRO },
-  'sv-SE': { translation: svSE },
-  'uk-UA': { translation: ukUA },
-  'ne-NP': { translation: neNP },
-  'da-DK': { translation: daDK },
-  'et-EE': { translation: etEE },
-  'fi-FI': { translation: fiFI },
-  'el-GR': { translation: elGR },
-  'th-TH': { translation: thTH },
-  'de-AT': { translation: deAT },
-  'fr-BE': { translation: frBE },
-  'es-AR': { translation: esAR },
-};
-
+// Initialize i18next without preloaded resources.
 i18n.use(initReactI18next).init({
-  resources,
+  resources: {},
   lng: 'en-US',
   fallbackLng: 'en-US',
   interpolation: { escapeValue: false },
 });
+
+const originalChangeLanguage = i18n.changeLanguage.bind(i18n);
+
+// Override changeLanguage to dynamically load translation files on demand.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(i18n as any).changeLanguage = async (lng: string) => {
+  if (!i18n.hasResourceBundle(lng, 'translation')) {
+    try {
+      const { default: translation } = await import(`./locales/${lng}.json`);
+      i18n.addResourceBundle(lng, 'translation', translation, true, true);
+    } catch (error) {
+      console.warn(`Failed to load translations for ${lng}`, error);
+    }
+  }
+  return originalChangeLanguage(lng);
+};
+
+// Load the default language initially.
+void i18n.changeLanguage('en-US');
 
 export default i18n;


### PR DESCRIPTION
## Summary
- load translations on demand by overriding `changeLanguage` with dynamic `import()` calls
- default to English and asynchronously fetch additional languages when selected
- adjust i18n tests for async loading

## Testing
- `npm run lint`
- `npx jest` 
- `npx jest --runTestsByPath __tests__/translations.test.ts src/__tests__/i18n.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689bf1b8b00c83259038645f995c4e3a