### PR TITLE
feat: avoid storing default local storage state

### DIFF
--- a/src/hooks/__tests__/use-dark-mode.test.ts
+++ b/src/hooks/__tests__/use-dark-mode.test.ts
@@ -16,6 +16,7 @@ describe('useDarkMode', () => {
 
   test('reads and writes localStorage', () => {
     const setSpy = jest.spyOn(Storage.prototype, 'setItem');
+    const removeSpy = jest.spyOn(Storage.prototype, 'removeItem');
     localStorage.setItem(DARK_MODE, 'false');
     const { result } = renderHook(() => useDarkMode());
     expect(result.current[0]).toBe(false);
@@ -25,8 +26,9 @@ describe('useDarkMode', () => {
       result.current[1](true);
     });
 
-    expect(localStorage.getItem(DARK_MODE)).toBe('true');
-    expect(setSpy).toHaveBeenCalledWith(DARK_MODE, 'true');
+    expect(removeSpy).toHaveBeenCalledWith(DARK_MODE);
+    expect(localStorage.getItem(DARK_MODE)).toBeNull();
+    expect(setSpy).toHaveBeenCalledWith(DARK_MODE, 'false');
     expect(hasDarkClass()).toBe(true);
   });
 

--- a/src/hooks/__tests__/use-local-storage-state.test.ts
+++ b/src/hooks/__tests__/use-local-storage-state.test.ts
@@ -6,6 +6,7 @@ jest.mock('@/lib/storage', () => ({
   __esModule: true,
   safeGet: jest.fn(),
   safeSet: jest.fn(),
+  safeRemove: jest.fn(),
 }));
 
 describe('useLocalStorageState', () => {
@@ -44,6 +45,22 @@ describe('useLocalStorageState', () => {
 
     expect(storage.safeSet).toHaveBeenLastCalledWith('obj', { a: 2 }, true);
     expect(result.current[0]).toEqual({ a: 2 });
+  });
+
+  test('removes key instead of persisting default value', () => {
+    (storage.safeGet as jest.Mock).mockReturnValue('default');
+
+    const { result } = renderHook(() => useLocalStorageState('key', 'default'));
+
+    expect(storage.safeRemove).toHaveBeenCalledWith('key');
+    expect(storage.safeSet).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current[1]('default');
+    });
+
+    expect(storage.safeRemove).toHaveBeenCalledWith('key');
+    expect(storage.safeSet).not.toHaveBeenCalled();
   });
 
   test('updates state when storage event fires for same key', () => {

--- a/src/hooks/__tests__/use-locale.test.ts
+++ b/src/hooks/__tests__/use-locale.test.ts
@@ -13,6 +13,7 @@ jest.mock('@/lib/storage', () => ({
   __esModule: true,
   safeGet: jest.fn(),
   safeSet: jest.fn(),
+  safeRemove: jest.fn(),
 }));
 
 describe('useLocale', () => {

--- a/src/hooks/__tests__/use-sora-tools.test.ts
+++ b/src/hooks/__tests__/use-sora-tools.test.ts
@@ -17,13 +17,24 @@ describe('useSoraTools', () => {
 
   test('persists state changes to localStorage', () => {
     const setSpy = jest.spyOn(Storage.prototype, 'setItem');
+    const removeSpy = jest.spyOn(Storage.prototype, 'removeItem');
     const { result } = renderHook(() => useSoraTools());
+
+    setSpy.mockClear();
+    removeSpy.mockClear();
+
+    act(() => {
+      result.current[1](true);
+    });
+
+    expect(localStorage.getItem('soraToolsEnabled')).toBe('true');
+    expect(setSpy).toHaveBeenCalledWith('soraToolsEnabled', 'true');
 
     act(() => {
       result.current[1](false);
     });
 
-    expect(localStorage.getItem('soraToolsEnabled')).toBe('false');
-    expect(setSpy).toHaveBeenCalledWith('soraToolsEnabled', 'false');
+    expect(localStorage.getItem('soraToolsEnabled')).toBeNull();
+    expect(removeSpy).toHaveBeenCalledWith('soraToolsEnabled');
   });
 });

--- a/src/hooks/use-local-storage-state.ts
+++ b/src/hooks/use-local-storage-state.ts
@@ -1,6 +1,15 @@
 import { useEffect, useState, Dispatch, SetStateAction } from 'react';
-import { safeGet, safeSet } from '@/lib/storage';
+import { safeGet, safeSet, safeRemove } from '@/lib/storage';
 
+/**
+ * Sync a stateful value with `localStorage`.
+ *
+ * When the state matches `defaultValue`, the corresponding key is removed
+ * from storage to avoid persisting default values.
+ *
+ * @param key - The localStorage key
+ * @param defaultValue - Value to fall back to when nothing is stored
+ */
 export function useLocalStorageState<T>(
   key: string,
   defaultValue: T,
@@ -13,12 +22,16 @@ export function useLocalStorageState<T>(
   });
 
   useEffect(() => {
+    if (Object.is(state, defaultValue)) {
+      safeRemove(key);
+      return;
+    }
     if (isString) {
       safeSet(key, state as unknown as string);
     } else {
       safeSet(key, state, true);
     }
-  }, [key, state, isString]);
+  }, [key, state, isString, defaultValue]);
 
   useEffect(() => {
     const onStorage = (e: StorageEvent) => {


### PR DESCRIPTION
## Summary
- remove localStorage entries when state equals the default value
- test that default values are not persisted
- document default-removal behavior for useLocalStorageState

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cabdb97248325addf4757288bd23f