### PR TITLE
feat: add aria-label to action delete button

### DIFF
--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -445,6 +445,11 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
                           variant="ghost"
                           className={`p-0 w-3.5 h-3.5 ${confirmDeleteActionIdx === idx ? 'text-destructive animate-pulse' : ''}`}
                           onClick={() => requestDeleteAction(idx)}
+                          aria-label={
+                            confirmDeleteActionIdx === idx
+                              ? t('confirm')
+                              : t('delete')
+                          }
                         >
                           {confirmDeleteActionIdx === idx ? (
                             <Check className="w-3.5 h-3.5" />

--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -247,8 +247,12 @@ describe('HistoryPanel action history', () => {
     const panel = screen.getByRole('tabpanel', { name: /latest actions/i });
     const entryText = within(panel).getByText('a');
     const entry = entryText.parentElement!.parentElement!;
-    const deleteBtn = within(entry).getByRole('button');
+    const deleteBtn = within(entry).getByRole('button', {
+      name: i18n.t('delete'),
+    });
+    expect(deleteBtn.getAttribute('aria-label')).toBe(i18n.t('delete'));
     fireEvent.click(deleteBtn);
+    expect(deleteBtn.getAttribute('aria-label')).toBe(i18n.t('confirm'));
     fireEvent.click(deleteBtn);
 
     expect(safeSet).toHaveBeenCalledWith(TRACKING_HISTORY, [], true);


### PR DESCRIPTION
## Summary
- add proper aria-label to action history delete button
- test presence and state change of the new aria-label

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cf2b402648325b415b059bd120d65