### PR TITLE
Refactor options update tracking to single event

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -242,27 +242,19 @@ const Dashboard = () => {
 
   const updateOptions = (updates: Partial<SoraOptions>) => {
     setOptions((prev) => {
-      const next = { ...prev, ...updates };
-      Object.keys(updates).forEach((key) => {
-        const value = updates[key as keyof SoraOptions];
-        if (key.startsWith('use_')) {
-          if (
-            typeof value === 'boolean' &&
-            value !== prev[key as keyof SoraOptions]
-          ) {
-            trackEvent(trackingEnabled, 'section_toggle', {
-              section: key,
-              enabled: value,
-            });
-          }
-        } else if (key === 'prompt') {
-          trackEvent(trackingEnabled, 'prompt_change');
-        } else if (key === 'negative_prompt') {
-          trackEvent(trackingEnabled, 'negative_prompt_change');
-        } else {
-          trackEvent(trackingEnabled, 'input_change');
-        }
+      const changedKeys = Object.keys(updates).filter((key) => {
+        const newValue = updates[key as keyof SoraOptions];
+        return newValue !== prev[key as keyof SoraOptions];
       });
+
+      const next = { ...prev, ...updates };
+
+      if (changedKeys.length > 0) {
+        trackEvent(trackingEnabled, 'options_change', {
+          keys: changedKeys.join(','),
+        });
+      }
+
       return next;
     });
   };

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -258,13 +258,28 @@ describe('Dashboard interactions', () => {
     render(<Dashboard />);
     await waitFor(() => expect(updateFn).not.toBeNull());
 
+    (trackEvent as jest.Mock).mockClear();
+
     act(() => {
-      updateFn?.({ prompt: 'foo' });
+      updateFn?.({ prompt: 'foo', negative_prompt: 'bar' });
     });
+
+    const optionCalls = (trackEvent as jest.Mock).mock.calls.filter(
+      (c) => c[1] === 'options_change',
+    );
+    expect(optionCalls).toHaveLength(1);
+    expect(optionCalls[0]).toEqual([
+      true,
+      'options_change',
+      { keys: 'prompt,negative_prompt' },
+    ]);
+
+    (trackEvent as jest.Mock).mockClear();
 
     await waitFor(() => {
       const json = JSON.parse(localStorage.getItem('currentJson') || '{}');
       expect(json.prompt).toBe('foo');
+      expect(json.negative_prompt).toBe('bar');
     });
 
     const copyButton = screen.getByRole('button', { name: /copy/i });


### PR DESCRIPTION
## Summary
- track changed option keys and emit one analytics event
- test dashboard updates for a single tracking call with key list

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c8630a3988325b56fc8416fa5f538