### PR TITLE
fix: externalize index.html modules to avoid Vite proxy error

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,42 +30,8 @@
         document.documentElement.lang = 'en';
       }
     </script>
-    <script type="module">
-      import { DARK_MODE } from './src/lib/storage-keys.ts';
-      try {
-        const val = localStorage.getItem(DARK_MODE);
-        if (val === null || val === 'true') {
-          document.documentElement.classList.add('dark');
-        }
-      } catch {
-        document.documentElement.classList.add('dark');
-      }
-    </script>
-    <script type="module">
-      (() => {
-        try {
-          const disabled = import.meta.env.VITE_DISABLE_ANALYTICS === 'true';
-          if (disabled) return;
-          const enabled = localStorage.getItem('trackingEnabled');
-          if (enabled === null || enabled === 'true') {
-            const id = import.meta.env.VITE_MEASUREMENT_ID || 'G-RVR9TSBQL7';
-            const s = document.createElement('script');
-            s.async = true;
-            s.src = `https://www.googletagmanager.com/gtag/js?id=${id}`;
-            document.head.appendChild(s);
-            window.dataLayer = window.dataLayer || [];
-            function gtag() {
-              dataLayer.push(arguments);
-            }
-            window.gtag = gtag;
-            gtag('js', new Date());
-            gtag('config', id);
-          }
-        } catch (e) {
-          console.error('Tracking initialization failed', e);
-        }
-      })();
-    </script>
+    <script type="module" src="/src/init-dark-mode.ts"></script>
+    <script type="module" src="/src/init-analytics.ts"></script>
   </head>
 
   <body>

--- a/src/init-analytics.ts
+++ b/src/init-analytics.ts
@@ -1,0 +1,32 @@
+export {};
+
+declare global {
+  interface Window {
+    dataLayer: unknown[];
+    gtag: (...args: unknown[]) => void;
+  }
+}
+
+(() => {
+  try {
+    const disabled = import.meta.env.VITE_DISABLE_ANALYTICS === 'true';
+    if (disabled) return;
+    const enabled = localStorage.getItem('trackingEnabled');
+    if (enabled === null || enabled === 'true') {
+      const id = import.meta.env.VITE_MEASUREMENT_ID || 'G-RVR9TSBQL7';
+      const s = document.createElement('script');
+      s.async = true;
+      s.src = `https://www.googletagmanager.com/gtag/js?id=${id}`;
+      document.head.appendChild(s);
+      window.dataLayer = window.dataLayer || [];
+      function gtag(...args: unknown[]) {
+        window.dataLayer.push(args);
+      }
+      window.gtag = gtag;
+      gtag('js', new Date());
+      gtag('config', id);
+    }
+  } catch (e) {
+    console.error('Tracking initialization failed', e);
+  }
+})();

--- a/src/init-dark-mode.ts
+++ b/src/init-dark-mode.ts
@@ -1,0 +1,10 @@
+import { DARK_MODE } from './lib/storage-keys';
+
+try {
+  const val = localStorage.getItem(DARK_MODE);
+  if (val === null || val === 'true') {
+    document.documentElement.classList.add('dark');
+  }
+} catch {
+  document.documentElement.classList.add('dark');
+}


### PR DESCRIPTION
## Summary
- move dark mode and analytics inline scripts into dedicated modules
- import new modules from `index.html` to prevent missing HTML proxy errors

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cef078dd8832594d0b021daa8d1b4