### PR TITLE
fix: handle i18n base path

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,9 @@
 Object.defineProperty(globalThis, 'import', { value: {} });
 Object.defineProperty(globalThis.import, 'meta', { value: { env: {} } });
+declare global {
+  var __BASE_URL__: string;
+}
+globalThis.__BASE_URL__ = '/';
 import { jest } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
@@ -15,6 +19,8 @@ import path from 'path';
   }
   const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
   return Promise.resolve({
+    ok: true,
+    status: 200,
     json: async () => data,
     clone: function () {
       return this;
@@ -28,5 +34,7 @@ import path from 'path';
 };
 
 // Initialize i18next for component tests
-import { changeLanguageAsync } from './src/i18n';
-void changeLanguageAsync('en-US');
+void (async () => {
+  const { changeLanguageAsync } = await import('./src/i18n');
+  await changeLanguageAsync('en-US');
+})();

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,5 +1,6 @@
 import i18n, { type Resource } from 'i18next';
 import { initReactI18next } from 'react-i18next';
+declare const __BASE_URL__: string;
 
 // Initialize i18next without preloaded resources.
 
@@ -13,11 +14,14 @@ i18n.use(initReactI18next).init({
 export async function changeLanguageAsync(lng: string) {
   if (!i18n.hasResourceBundle(lng, 'translation')) {
     try {
-      const url = `/locales/${lng}.json`;
+      const url = `${__BASE_URL__}locales/${lng}.json`;
       let response: Response | undefined =
         typeof caches !== 'undefined' ? await caches.match(url) : undefined;
       if (!response) {
         response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch ${url}: ${response.status}`);
+        }
         if (typeof caches !== 'undefined') {
           const cache = await caches.open('sora-prompt-cache-v2');
           cache.put(url, response.clone());

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,11 +20,14 @@ try {
 }
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
+export default defineConfig(({ mode }) => {
+  const base = process.env.BASE_URL || '/';
+  return {
   server: {
     host: '::',
     port: 8080,
   },
+  base,
   plugins: [
     react(),
     VitePWA({
@@ -61,5 +64,7 @@ export default defineConfig(({ mode }) => ({
   define: {
     'import.meta.env.VITE_COMMIT_HASH': JSON.stringify(commitHash),
     'import.meta.env.VITE_COMMIT_DATE': JSON.stringify(commitDate),
+    __BASE_URL__: JSON.stringify(base),
   },
-}));
+  };
+});


### PR DESCRIPTION
## Summary
- load locale files relative to app base URL and guard fetch errors
- expose `__BASE_URL__` from Vite config and provide stub for tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cea1cb4288325bf45e8c1499f2399