### PR TITLE
refactor: centralize toggleable fields

### DIFF
--- a/src/components/ToggleField.tsx
+++ b/src/components/ToggleField.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+
+interface ToggleFieldProps {
+  id: string;
+  label: React.ReactNode;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  children: React.ReactNode;
+}
+
+const cloneChildrenWithDisabled = (
+  children: React.ReactNode,
+  disabled: boolean,
+): React.ReactNode => {
+  return React.Children.map(children, (child) => {
+    if (React.isValidElement(child)) {
+      return React.cloneElement(
+        child,
+        {
+          ...(child.props as Record<string, unknown>),
+          disabled,
+          children: cloneChildrenWithDisabled(child.props.children, disabled),
+        },
+      );
+    }
+    return child;
+  });
+};
+
+export const ToggleField: React.FC<ToggleFieldProps> = ({
+  id,
+  label,
+  checked,
+  onCheckedChange,
+  children,
+}) => {
+  const disabled = !checked;
+  const clonedChildren = cloneChildrenWithDisabled(children, disabled);
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id={id}
+          checked={checked}
+          onCheckedChange={(value) => onCheckedChange(!!value)}
+        />
+        <Label htmlFor={id}>{label}</Label>
+      </div>
+      <div className={disabled ? 'opacity-50 pointer-events-none' : ''}>{clonedChildren}</div>
+    </div>
+  );
+};
+
+export default ToggleField;
+

--- a/src/components/__tests__/PromptSection.test.tsx
+++ b/src/components/__tests__/PromptSection.test.tsx
@@ -23,7 +23,9 @@ describe('PromptSection', () => {
     fireEvent.change(promptInput, { target: { value: 'new prompt' } });
     expect(updateOptions).toHaveBeenCalledWith({ prompt: 'new prompt' });
 
-    const negativeInput = screen.getByLabelText(/^negative prompt$/i);
+    const negativeInput = screen.getByRole('textbox', {
+      name: /negative prompt/i,
+    });
     fireEvent.change(negativeInput, { target: { value: 'new negative' } });
     expect(updateOptions).toHaveBeenCalledWith({
       negative_prompt: 'new negative',
@@ -41,7 +43,7 @@ describe('PromptSection', () => {
       />,
     );
 
-    const textarea = screen.getByLabelText(/^negative prompt$/i);
+    const textarea = screen.getByRole('textbox', { name: /negative prompt/i });
     expect(textarea.hasAttribute('disabled')).toBe(true);
 
     const checkbox = screen.getByRole('checkbox');
@@ -56,7 +58,9 @@ describe('PromptSection', () => {
       />,
     );
     expect(
-      screen.getByLabelText(/^negative prompt$/i).hasAttribute('disabled'),
+      screen.getByRole('textbox', { name: /negative prompt/i }).hasAttribute(
+        'disabled',
+      ),
     ).toBe(false);
   });
 });

--- a/src/components/sections/CameraCompositionSection.tsx
+++ b/src/components/sections/CameraCompositionSection.tsx
@@ -8,10 +8,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Checkbox } from '@/components/ui/checkbox';
 import { SearchableDropdown } from '../SearchableDropdown';
 import { MultiSelectDropdown } from '../MultiSelectDropdown';
 import { CollapsibleSection } from '../CollapsibleSection';
+import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
 import { cameraOptionTranslations } from '@/data/optionTranslations';
 import { getOptionLabel as translateOption } from '@/lib/optionTranslator';
@@ -64,30 +64,27 @@ export const CameraCompositionSection: React.FC<
           />
         </div>
 
-        <div className="flex items-center space-x-2 mb-4">
-          <Checkbox
-            id="use_lens_type"
-            checked={options.use_lens_type}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_lens_type: !!checked })
-            }
-          />
-          <Label htmlFor="use_lens_type">{t('useLensType')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('lensType')}</Label>
-          <SearchableDropdown
-            options={lensTypeOptions}
-            value={options.lens_type}
-            onValueChange={(value) => updateOptions({ lens_type: value })}
-            label="Lens Type"
-            disabled={!options.use_lens_type}
-            getOptionLabel={(opt) =>
-              translateOption(opt, cameraOptionTranslations.lensType, t)
-            }
-          />
-        </div>
+        <ToggleField
+          id="use_lens_type"
+          label={t('useLensType')}
+          checked={options.use_lens_type}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_lens_type: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('lensType')}</Label>
+            <SearchableDropdown
+              options={lensTypeOptions}
+              value={options.lens_type}
+              onValueChange={(value) => updateOptions({ lens_type: value })}
+              label="Lens Type"
+              getOptionLabel={(opt) =>
+                translateOption(opt, cameraOptionTranslations.lensType, t)
+              }
+            />
+          </div>
+        </ToggleField>
 
         <div>
           <Label>{t('shotType')}</Label>
@@ -102,30 +99,29 @@ export const CameraCompositionSection: React.FC<
           />
         </div>
 
-        <div className="flex items-center space-x-2 mb-4">
-          <Checkbox
-            id="use_camera_angle"
-            checked={options.use_camera_angle}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_camera_angle: !!checked })
-            }
-          />
-          <Label htmlFor="use_camera_angle">{t('useCameraAngle')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('cameraAngle')}</Label>
-          <SearchableDropdown
-            options={cameraAngleOptions}
-            value={options.camera_angle}
-            onValueChange={(value) => updateOptions({ camera_angle: value })}
-            label="Camera Angle"
-            disabled={!options.use_camera_angle}
-            getOptionLabel={(opt) =>
-              translateOption(opt, cameraOptionTranslations.cameraAngle, t)
-            }
-          />
-        </div>
+        <ToggleField
+          id="use_camera_angle"
+          label={t('useCameraAngle')}
+          checked={options.use_camera_angle}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_camera_angle: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('cameraAngle')}</Label>
+            <SearchableDropdown
+              options={cameraAngleOptions}
+              value={options.camera_angle}
+              onValueChange={(value) =>
+                updateOptions({ camera_angle: value })
+              }
+              label="Camera Angle"
+              getOptionLabel={(opt) =>
+                translateOption(opt, cameraOptionTranslations.cameraAngle, t)
+              }
+            />
+          </div>
+        </ToggleField>
 
         <div>
           <Label htmlFor="subject_focus">{t('subjectFocus')}</Label>
@@ -166,78 +162,81 @@ export const CameraCompositionSection: React.FC<
           />
         </div>
 
-        <div className="flex items-center space-x-2 mb-4">
-          <Checkbox
-            id="use_aperture"
-            checked={options.use_aperture}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_aperture: !!checked })
-            }
-          />
-          <Label htmlFor="use_aperture">{t('useAperture')}</Label>
-        </div>
+        <ToggleField
+          id="use_aperture"
+          label={t('useAperture')}
+          checked={options.use_aperture}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_aperture: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('aperture')}</Label>
+            <SearchableDropdown
+              options={apertureOptions}
+              value={options.aperture}
+              onValueChange={(value) =>
+                updateOptions({ aperture: value })
+              }
+              label="Aperture"
+              getOptionLabel={(opt) =>
+                translateOption(opt, cameraOptionTranslations.aperture, t)
+              }
+            />
+          </div>
+        </ToggleField>
 
-        <div>
-          <Label>{t('aperture')}</Label>
-          <SearchableDropdown
-            options={apertureOptions}
-            value={options.aperture}
-            onValueChange={(value) => updateOptions({ aperture: value })}
-            label="Aperture"
-            disabled={!options.use_aperture}
-            getOptionLabel={(opt) =>
-              translateOption(opt, cameraOptionTranslations.aperture, t)
-            }
-          />
-        </div>
+        <ToggleField
+          id="use_dof"
+          label={t('useDepthOfField')}
+          checked={options.use_dof}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_dof: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('depthOfField')}</Label>
+            <SearchableDropdown
+              options={depthOfFieldOptions}
+              value={options.depth_of_field || 'default'}
+              onValueChange={(value) =>
+                updateOptions({ depth_of_field: value })
+              }
+              label="Depth of Field Options"
+              getOptionLabel={(opt) =>
+                translateOption(
+                  opt,
+                  cameraOptionTranslations.depthOfField,
+                  t,
+                )
+              }
+            />
+          </div>
+        </ToggleField>
 
-        <div className="flex items-center space-x-2 mb-4">
-          <Checkbox
-            id="use_dof"
-            checked={options.use_dof}
-            onCheckedChange={(checked) => updateOptions({ use_dof: !!checked })}
-          />
-          <Label htmlFor="use_dof">{t('useDepthOfField')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('depthOfField')}</Label>
-          <SearchableDropdown
-            options={depthOfFieldOptions}
-            value={options.depth_of_field || 'default'}
-            onValueChange={(value) => updateOptions({ depth_of_field: value })}
-            label="Depth of Field Options"
-            disabled={!options.use_dof}
-            getOptionLabel={(opt) =>
-              translateOption(opt, cameraOptionTranslations.depthOfField, t)
-            }
-          />
-        </div>
-
-        <div className="flex items-center space-x-2 mb-4">
-          <Checkbox
-            id="use_blur_style"
-            checked={options.use_blur_style}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_blur_style: !!checked })
-            }
-          />
-          <Label htmlFor="use_blur_style">{t('useBlurStyle')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('blurStyle')}</Label>
-          <SearchableDropdown
-            options={blurStyleOptions}
-            value={options.blur_style || 'default'}
-            onValueChange={(value) => updateOptions({ blur_style: value })}
-            label="Blur Style Options"
-            disabled={!options.use_blur_style}
-            getOptionLabel={(opt) =>
-              translateOption(opt, cameraOptionTranslations.blurStyle, t)
-            }
-          />
-        </div>
+        <ToggleField
+          id="use_blur_style"
+          label={t('useBlurStyle')}
+          checked={options.use_blur_style}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_blur_style: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('blurStyle')}</Label>
+            <SearchableDropdown
+              options={blurStyleOptions}
+              value={options.blur_style || 'default'}
+              onValueChange={(value) =>
+                updateOptions({ blur_style: value })
+              }
+              label="Blur Style Options"
+              getOptionLabel={(opt) =>
+                translateOption(opt, cameraOptionTranslations.blurStyle, t)
+              }
+            />
+          </div>
+        </ToggleField>
       </div>
     </CollapsibleSection>
   );

--- a/src/components/sections/DimensionsFormatSection.tsx
+++ b/src/components/sections/DimensionsFormatSection.tsx
@@ -9,8 +9,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Checkbox } from '@/components/ui/checkbox';
 import { CollapsibleSection } from '../CollapsibleSection';
+import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
 
 interface DimensionsFormatSectionProps {
@@ -94,43 +94,39 @@ export const DimensionsFormatSection: React.FC<
           </Select>
         </div>
 
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_dimensions"
-            checked={options.use_dimensions}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_dimensions: !!checked })
-            }
-          />
-          <Label htmlFor="use_dimensions">{t('useDimensions')}</Label>
-        </div>
-
-        <>
-          <div>
-            <Label htmlFor="width">{t('width')}</Label>
-            <Input
-              id="width"
-              type="number"
-              value={options.width || 1024}
-              onChange={(e) =>
-                updateOptions({ width: parseInt(e.target.value) })
-              }
-              disabled={!options.use_dimensions}
-            />
+        <ToggleField
+          id="use_dimensions"
+          label={t('useDimensions')}
+          checked={options.use_dimensions}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_dimensions: !!checked })
+          }
+        >
+          <div className="grid grid-cols-1 gap-4">
+            <div>
+              <Label htmlFor="width">{t('width')}</Label>
+              <Input
+                id="width"
+                type="number"
+                value={options.width || 1024}
+                onChange={(e) =>
+                  updateOptions({ width: parseInt(e.target.value) })
+                }
+              />
+            </div>
+            <div>
+              <Label htmlFor="height">{t('height')}</Label>
+              <Input
+                id="height"
+                type="number"
+                value={options.height || 576}
+                onChange={(e) =>
+                  updateOptions({ height: parseInt(e.target.value) })
+                }
+              />
+            </div>
           </div>
-          <div>
-            <Label htmlFor="height">{t('height')}</Label>
-            <Input
-              id="height"
-              type="number"
-              value={options.height || 576}
-              onChange={(e) =>
-                updateOptions({ height: parseInt(e.target.value) })
-              }
-              disabled={!options.use_dimensions}
-            />
-          </div>
-        </>
+        </ToggleField>
 
         <div>
           <Label htmlFor="output_format">{t('outputFormat')}</Label>

--- a/src/components/sections/DnDSection.tsx
+++ b/src/components/sections/DnDSection.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Label } from '@/components/ui/label';
 import { useTranslation } from 'react-i18next';
-import { Checkbox } from '@/components/ui/checkbox';
 import { SearchableDropdown } from '../SearchableDropdown';
 import { CollapsibleSection } from '../CollapsibleSection';
+import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
 import {
   characterRaceOptions,
@@ -38,201 +38,171 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
       onToggle={onToggle}
     >
       <div className="grid grid-cols-1 gap-4">
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_dnd_character_race"
-            checked={options.use_dnd_character_race}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_dnd_character_race: !!checked })
-            }
-          />
-          <Label htmlFor="use_dnd_character_race">
-            {t('useCharacterRace')}
-          </Label>
-        </div>
+        <ToggleField
+          id="use_dnd_character_race"
+          label={t('useCharacterRace')}
+          checked={options.use_dnd_character_race}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_dnd_character_race: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('characterRace')}</Label>
+            <SearchableDropdown
+              options={characterRaceOptions}
+              value={options.dnd_character_race || 'human'}
+              onValueChange={(value) =>
+                updateOptions({ dnd_character_race: value })
+              }
+              label="Character Race Options"
+            />
+          </div>
+        </ToggleField>
 
-        <div>
-          <Label>{t('characterRace')}</Label>
-          <SearchableDropdown
-            options={characterRaceOptions}
-            value={options.dnd_character_race || 'human'}
-            onValueChange={(value) =>
-              updateOptions({ dnd_character_race: value })
-            }
-            label="Character Race Options"
-            disabled={!options.use_dnd_character_race}
-          />
-        </div>
+        <ToggleField
+          id="use_dnd_character_class"
+          label={t('useCharacterClass')}
+          checked={options.use_dnd_character_class}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_dnd_character_class: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('characterClass')}</Label>
+            <SearchableDropdown
+              options={characterClassOptions}
+              value={options.dnd_character_class || 'fighter'}
+              onValueChange={(value) =>
+                updateOptions({ dnd_character_class: value })
+              }
+              label="Character Class Options"
+            />
+          </div>
+        </ToggleField>
 
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_dnd_character_class"
-            checked={options.use_dnd_character_class}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_dnd_character_class: !!checked })
-            }
-          />
-          <Label htmlFor="use_dnd_character_class">
-            {t('useCharacterClass')}
-          </Label>
-        </div>
+        <ToggleField
+          id="use_dnd_character_background"
+          label={t('useCharacterBackground')}
+          checked={options.use_dnd_character_background}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_dnd_character_background: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('characterBackground')}</Label>
+            <SearchableDropdown
+              options={characterBackgroundOptions}
+              value={options.dnd_character_background || 'soldier'}
+              onValueChange={(value) =>
+                updateOptions({ dnd_character_background: value })
+              }
+              label="Character Background Options"
+            />
+          </div>
+        </ToggleField>
 
-        <div>
-          <Label>{t('characterClass')}</Label>
-          <SearchableDropdown
-            options={characterClassOptions}
-            value={options.dnd_character_class || 'fighter'}
-            onValueChange={(value) =>
-              updateOptions({ dnd_character_class: value })
-            }
-            label="Character Class Options"
-            disabled={!options.use_dnd_character_class}
-          />
-        </div>
+        <ToggleField
+          id="use_dnd_character_alignment"
+          label={t('useCharacterAlignment')}
+          checked={options.use_dnd_character_alignment}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_dnd_character_alignment: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('characterAlignment')}</Label>
+            <SearchableDropdown
+              options={characterAlignmentOptions}
+              value={options.dnd_character_alignment || 'lawful good'}
+              onValueChange={(value) =>
+                updateOptions({ dnd_character_alignment: value })
+              }
+              label="Character Alignment Options"
+            />
+          </div>
+        </ToggleField>
 
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_dnd_character_background"
-            checked={options.use_dnd_character_background}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_dnd_character_background: !!checked })
-            }
-          />
-          <Label htmlFor="use_dnd_character_background">
-            {t('useCharacterBackground')}
-          </Label>
-        </div>
+        <ToggleField
+          id="use_dnd_monster_type"
+          label={t('useMonsterType')}
+          checked={options.use_dnd_monster_type}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_dnd_monster_type: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('monsterType')}</Label>
+            <SearchableDropdown
+              options={monsterTypeOptions}
+              value={options.dnd_monster_type || 'dragon'}
+              onValueChange={(value) =>
+                updateOptions({ dnd_monster_type: value })
+              }
+              label="Monster Type Options"
+            />
+          </div>
+        </ToggleField>
 
-        <div>
-          <Label>{t('characterBackground')}</Label>
-          <SearchableDropdown
-            options={characterBackgroundOptions}
-            value={options.dnd_character_background || 'soldier'}
-            onValueChange={(value) =>
-              updateOptions({ dnd_character_background: value })
-            }
-            label="Character Background Options"
-            disabled={!options.use_dnd_character_background}
-          />
-        </div>
+        <ToggleField
+          id="use_dnd_environment"
+          label={t('useDnDEnvironment')}
+          checked={options.use_dnd_environment}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_dnd_environment: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('dndEnvironment')}</Label>
+            <SearchableDropdown
+              options={dndEnvironmentOptions}
+              value={options.dnd_environment || 'dungeon'}
+              onValueChange={(value) =>
+                updateOptions({ dnd_environment: value })
+              }
+              label="D&D Environment Options"
+            />
+          </div>
+        </ToggleField>
 
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_dnd_character_alignment"
-            checked={options.use_dnd_character_alignment}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_dnd_character_alignment: !!checked })
-            }
-          />
-          <Label htmlFor="use_dnd_character_alignment">
-            {t('useCharacterAlignment')}
-          </Label>
-        </div>
+        <ToggleField
+          id="use_dnd_magic_school"
+          label={t('useMagicSchool')}
+          checked={options.use_dnd_magic_school}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_dnd_magic_school: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('magicSchool')}</Label>
+            <SearchableDropdown
+              options={magicSchoolOptions}
+              value={options.dnd_magic_school || 'evocation'}
+              onValueChange={(value) =>
+                updateOptions({ dnd_magic_school: value })
+              }
+              label="Magic School Options"
+            />
+          </div>
+        </ToggleField>
 
-        <div>
-          <Label>{t('characterAlignment')}</Label>
-          <SearchableDropdown
-            options={characterAlignmentOptions}
-            value={options.dnd_character_alignment || 'lawful good'}
-            onValueChange={(value) =>
-              updateOptions({ dnd_character_alignment: value })
-            }
-            label="Character Alignment Options"
-            disabled={!options.use_dnd_character_alignment}
-          />
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_dnd_monster_type"
-            checked={options.use_dnd_monster_type}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_dnd_monster_type: !!checked })
-            }
-          />
-          <Label htmlFor="use_dnd_monster_type">{t('useMonsterType')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('monsterType')}</Label>
-          <SearchableDropdown
-            options={monsterTypeOptions}
-            value={options.dnd_monster_type || 'dragon'}
-            onValueChange={(value) =>
-              updateOptions({ dnd_monster_type: value })
-            }
-            label="Monster Type Options"
-            disabled={!options.use_dnd_monster_type}
-          />
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_dnd_environment"
-            checked={options.use_dnd_environment}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_dnd_environment: !!checked })
-            }
-          />
-          <Label htmlFor="use_dnd_environment">{t('useDnDEnvironment')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('dndEnvironment')}</Label>
-          <SearchableDropdown
-            options={dndEnvironmentOptions}
-            value={options.dnd_environment || 'dungeon'}
-            onValueChange={(value) => updateOptions({ dnd_environment: value })}
-            label="D&D Environment Options"
-            disabled={!options.use_dnd_environment}
-          />
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_dnd_magic_school"
-            checked={options.use_dnd_magic_school}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_dnd_magic_school: !!checked })
-            }
-          />
-          <Label htmlFor="use_dnd_magic_school">{t('useMagicSchool')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('magicSchool')}</Label>
-          <SearchableDropdown
-            options={magicSchoolOptions}
-            value={options.dnd_magic_school || 'evocation'}
-            onValueChange={(value) =>
-              updateOptions({ dnd_magic_school: value })
-            }
-            label="Magic School Options"
-            disabled={!options.use_dnd_magic_school}
-          />
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_dnd_item_type"
-            checked={options.use_dnd_item_type}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_dnd_item_type: !!checked })
-            }
-          />
-          <Label htmlFor="use_dnd_item_type">{t('useItemType')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('itemType')}</Label>
-          <SearchableDropdown
-            options={itemTypeOptions}
-            value={options.dnd_item_type || 'magic sword'}
-            onValueChange={(value) => updateOptions({ dnd_item_type: value })}
-            label="Item Type Options"
-            disabled={!options.use_dnd_item_type}
-          />
-        </div>
+        <ToggleField
+          id="use_dnd_item_type"
+          label={t('useItemType')}
+          checked={options.use_dnd_item_type}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_dnd_item_type: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('itemType')}</Label>
+            <SearchableDropdown
+              options={itemTypeOptions}
+              value={options.dnd_item_type || 'magic sword'}
+              onValueChange={(value) => updateOptions({ dnd_item_type: value })}
+              label="Item Type Options"
+            />
+          </div>
+        </ToggleField>
       </div>
     </CollapsibleSection>
   );

--- a/src/components/sections/EnhancementsSection.tsx
+++ b/src/components/sections/EnhancementsSection.tsx
@@ -5,6 +5,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { SearchableDropdown } from '../SearchableDropdown';
 import { CollapsibleSection } from '../CollapsibleSection';
 import { Slider } from '@/components/ui/slider';
+import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
 
 import {
@@ -59,53 +60,49 @@ export const EnhancementsSection: React.FC<EnhancementsSectionProps> = ({
           <Label htmlFor="prevent_deformities">{t('preventDeformities')}</Label>
         </div>
 
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_upscale_factor"
-            checked={options.use_upscale_factor}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_upscale_factor: !!checked })
-            }
-          />
-          <Label htmlFor="use_upscale_factor">{t('useUpscaleFactor')}</Label>
-        </div>
+        <ToggleField
+          id="use_upscale_factor"
+          label={t('useUpscaleFactor')}
+          checked={options.use_upscale_factor}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_upscale_factor: !!checked })
+          }
+        >
+          <div>
+            <Label htmlFor="upscale">
+              {t('upscaleFactorLabel', { value: options.upscale })}
+            </Label>
+            <Slider
+              value={[options.upscale]}
+              onValueChange={(value) => updateOptions({ upscale: value[0] })}
+              min={1}
+              max={4}
+              step={0.1}
+              className="mt-2"
+            />
+          </div>
+        </ToggleField>
 
-        <div>
-          <Label htmlFor="upscale">
-            {t('upscaleFactorLabel', { value: options.upscale })}
-          </Label>
-          <Slider
-            value={[options.upscale]}
-            onValueChange={(value) => updateOptions({ upscale: value[0] })}
-            min={1}
-            max={4}
-            step={0.1}
-            className="mt-2"
-            disabled={!options.use_upscale_factor}
-          />
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_safety_filter"
-            checked={options.use_safety_filter}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_safety_filter: !!checked })
-            }
-          />
-          <Label htmlFor="use_safety_filter">{t('useSafetyFilter')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('safetyFilter')}</Label>
-          <SearchableDropdown
-            options={safetyFilterOptions}
-            value={options.safety_filter || 'default (auto safety level)'}
-            onValueChange={handleSafetyFilterChange}
-            label="Safety Filter Options"
-            disabled={!options.use_safety_filter}
-          />
-        </div>
+        <ToggleField
+          id="use_safety_filter"
+          label={t('useSafetyFilter')}
+          checked={options.use_safety_filter}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_safety_filter: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('safetyFilter')}</Label>
+            <SearchableDropdown
+              options={safetyFilterOptions}
+              value={
+                options.safety_filter || 'default (auto safety level)'
+              }
+              onValueChange={handleSafetyFilterChange}
+              label="Safety Filter Options"
+            />
+          </div>
+        </ToggleField>
 
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -120,27 +117,28 @@ export const EnhancementsSection: React.FC<EnhancementsSectionProps> = ({
           </Label>
         </div>
 
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_quality_booster"
-            checked={options.use_quality_booster}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_quality_booster: !!checked })
-            }
-          />
-          <Label htmlFor="use_quality_booster">{t('useQualityBooster')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('qualityBooster')}</Label>
-          <SearchableDropdown
-            options={qualityBoosterOptions}
-            value={options.quality_booster || 'default (standard quality)'}
-            onValueChange={(value) => updateOptions({ quality_booster: value })}
-            label="Quality Booster Options"
-            disabled={!options.use_quality_booster}
-          />
-        </div>
+        <ToggleField
+          id="use_quality_booster"
+          label={t('useQualityBooster')}
+          checked={options.use_quality_booster}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_quality_booster: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('qualityBooster')}</Label>
+            <SearchableDropdown
+              options={qualityBoosterOptions}
+              value={
+                options.quality_booster || 'default (standard quality)'
+              }
+              onValueChange={(value) =>
+                updateOptions({ quality_booster: value })
+              }
+              label="Quality Booster Options"
+            />
+          </div>
+        </ToggleField>
 
         <div className="flex items-center space-x-2">
           <Checkbox

--- a/src/components/sections/FaceSection.tsx
+++ b/src/components/sections/FaceSection.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Checkbox } from '@/components/ui/checkbox';
 import { SearchableDropdown } from '../SearchableDropdown';
 import { CollapsibleSection } from '../CollapsibleSection';
+import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
 import { faceOptionTranslations } from '@/data/optionTranslations';
 import { getOptionLabel as translateOption } from '@/lib/optionTranslator';
@@ -53,80 +54,79 @@ export const FaceSection: React.FC<FaceSectionProps> = ({
           <Label htmlFor="dont_change_face">{t('dontChangeFace')}</Label>
         </div>
 
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_subject_gender"
-            checked={options.use_subject_gender}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_subject_gender: !!checked })
-            }
-          />
-          <Label htmlFor="use_subject_gender">{t('useSubjectGender')}</Label>
-        </div>
+        <ToggleField
+          id="use_subject_gender"
+          label={t('useSubjectGender')}
+          checked={options.use_subject_gender}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_subject_gender: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('subjectGender')}</Label>
+            <SearchableDropdown
+              options={subjectGenderOptions}
+              value={
+                options.subject_gender || 'default (auto/inferred gender)'
+              }
+              onValueChange={(value) => updateOptions({ subject_gender: value })}
+              label="Subject Gender Options"
+              getOptionLabel={(opt) =>
+                translateOption(opt, faceOptionTranslations.subjectGender, t)
+              }
+            />
+          </div>
+        </ToggleField>
 
-        <div>
-          <Label>{t('subjectGender')}</Label>
-          <SearchableDropdown
-            options={subjectGenderOptions}
-            value={options.subject_gender || 'default (auto/inferred gender)'}
-            onValueChange={(value) => updateOptions({ subject_gender: value })}
-            label="Subject Gender Options"
-            disabled={!options.use_subject_gender}
-            getOptionLabel={(opt) =>
-              translateOption(opt, faceOptionTranslations.subjectGender, t)
-            }
-          />
-        </div>
+        <ToggleField
+          id="use_makeup_style"
+          label={t('useMakeupStyle')}
+          checked={options.use_makeup_style}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_makeup_style: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('makeupStyle')}</Label>
+            <SearchableDropdown
+              options={makeupStyleOptions}
+              value={
+                options.makeup_style || 'default (no specific makeup)'
+              }
+              onValueChange={(value) => updateOptions({ makeup_style: value })}
+              label="Makeup Style Options"
+              getOptionLabel={(opt) =>
+                translateOption(opt, faceOptionTranslations.makeupStyle, t)
+              }
+            />
+          </div>
+        </ToggleField>
 
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_makeup_style"
-            checked={options.use_makeup_style}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_makeup_style: !!checked })
-            }
-          />
-          <Label htmlFor="use_makeup_style">{t('useMakeupStyle')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('makeupStyle')}</Label>
-          <SearchableDropdown
-            options={makeupStyleOptions}
-            value={options.makeup_style || 'default (no specific makeup)'}
-            onValueChange={(value) => updateOptions({ makeup_style: value })}
-            label="Makeup Style Options"
-            disabled={!options.use_makeup_style}
-            getOptionLabel={(opt) =>
-              translateOption(opt, faceOptionTranslations.makeupStyle, t)
-            }
-          />
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_character_mood"
-            checked={options.use_character_mood}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_character_mood: !!checked })
-            }
-          />
-          <Label htmlFor="use_character_mood">{t('useCharacterMood')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('characterMood')}</Label>
-          <SearchableDropdown
-            options={characterMoodOptions}
-            value={options.character_mood || 'default (neutral mood)'}
-            onValueChange={(value) => updateOptions({ character_mood: value })}
-            label="Character Mood Options"
-            disabled={!options.use_character_mood}
-            getOptionLabel={(opt) =>
-              translateOption(opt, faceOptionTranslations.characterMood, t)
-            }
-          />
-        </div>
+        <ToggleField
+          id="use_character_mood"
+          label={t('useCharacterMood')}
+          checked={options.use_character_mood}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_character_mood: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('characterMood')}</Label>
+            <SearchableDropdown
+              options={characterMoodOptions}
+              value={
+                options.character_mood || 'default (neutral mood)'
+              }
+              onValueChange={(value) =>
+                updateOptions({ character_mood: value })
+              }
+              label="Character Mood Options"
+              getOptionLabel={(opt) =>
+                translateOption(opt, faceOptionTranslations.characterMood, t)
+              }
+            />
+          </div>
+        </ToggleField>
       </div>
     </CollapsibleSection>
   );

--- a/src/components/sections/MaterialSection.tsx
+++ b/src/components/sections/MaterialSection.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Label } from '@/components/ui/label';
 import { useTranslation } from 'react-i18next';
-import { Checkbox } from '@/components/ui/checkbox';
 import { SearchableDropdown } from '../SearchableDropdown';
 import { CollapsibleSection } from '../CollapsibleSection';
+import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
 
 import { materialOptions } from '@/data/materialOptions';
@@ -35,31 +35,26 @@ export const MaterialSection: React.FC<MaterialSectionProps> = ({
           />
         </div>
 
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_secondary_material"
-            checked={options.use_secondary_material}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_secondary_material: !!checked })
-            }
-          />
-          <Label htmlFor="use_secondary_material">
-            {t('useSecondaryMaterial')}
-          </Label>
-        </div>
-
-        <div>
-          <Label>{t('secondaryMaterial')}</Label>
-          <SearchableDropdown
-            options={materialOptions}
-            value={options.secondary_material || 'default'}
-            onValueChange={(value) =>
-              updateOptions({ secondary_material: value })
-            }
-            label="Secondary Material Options"
-            disabled={!options.use_secondary_material}
-          />
-        </div>
+        <ToggleField
+          id="use_secondary_material"
+          label={t('useSecondaryMaterial')}
+          checked={options.use_secondary_material}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_secondary_material: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('secondaryMaterial')}</Label>
+            <SearchableDropdown
+              options={materialOptions}
+              value={options.secondary_material || 'default'}
+              onValueChange={(value) =>
+                updateOptions({ secondary_material: value })
+              }
+              label="Secondary Material Options"
+            />
+          </div>
+        </ToggleField>
       </div>
     </CollapsibleSection>
   );

--- a/src/components/sections/PromptSection.tsx
+++ b/src/components/sections/PromptSection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
+import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
 import { useResizeTracker } from '@/hooks/use-resize-tracker';
 
@@ -38,29 +38,24 @@ export const PromptSection: React.FC<PromptSectionProps> = ({
         />
       </div>
 
-      <div>
-        <div className="flex items-center space-x-2 mb-2">
-          <Checkbox
-            id="use_negative_prompt"
-            checked={options.use_negative_prompt}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_negative_prompt: !!checked })
-            }
-          />
-          <Label htmlFor="negative_prompt" className="text-base font-semibold">
-            {t('negativePrompt')}
-          </Label>
-        </div>
+      <ToggleField
+        id="use_negative_prompt"
+        label={t('negativePrompt')}
+        checked={options.use_negative_prompt}
+        onCheckedChange={(checked) =>
+          updateOptions({ use_negative_prompt: !!checked })
+        }
+      >
         <Textarea
           id="negative_prompt"
           value={options.negative_prompt}
           onChange={(e) => updateOptions({ negative_prompt: e.target.value })}
           placeholder={t('negativePromptPlaceholder')}
           className="min-h-[80px] resize-y"
-          disabled={!options.use_negative_prompt}
           ref={negativeRef}
+          aria-label={t('negativePrompt')}
         />
-      </div>
+      </ToggleField>
     </div>
   );
 };

--- a/src/components/sections/SettingsLocationSection.tsx
+++ b/src/components/sections/SettingsLocationSection.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import i18n from '@/i18n';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
-import { Checkbox } from '@/components/ui/checkbox';
 import { SearchableDropdown } from '../SearchableDropdown';
 import { CollapsibleSection } from '../CollapsibleSection';
+import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
 import {
   environmentOptions,
@@ -42,114 +42,103 @@ export const SettingsLocationSection: React.FC<
           />
         </div>
 
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_environment"
-            checked={options.use_environment}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_environment: !!checked })
-            }
-          />
-          <Label htmlFor="use_environment">{t('useEnvironment')}</Label>
-        </div>
+        <ToggleField
+          id="use_environment"
+          label={t('useEnvironment')}
+          checked={options.use_environment}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_environment: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('environment')}</Label>
+            <SearchableDropdown
+              options={environmentOptions}
+              value={options.environment}
+              onValueChange={(value) => updateOptions({ environment: value })}
+              label={t('environmentOptions')}
+            />
+          </div>
+        </ToggleField>
 
-        <div>
-          <Label>{t('environment')}</Label>
-          <SearchableDropdown
-            options={environmentOptions}
-            value={options.environment}
-            onValueChange={(value) => updateOptions({ environment: value })}
-            label={t('environmentOptions')}
-            disabled={!options.use_environment}
-          />
-        </div>
+        <ToggleField
+          id="use_location"
+          label={t('useLocation')}
+          checked={options.use_location}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_location: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('location')}</Label>
+            <SearchableDropdown
+              options={locationOptions}
+              value={options.location || 'Berlin, Germany'}
+              onValueChange={(value) => updateOptions({ location: value })}
+              label={t('locationOptions')}
+            />
+          </div>
+        </ToggleField>
 
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_location"
-            checked={options.use_location}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_location: !!checked })
-            }
-          />
-          <Label htmlFor="use_location">{t('useLocation')}</Label>
-        </div>
+        <ToggleField
+          id="use_season"
+          label={t('useSeason')}
+          checked={options.use_season}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_season: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('season')}</Label>
+            <SearchableDropdown
+              options={seasonOptions}
+              value={options.season || 'default (any season)'}
+              onValueChange={(value) => updateOptions({ season: value })}
+              label={t('seasonOptions')}
+            />
+          </div>
+        </ToggleField>
 
-        <div>
-          <Label>{t('location')}</Label>
-          <SearchableDropdown
-            options={locationOptions}
-            value={options.location || 'Berlin, Germany'}
-            onValueChange={(value) => updateOptions({ location: value })}
-            label={t('locationOptions')}
-            disabled={!options.use_location}
-          />
-        </div>
+        <ToggleField
+          id="use_time_of_year"
+          label={t('useTimeOfYear')}
+          checked={options.use_time_of_year}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_time_of_year: !!checked })
+          }
+        >
+          <div>
+            <Label htmlFor="time_of_year">{t('timeOfYear')}</Label>
+            <Input
+              id="time_of_year"
+              value={options.time_of_year}
+              onChange={(e) => updateOptions({ time_of_year: e.target.value })}
+            />
+          </div>
+        </ToggleField>
 
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_season"
-            checked={options.use_season}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_season: !!checked })
-            }
-          />
-          <Label htmlFor="use_season">{t('useSeason')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('season')}</Label>
-          <SearchableDropdown
-            options={seasonOptions}
-            value={options.season || 'default (any season)'}
-            onValueChange={(value) => updateOptions({ season: value })}
-            label={t('seasonOptions')}
-            disabled={!options.use_season}
-          />
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_time_of_year"
-            checked={options.use_time_of_year}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_time_of_year: !!checked })
-            }
-          />
-          <Label htmlFor="use_time_of_year">{t('useTimeOfYear')}</Label>
-        </div>
-
-        <div>
-          <Label htmlFor="time_of_year">{t('timeOfYear')}</Label>
-          <Input
-            id="time_of_year"
-            value={options.time_of_year}
-            onChange={(e) => updateOptions({ time_of_year: e.target.value })}
-            disabled={!options.use_time_of_year}
-          />
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_atmosphere_mood"
-            checked={options.use_atmosphere_mood}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_atmosphere_mood: !!checked })
-            }
-          />
-          <Label htmlFor="use_atmosphere_mood">{t('useAtmosphereMood')}</Label>
-        </div>
-
-        <div>
-          <Label>{t('atmosphereMood')}</Label>
-          <SearchableDropdown
-            options={atmosphereMoodOptions}
-            value={options.atmosphere_mood || 'default (neutral mood)'}
-            onValueChange={(value) => updateOptions({ atmosphere_mood: value })}
-            label={t('atmosphereMoodOptions')}
-            disabled={!options.use_atmosphere_mood}
-          />
-        </div>
+        <ToggleField
+          id="use_atmosphere_mood"
+          label={t('useAtmosphereMood')}
+          checked={options.use_atmosphere_mood}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_atmosphere_mood: !!checked })
+          }
+        >
+          <div>
+            <Label>{t('atmosphereMood')}</Label>
+            <SearchableDropdown
+              options={atmosphereMoodOptions}
+              value={
+                options.atmosphere_mood || 'default (neutral mood)'
+              }
+              onValueChange={(value) =>
+                updateOptions({ atmosphere_mood: value })
+              }
+              label={t('atmosphereMoodOptions')}
+            />
+          </div>
+        </ToggleField>
       </div>
     </CollapsibleSection>
   );

--- a/src/components/sections/VideoMotionSection.tsx
+++ b/src/components/sections/VideoMotionSection.tsx
@@ -12,6 +12,7 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { Slider } from '@/components/ui/slider';
 import { CollapsibleSection } from '../CollapsibleSection';
+import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
 
 interface VideoMotionSectionProps {
@@ -36,31 +37,28 @@ export const VideoMotionSection: React.FC<VideoMotionSectionProps> = ({
       onToggle={onToggle}
     >
       <div className="grid grid-cols-1 gap-4">
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id="use_duration"
-            checked={options.use_duration}
-            onCheckedChange={(checked) =>
-              updateOptions({ use_duration: !!checked })
-            }
-          />
-          <Label htmlFor="use_duration">{t('useDuration')}</Label>
-        </div>
-
-        <div>
-          <Label htmlFor="duration_seconds">{t('durationSeconds')}</Label>
-          <Input
-            id="duration_seconds"
-            type="number"
-            value={options.duration_seconds}
-            onChange={(e) =>
-              updateOptions({ duration_seconds: parseInt(e.target.value) })
-            }
-            min="1"
-            max="30"
-            disabled={!options.use_duration}
-          />
-        </div>
+        <ToggleField
+          id="use_duration"
+          label={t('useDuration')}
+          checked={options.use_duration}
+          onCheckedChange={(checked) =>
+            updateOptions({ use_duration: !!checked })
+          }
+        >
+          <div>
+            <Label htmlFor="duration_seconds">{t('durationSeconds')}</Label>
+            <Input
+              id="duration_seconds"
+              type="number"
+              value={options.duration_seconds}
+              onChange={(e) =>
+                updateOptions({ duration_seconds: parseInt(e.target.value) })
+              }
+              min="1"
+              max="30"
+            />
+          </div>
+        </ToggleField>
 
         <div className="flex items-center space-x-2">
           <Checkbox

--- a/src/components/sections/__tests__/PromptSection.test.tsx
+++ b/src/components/sections/__tests__/PromptSection.test.tsx
@@ -23,7 +23,9 @@ describe('PromptSection', () => {
     fireEvent.change(promptInput, { target: { value: 'new prompt' } });
     expect(updateOptions).toHaveBeenCalledWith({ prompt: 'new prompt' });
 
-    const negativeInput = screen.getByLabelText(/^negative prompt$/i);
+    const negativeInput = screen.getByRole('textbox', {
+      name: /negative prompt/i,
+    });
     fireEvent.change(negativeInput, { target: { value: 'new negative' } });
     expect(updateOptions).toHaveBeenCalledWith({
       negative_prompt: 'new negative',
@@ -41,7 +43,7 @@ describe('PromptSection', () => {
       />,
     );
 
-    const textarea = screen.getByLabelText(/^negative prompt$/i);
+    const textarea = screen.getByRole('textbox', { name: /negative prompt/i });
     expect(textarea.hasAttribute('disabled')).toBe(true);
 
     const checkbox = screen.getByRole('checkbox');
@@ -56,7 +58,9 @@ describe('PromptSection', () => {
       />,
     );
     expect(
-      screen.getByLabelText(/^negative prompt$/i).hasAttribute('disabled'),
+      screen.getByRole('textbox', { name: /negative prompt/i }).hasAttribute(
+        'disabled',
+      ),
     ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add reusable `ToggleField` for checkbox + field pairs
- refactor section components to use `ToggleField`
- update prompt section tests for new toggle behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c8ba8f96c8325860fd7d8a84f36ad