### PR TITLE
Sanitize options loaded from JSON

### DIFF
--- a/src/lib/__tests__/loadOptionsFromJson.test.ts
+++ b/src/lib/__tests__/loadOptionsFromJson.test.ts
@@ -19,6 +19,11 @@ describe('loadOptionsFromJson', () => {
     spy.mockRestore();
   });
 
+  test('returns null for invalid options object', () => {
+    const bad = JSON.stringify({ steps: 'ten' });
+    expect(loadOptionsFromJson(bad)).toBeNull();
+  });
+
   test('normalizes composition_rules from snake_case', () => {
     const json = JSON.stringify({ composition_rules: ['rule_of_thirds'] });
     const result = loadOptionsFromJson(json);
@@ -63,5 +68,14 @@ describe('loadOptionsFromJson', () => {
     expect(result.subject_gender).toBe('female');
     expect(result.use_makeup_style).toBe(true);
     expect(result.makeup_style).toBe('gothic');
+  });
+
+  test('ignores dangerous keys to prevent prototype pollution', () => {
+    const json = '{"constructor":{"prototype":{"polluted":"yes"}}}';
+    const result = loadOptionsFromJson(json);
+    expect(result).not.toBeNull();
+    const typed = result as unknown as Record<string, unknown>;
+    expect(typed['polluted']).toBeUndefined();
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- strip dangerous keys from JSON before merging
- validate parsed options and return null when invalid
- add tests covering invalid or polluted input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bf0f984d48325a406c2fb76246b43