### PR TITLE
Use standard reload and log cache purge

### DIFF
--- a/src/lib/purgeCache.ts
+++ b/src/lib/purgeCache.ts
@@ -31,5 +31,6 @@ export async function purgeCache(): Promise<void> {
     console.warn('Failed to unregister service workers', err);
   }
 
-  location.reload(true);
+  console.info('Caches cleared, reloading page');
+  window.location.reload();
 }


### PR DESCRIPTION
## Summary
- call `window.location.reload()` instead of deprecated `location.reload(true)`
- log a message when caches are purged before reload

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bf1af691c83259c86695a828e97d6