### PR TITLE
fix: load syntax highlighter via cjs path

### DIFF
--- a/src/components/GeneratedJson.tsx
+++ b/src/components/GeneratedJson.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { diffChars, Change } from 'diff';
-import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/prism-light';
 import jsonLang from 'react-syntax-highlighter/dist/cjs/languages/prism/json';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { trackEvent } from '@/lib/analytics';


### PR DESCRIPTION
## Summary
- fix failing build by importing SyntaxHighlighter from explicit CJS prism-light path

## Testing
- `npm test` *(fails: i18n.test.tsx, sw.test.ts, DisclaimerModal.test.tsx, FaceSection.test.tsx)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce1cd11e88325a953d3860637b3f2