### PR TITLE
feat: add async language loading

### DIFF
--- a/src/__tests__/i18n.test.tsx
+++ b/src/__tests__/i18n.test.tsx
@@ -1,13 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
-import i18n from '../i18n';
+import i18n, { changeLanguageAsync } from '../i18n';
 
 afterEach(async () => {
-  await i18n.changeLanguage('en-US');
+  await changeLanguageAsync('en-US');
 });
 
 test('renders spanish translation', async () => {
-  await i18n.changeLanguage('es-ES');
+  await changeLanguageAsync('es-ES');
   render(
     <I18nextProvider i18n={i18n}>
       <span>{i18n.t('copy')}</span>
@@ -17,11 +17,14 @@ test('renders spanish translation', async () => {
 });
 
 test('falls back to english when language unsupported', async () => {
-  await i18n.changeLanguage('xx');
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  await changeLanguageAsync('xx');
   render(
     <I18nextProvider i18n={i18n}>
       <span>{i18n.t('copy')}</span>
     </I18nextProvider>,
   );
   expect(screen.getByText('Copy')).toBeTruthy();
+  expect(warnSpy).toHaveBeenCalled();
+  warnSpy.mockRestore();
 });

--- a/src/components/sections/__tests__/CameraCompositionSection.test.tsx
+++ b/src/components/sections/__tests__/CameraCompositionSection.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import i18n from '@/i18n';
+import i18n, { changeLanguageAsync } from '@/i18n';
 import { CameraCompositionSection } from '../CameraCompositionSection';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 
@@ -266,7 +266,7 @@ describe('CameraCompositionSection', () => {
   });
 
   test('lens type dropdown localizes options when language changes', async () => {
-    await i18n.changeLanguage('es-ES');
+    await changeLanguageAsync('es-ES');
     render(
       <CameraCompositionSection
         options={{
@@ -285,11 +285,11 @@ describe('CameraCompositionSection', () => {
     expect(
       await screen.findByRole('button', { name: /gran angular 24mm/i }),
     ).toBeDefined();
-    await i18n.changeLanguage('en-US');
+    await changeLanguageAsync('en-US');
   });
 
   test('subject focus dropdown localizes options when language changes', async () => {
-    await i18n.changeLanguage('es-ES');
+    await changeLanguageAsync('es-ES');
     render(
       <CameraCompositionSection
         options={{
@@ -307,6 +307,6 @@ describe('CameraCompositionSection', () => {
     expect(
       await screen.findByRole('option', { name: /centro/i }),
     ).toBeDefined();
-    await i18n.changeLanguage('en-US');
+    await changeLanguageAsync('en-US');
   });
 });

--- a/src/components/sections/__tests__/FaceSection.test.tsx
+++ b/src/components/sections/__tests__/FaceSection.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import i18n from '@/i18n';
+import i18n, { changeLanguageAsync } from '@/i18n';
 import { FaceSection } from '../FaceSection';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 
@@ -124,7 +124,7 @@ describe('FaceSection', () => {
   });
 
   test('dropdown shows localized options when language changes', async () => {
-    await i18n.changeLanguage('es-ES');
+    await changeLanguageAsync('es-ES');
     render(
       <FaceSection
         options={{
@@ -141,6 +141,6 @@ describe('FaceSection', () => {
     expect(
       await screen.findByRole('button', { name: /femenino/i }),
     ).toBeDefined();
-    await i18n.changeLanguage('en-US');
+    await changeLanguageAsync('en-US');
   });
 });

--- a/src/hooks/__tests__/use-locale.test.ts
+++ b/src/hooks/__tests__/use-locale.test.ts
@@ -1,12 +1,12 @@
 import { renderHook, act } from '@testing-library/react';
 import { useLocale } from '../use-locale';
-import i18n from '@/i18n';
+import { changeLanguageAsync } from '@/i18n';
 import * as storage from '@/lib/storage';
 import { LOCALE } from '@/lib/storage-keys';
 
 jest.mock('@/i18n', () => ({
   __esModule: true,
-  default: { changeLanguage: jest.fn() },
+  changeLanguageAsync: jest.fn(),
 }));
 
 jest.mock('@/lib/storage', () => ({
@@ -42,7 +42,7 @@ describe('useLocale', () => {
     const { result } = renderHook(() => useLocale());
     expect(result.current[0]).toBe('fr-FR');
     expect(storage.safeGet).toHaveBeenCalledWith(LOCALE, 'fr-FR', false);
-    expect(i18n.changeLanguage).toHaveBeenLastCalledWith('fr-FR');
+    expect(changeLanguageAsync).toHaveBeenLastCalledWith('fr-FR');
   });
 
   test('updates locale and persists value', () => {
@@ -53,7 +53,7 @@ describe('useLocale', () => {
       result.current[1]('fr');
     });
 
-    expect(i18n.changeLanguage).toHaveBeenLastCalledWith('fr-FR');
+    expect(changeLanguageAsync).toHaveBeenLastCalledWith('fr-FR');
     expect(storage.safeSet).toHaveBeenLastCalledWith(LOCALE, 'fr-FR');
     expect(result.current[0]).toBe('fr-FR');
   });

--- a/src/hooks/use-locale.ts
+++ b/src/hooks/use-locale.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import i18n from '@/i18n';
+import { changeLanguageAsync } from '@/i18n';
 import { useLocalStorageState } from './use-local-storage-state';
 import { LOCALE } from '@/lib/storage-keys';
 
@@ -69,7 +69,7 @@ export function useLocale() {
       setLocale(normalized);
       return;
     }
-    i18n.changeLanguage(locale);
+    changeLanguageAsync(locale);
   }, [locale, setLocale]);
 
   return [locale, setLocale] as const;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,7 +1,8 @@
-import i18n from 'i18next';
+import i18n, { type Resource } from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
 // Initialize i18next without preloaded resources.
+
 i18n.use(initReactI18next).init({
   resources: {},
   lng: 'en-US',
@@ -9,23 +10,27 @@ i18n.use(initReactI18next).init({
   interpolation: { escapeValue: false },
 });
 
-const originalChangeLanguage = i18n.changeLanguage.bind(i18n);
-
-// Override changeLanguage to dynamically load translation files on demand.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(i18n as any).changeLanguage = async (lng: string) => {
+export async function changeLanguageAsync(lng: string) {
   if (!i18n.hasResourceBundle(lng, 'translation')) {
     try {
-      const { default: translation } = await import(`./locales/${lng}.json`);
-      i18n.addResourceBundle(lng, 'translation', translation, true, true);
+      const { default: translation } = await import(
+        `./locales/${lng}.json`
+      );
+      i18n.addResourceBundle(
+        lng,
+        'translation',
+        translation as Resource,
+        true,
+        true,
+      );
     } catch (error) {
       console.warn(`Failed to load translations for ${lng}`, error);
     }
   }
-  return originalChangeLanguage(lng);
-};
+  return i18n.changeLanguage(lng);
+}
 
 // Load the default language initially.
-void i18n.changeLanguage('en-US');
+void changeLanguageAsync('en-US');
 
 export default i18n;


### PR DESCRIPTION
## Summary
- add `changeLanguageAsync` for dynamic i18n imports without `any` cast
- update locale hook and tests to use the new loader
- test that missing translations gracefully fall back to English

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9f2077e483259f356f2a43090f09