### PR TITLE
Improve custom preset loading error handling

### DIFF
--- a/src/lib/presetLoader.ts
+++ b/src/lib/presetLoader.ts
@@ -96,9 +96,27 @@ export function importCustomPresets(data: string | CustomPresetData): void {
 }
 
 export async function loadCustomPresetsFromUrl(url: string) {
+  let res: Response;
   try {
-    const res = await fetch(url);
-    const json = await res.json();
+    res = await fetch(url);
+  } catch (err) {
+    throw new Error('Failed to load custom presets: ' + err);
+  }
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to load custom presets: HTTP ${res.status} ${res.statusText || ''}`.trim(),
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = await res.json();
+  } catch (err) {
+    throw new Error('Failed to load custom presets: invalid JSON: ' + err);
+  }
+
+  try {
     importCustomPresets(json);
   } catch (err) {
     throw new Error('Failed to load custom presets: ' + err);


### PR DESCRIPTION
## Summary
- Improve error handling in `loadCustomPresetsFromUrl` to check HTTP status and surface invalid JSON errors
- Test non-OK responses and malformed JSON from the presets loader

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bf5b66af48325bcff5692ad2e46ac