### PR TITLE
fix service worker and i18n errors

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -6,15 +6,20 @@ import path from 'path';
 
 // Provide minimal fetch and Cache API stubs for tests
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const enUs = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, 'src/locales/en-US.json'), 'utf-8'),
-);
-
-(globalThis as any).fetch = jest.fn().mockResolvedValue({
-  json: async () => enUs,
-  clone: function () {
-    return this;
-  },
+(globalThis as any).fetch = jest.fn((url: string) => {
+  const match = url.match(/\/locales\/(.*)\.json$/);
+  const locale = match ? match[1] : 'en-US';
+  const file = path.resolve(__dirname, `src/locales/${locale}.json`);
+  if (!fs.existsSync(file)) {
+    return Promise.reject(new Error('Not Found'));
+  }
+  const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
+  return Promise.resolve({
+    json: async () => data,
+    clone: function () {
+      return this;
+    },
+  });
 });
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).caches = {

--- a/public/locales/bn-IN.json
+++ b/public/locales/bn-IN.json
@@ -1,0 +1,1 @@
+../../src/locales/bn-IN.json

--- a/public/locales/da-DK.json
+++ b/public/locales/da-DK.json
@@ -1,0 +1,1 @@
+../../src/locales/da-DK.json

--- a/public/locales/de-AT.json
+++ b/public/locales/de-AT.json
@@ -1,0 +1,1 @@
+../../src/locales/de-AT.json

--- a/public/locales/de-DE.json
+++ b/public/locales/de-DE.json
@@ -1,0 +1,1 @@
+../../src/locales/de-DE.json

--- a/public/locales/el-GR.json
+++ b/public/locales/el-GR.json
@@ -1,0 +1,1 @@
+../../src/locales/el-GR.json

--- a/public/locales/en-GB.json
+++ b/public/locales/en-GB.json
@@ -1,0 +1,1 @@
+../../src/locales/en-GB.json

--- a/public/locales/en-PR.json
+++ b/public/locales/en-PR.json
@@ -1,0 +1,1 @@
+../../src/locales/en-PR.json

--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -1,0 +1,1 @@
+../../src/locales/en-US.json

--- a/public/locales/es-AR.json
+++ b/public/locales/es-AR.json
@@ -1,0 +1,1 @@
+../../src/locales/es-AR.json

--- a/public/locales/es-ES.json
+++ b/public/locales/es-ES.json
@@ -1,0 +1,1 @@
+../../src/locales/es-ES.json

--- a/public/locales/es-MX.json
+++ b/public/locales/es-MX.json
@@ -1,0 +1,1 @@
+../../src/locales/es-MX.json

--- a/public/locales/et-EE.json
+++ b/public/locales/et-EE.json
@@ -1,0 +1,1 @@
+../../src/locales/et-EE.json

--- a/public/locales/fi-FI.json
+++ b/public/locales/fi-FI.json
@@ -1,0 +1,1 @@
+../../src/locales/fi-FI.json

--- a/public/locales/fr-BE.json
+++ b/public/locales/fr-BE.json
@@ -1,0 +1,1 @@
+../../src/locales/fr-BE.json

--- a/public/locales/fr-FR.json
+++ b/public/locales/fr-FR.json
@@ -1,0 +1,1 @@
+../../src/locales/fr-FR.json

--- a/public/locales/it-IT.json
+++ b/public/locales/it-IT.json
@@ -1,0 +1,1 @@
+../../src/locales/it-IT.json

--- a/public/locales/ja-JP.json
+++ b/public/locales/ja-JP.json
@@ -1,0 +1,1 @@
+../../src/locales/ja-JP.json

--- a/public/locales/ko-KR.json
+++ b/public/locales/ko-KR.json
@@ -1,0 +1,1 @@
+../../src/locales/ko-KR.json

--- a/public/locales/ne-NP.json
+++ b/public/locales/ne-NP.json
@@ -1,0 +1,1 @@
+../../src/locales/ne-NP.json

--- a/public/locales/pt-BR.json
+++ b/public/locales/pt-BR.json
@@ -1,0 +1,1 @@
+../../src/locales/pt-BR.json

--- a/public/locales/pt-PT.json
+++ b/public/locales/pt-PT.json
@@ -1,0 +1,1 @@
+../../src/locales/pt-PT.json

--- a/public/locales/ro-RO.json
+++ b/public/locales/ro-RO.json
@@ -1,0 +1,1 @@
+../../src/locales/ro-RO.json

--- a/public/locales/ru-RU.json
+++ b/public/locales/ru-RU.json
@@ -1,0 +1,1 @@
+../../src/locales/ru-RU.json

--- a/public/locales/sv-SE.json
+++ b/public/locales/sv-SE.json
@@ -1,0 +1,1 @@
+../../src/locales/sv-SE.json

--- a/public/locales/th-TH.json
+++ b/public/locales/th-TH.json
@@ -1,0 +1,1 @@
+../../src/locales/th-TH.json

--- a/public/locales/uk-UA.json
+++ b/public/locales/uk-UA.json
@@ -1,0 +1,1 @@
+../../src/locales/uk-UA.json

--- a/public/locales/zh-CN.json
+++ b/public/locales/zh-CN.json
@@ -1,0 +1,1 @@
+../../src/locales/zh-CN.json

--- a/public/sw.js
+++ b/public/sw.js
@@ -101,8 +101,18 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   event.respondWith(
-    caches.match(event.request, { ignoreSearch: true }).then((response) => {
-      return response || fetch(event.request);
-    }),
+    (async () => {
+      const cached = await caches.match(event.request);
+      if (cached) return cached;
+      try {
+        return await fetch(event.request);
+      } catch {
+        if (event.request.mode === 'navigate') {
+          const fallback = await caches.match('/index.html');
+          if (fallback) return fallback;
+        }
+        return Response.error();
+      }
+    })(),
   );
 });

--- a/src/components/__tests__/DisclaimerModal.test.tsx
+++ b/src/components/__tests__/DisclaimerModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { jest } from '@jest/globals';
 import DisclaimerModal from '../DisclaimerModal';
 
@@ -59,24 +59,23 @@ describe('DisclaimerModal', () => {
   });
 
   test('shows loader while fetching', async () => {
-    let resolveFetch: (value: Response) => void = () => {};
     global.fetch = jest.fn().mockImplementation(
       () =>
         new Promise<Response>((res) => {
-          resolveFetch = res;
+          setTimeout(
+            () =>
+              res({
+                ok: true,
+                text: () => Promise.resolve('loaded text'),
+              } as Response),
+            0,
+          );
         }),
     );
 
     render(<DisclaimerModal open={true} onOpenChange={() => {}} />);
 
     expect(screen.getByTestId('disclaimer-loader')).toBeDefined();
-
-    await act(async () => {
-      resolveFetch({
-        ok: true,
-        text: () => Promise.resolve('loaded text'),
-      } as Response);
-    });
 
     expect(await screen.findByText('loaded text')).toBeDefined();
   });
@@ -96,7 +95,7 @@ describe('DisclaimerModal', () => {
 
     rerender(<DisclaimerModal open={true} onOpenChange={() => {}} />);
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
     expect(await screen.findByText('loaded text')).toBeDefined();
   });
 

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -49,15 +49,15 @@ describe('trackEvent', () => {
   });
 
   test('does not call gtag when missing', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     trackEvent(true, 'foo');
     trackEvent(true, 'bar');
 
-    expect(errorSpy).toHaveBeenCalledWith(
+    expect(warnSpy).toHaveBeenCalledWith(
       'Tracking Analytics: gtag function missing.',
     );
-    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   test('gtag errors stop further tracking', () => {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -41,7 +41,7 @@ export function trackEvent(
 
   if (typeof gtag !== 'function') {
     if (!gtagMissingLogged) {
-      console.error('Tracking Analytics: gtag function missing.');
+      console.warn('Tracking Analytics: gtag function missing.');
       gtagMissingLogged = true;
     }
     return;


### PR DESCRIPTION
## Summary
- serve locale json assets so dynamic translations load correctly
- harden service worker fetch handling to avoid returning HTML for script requests and support offline fallback
- downgrade missing gtag message to warning and expand test fetch stubs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ce4184f3c8325b63dbf12f15c147d