### PR TITLE
feat: add CLI for JSON generation

### DIFF
--- a/cli/__tests__/index.test.ts
+++ b/cli/__tests__/index.test.ts
@@ -1,0 +1,21 @@
+/** @jest-environment node */
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { writeFileSync } from 'node:fs';
+import { runCli } from '../index.ts';
+
+test('generates JSON from flags', () => {
+  const out = runCli(['--prompt', 'hello', '--width', '123']);
+  const obj = JSON.parse(out);
+  expect(obj.prompt).toBe('hello');
+  expect(obj.width).toBe(123);
+});
+
+test('generates JSON from file', () => {
+  const file = join(tmpdir(), 'options.json');
+  writeFileSync(file, JSON.stringify({ prompt: 'from file', width: 456 }));
+  const out = runCli(['--file', file]);
+  const obj = JSON.parse(out);
+  expect(obj.prompt).toBe('from file');
+  expect(obj.width).toBe(456);
+});

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { generateJson } from '../src/lib/generateJson.ts';
+import { loadOptionsFromJson } from '../src/lib/loadOptionsFromJson.ts';
+import { DEFAULT_OPTIONS } from '../src/lib/defaultOptions.ts';
+import { OPTION_FLAG_MAP } from '../src/lib/optionFlagMap.ts';
+import type { SoraOptions } from '../src/lib/soraOptions.ts';
+
+function parseArgs(argv: string[]): Record<string, string | boolean> {
+  const args: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        args[key] = next;
+        i++;
+      } else {
+        args[key] = true;
+      }
+    }
+  }
+  return args;
+}
+
+function buildOptionsFromFlags(values: Record<string, string | boolean>): SoraOptions {
+  const updates: Partial<SoraOptions> = {};
+
+  Object.entries(values).forEach(([key, value]) => {
+    if (key === 'file') return;
+    const defaultVal = DEFAULT_OPTIONS[key as keyof SoraOptions];
+    if (defaultVal === undefined) return;
+
+    let parsed: any = value;
+    if (typeof defaultVal === 'number') {
+      parsed = Number(value);
+    } else if (typeof defaultVal === 'boolean') {
+      parsed = value === 'true' || value === true;
+    } else if (Array.isArray(defaultVal)) {
+      parsed = String(value).split(',');
+    }
+    (updates as any)[key] = parsed;
+
+    const flag = OPTION_FLAG_MAP[key];
+    if (flag) (updates as any)[flag] = true;
+    if (key.startsWith('dnd_')) (updates as any).use_dnd_section = true;
+    if (key === 'width' || key === 'height') (updates as any).use_dimensions = true;
+  });
+
+  return { ...DEFAULT_OPTIONS, ...updates };
+}
+
+export function runCli(argv: string[]): string {
+  const args = parseArgs(argv);
+
+  let options: SoraOptions | null = null;
+
+  if (typeof args.file === 'string') {
+    try {
+      const json = readFileSync(args.file, 'utf8');
+      options = loadOptionsFromJson(json);
+    } catch {
+      options = null;
+    }
+  }
+
+  if (!options) {
+    options = buildOptionsFromFlags(args);
+  }
+
+  return generateJson(options);
+}
+
+if (process.argv[1]?.includes('cli/index')) {
+  process.stdout.write(runCli(process.argv.slice(2)));
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "overrides": {
     "test-exclude": "^7.0.1"
   },
+  "bin": {
+    "sora-crafter": "dist/cli/index.js"
+  },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-accordion": "^1.2.0",

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,26 @@ npm run dev
 Copy `.env.example` to `.env` and adjust the variables. `VITE_MEASUREMENT_ID` holds your Google Analytics ID and `VITE_DISABLE_ANALYTICS` disables tracking. `VITE_DISABLE_STATS` disables the GitHub stats fetch. `VITE_DISCLAIMER_URL` can point to a custom path and should include a `{locale}` placeholder. Set `VITE_GTAG_DEBUG` to `true` to enable GA debug mode.
 Then open http://localhost:8080 in your browser.
 
+### CLI
+
+Generate prompt JSON directly from the command line:
+
+```sh
+npx ts-node cli/index.ts --prompt "A castle at dawn" --width 800
+```
+
+Load options from a JSON file instead:
+
+```sh
+npx ts-node cli/index.ts --file options.json
+```
+
+When installed from npm, the CLI is exposed as `sora-crafter`:
+
+```sh
+sora-crafter --prompt "A castle at dawn"
+```
+
 ### Docker
 
 Build and run a containerized version of the app:


### PR DESCRIPTION
## Summary
- add a CLI that generates JSON from flags or a file
- expose CLI via `sora-crafter` bin
- document CLI usage and add tests

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689bf9aeb3b08325ac9c55d03aea9674