### PR TITLE
feat: prompt update before reload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ const queryClient = new QueryClient({
 
 const App = () => {
   useDarkMode();
-  const checkForUpdate = useUpdateCheck();
+  const { checkForUpdate } = useUpdateCheck();
   useEffect(() => {
     checkForUpdate();
   }, [checkForUpdate]);

--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocale } from '@/hooks/use-locale';
 import { Button } from '@/components/ui/button';
@@ -12,6 +12,9 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 import SettingsPanel from './SettingsPanel';
+import { useUpdateCheck } from '@/hooks/use-update-check';
+import { useToast } from '@/components/ui/use-toast';
+import { ToastAction } from '@/components/ui/toast';
 import {
   Copy,
   Check,
@@ -98,6 +101,29 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   const [minimized, setMinimized] = useState(false);
   const [clearing, setClearing] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const { checkForUpdate, updateAvailable } = useUpdateCheck();
+  const { toast } = useToast();
+
+  useEffect(() => {
+    checkForUpdate();
+  }, [checkForUpdate]);
+
+  useEffect(() => {
+    if (updateAvailable) {
+      toast({
+        title: 'Update available',
+        description: 'Refresh the page to load the latest version.',
+        action: (
+          <ToastAction
+            altText="Refresh"
+            onClick={() => window.location.reload()}
+          >
+            Refresh
+          </ToastAction>
+        ),
+      });
+    }
+  }, [updateAvailable, toast]);
   
   if (minimized) {
     return (

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -71,7 +71,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const { t } = useTranslation();
   const [confirmDisableTracking, setConfirmDisableTracking] = useState(false);
   const [confirmEnableTracking, setConfirmEnableTracking] = useState(false);
-  const checkForUpdate = useUpdateCheck();
+  const { checkForUpdate } = useUpdateCheck();
 
   useEffect(() => {
     if (open) {

--- a/src/hooks/__tests__/use-update-check.test.ts
+++ b/src/hooks/__tests__/use-update-check.test.ts
@@ -21,9 +21,25 @@ describe('useUpdateCheck', () => {
     });
     const { result } = renderHook(() => useUpdateCheck());
     await act(async () => {
-      await result.current();
+      await result.current.checkForUpdate();
     });
     expect(getRegistration).toHaveBeenCalled();
     expect(update).toHaveBeenCalled();
+  });
+
+  it('sets updateAvailable when registration has waiting worker', async () => {
+    const update = jest.fn().mockResolvedValue(undefined);
+    const waiting = {};
+    const getRegistration = jest.fn().mockResolvedValue({ update, waiting });
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: { getRegistration },
+    });
+    const { result } = renderHook(() => useUpdateCheck());
+    expect(result.current.updateAvailable).toBe(false);
+    await act(async () => {
+      await result.current.checkForUpdate();
+    });
+    expect(result.current.updateAvailable).toBe(true);
   });
 });

--- a/src/hooks/use-update-check.ts
+++ b/src/hooks/use-update-check.ts
@@ -1,19 +1,23 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 export function useUpdateCheck() {
-  return useCallback(async () => {
-    if (!('serviceWorker' in navigator)) return;
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+
+  const checkForUpdate = useCallback(async () => {
+    if (!('serviceWorker' in navigator) || !navigator.serviceWorker) return;
     try {
       const registration = await navigator.serviceWorker.getRegistration();
       if (!registration) return;
       await registration.update();
       if (registration.waiting) {
-        window.location.reload();
+        setUpdateAvailable(true);
       }
     } catch (error) {
       console.error('Service worker update check failed', error);
     }
   }, []);
+
+  return { checkForUpdate, updateAvailable };
 }
 
 export default useUpdateCheck;


### PR DESCRIPTION
## Summary
- expose `updateAvailable` flag from `useUpdateCheck`
- notify users in `ActionBar` when an update is available and refresh on confirmation
- add tests for update prompt flow

## Testing
- `npm test src/components/__tests__/ActionBar.test.tsx src/hooks/__tests__/use-update-check.test.ts --silent`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c9f139f38832587dc99f7037b58eb