### PR TITLE
refactor: centralize common option prefixes

### DIFF
--- a/src/data/cameraPresets.ts
+++ b/src/data/cameraPresets.ts
@@ -1,8 +1,7 @@
+import { COMMON_OPTION_PREFIXES } from './commonOptions';
+
 export const shotTypeOptions = [
-  'default',
-  'as is',
-  'not defined',
-  'keep original',
+  ...COMMON_OPTION_PREFIXES,
   'establishing',
   'wide',
   'extreme wide',
@@ -65,10 +64,7 @@ export const shotTypeOptions = [
 export type ShotTypeOption = (typeof shotTypeOptions)[number];
 
 export const cameraAngleOptions = [
-  'default',
-  'as is',
-  'not defined',
-  'keep original',
+  ...COMMON_OPTION_PREFIXES,
   'eye-level',
   'high',
   'low',
@@ -241,10 +237,7 @@ export const cameraTypeOptions = [
 export type CameraTypeOption = (typeof cameraTypeOptions)[number];
 
 export const lensTypeOptions = [
-  'default',
-  'as is',
-  'not defined',
-  'keep original',
+  ...COMMON_OPTION_PREFIXES,
   'standard 50mm',
   'wide 24mm',
   'ultra wide 14mm',

--- a/src/data/commonOptions.ts
+++ b/src/data/commonOptions.ts
@@ -1,0 +1,8 @@
+export const COMMON_OPTION_PREFIXES = [
+  'default',
+  'as is',
+  'not defined',
+  'keep original',
+] as const;
+
+export type CommonOptionPrefix = (typeof COMMON_OPTION_PREFIXES)[number];

--- a/src/data/locationPresets.ts
+++ b/src/data/locationPresets.ts
@@ -1,7 +1,7 @@
+import { COMMON_OPTION_PREFIXES } from './commonOptions';
+
 export const environmentOptions = [
-  'default',
-  'not defined',
-  'keep original',
+  ...COMMON_OPTION_PREFIXES,
   'any',
   'real world only',
   'original worlds only',

--- a/src/data/materialOptions.ts
+++ b/src/data/materialOptions.ts
@@ -1,7 +1,7 @@
+import { COMMON_OPTION_PREFIXES } from './commonOptions';
+
 export const materialOptions = [
-  'default',
-  'not defined',
-  'keep original',
+  ...COMMON_OPTION_PREFIXES,
   'any',
   'surprise me',
   'real textures only',


### PR DESCRIPTION
## Summary
- add `COMMON_OPTION_PREFIXES` constant for shared preset values
- reuse common prefix in camera, material, and location presets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c864bad1c8325972aac5760640d2b