### PR TITLE
feat: improve CLI flag handling

### DIFF
--- a/cli/__tests__/index.test.ts
+++ b/cli/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment node */
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { runCli } from '../index.ts';
 
 test('generates JSON from flags', () => {
@@ -18,4 +18,20 @@ test('generates JSON from file', () => {
   const obj = JSON.parse(out);
   expect(obj.prompt).toBe('from file');
   expect(obj.width).toBe(456);
+});
+
+test('shows help with --help', () => {
+  const out = runCli(['--help']);
+  expect(out).toMatch(/Usage: sora-crafter/);
+});
+
+test('prints version with --version', () => {
+  const version = JSON.parse(
+    readFileSync(join(__dirname, '../../package.json'), 'utf8'),
+  ).version;
+  expect(runCli(['--version']).trim()).toBe(version);
+});
+
+test('throws on unknown flag', () => {
+  expect(() => runCli(['--unknown'])).toThrow(/Unknown flag/);
 });

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -59,6 +59,30 @@ function buildOptionsFromFlags(
 export function runCli(argv: string[]): string {
   const args = parseArgs(argv);
 
+  if (args.help) {
+    return (
+      'Usage: sora-crafter [options]\n' +
+      '  --file <path>     Load options from JSON file\n' +
+      '  --help            Show this help message\n' +
+      '  --version         Show the package version\n'
+    );
+  }
+
+  if (args.version) {
+    const version = JSON.parse(readFileSync('package.json', 'utf8')).version;
+    return `${version}`;
+  }
+
+  const validKeys = new Set([
+    'file',
+    ...Object.keys(DEFAULT_OPTIONS),
+  ]);
+
+  const unknown = Object.keys(args).filter((k) => !validKeys.has(k));
+  if (unknown.length) {
+    throw new Error(`Unknown flag: --${unknown[0]}`);
+  }
+
   let options: SoraOptions | null = null;
 
   if (typeof args.file === 'string') {


### PR DESCRIPTION
## Summary
- handle `--help` and `--version` in CLI
- validate CLI flags and warn on unknown ones
- test help/version output and unknown flag

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cee2e024c832597a909051165d21d