### PR TITLE
fix: sanitize base url

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,9 @@
 Object.defineProperty(globalThis, 'import', { value: {} });
-Object.defineProperty(globalThis.import, 'meta', { value: { env: {} } });
+Object.defineProperty(globalThis.import, 'meta', {
+  value: { env: { BASE_URL: '/' } },
+});
 declare global {
+  // eslint-disable-next-line no-var
   var __BASE_URL__: string;
 }
 globalThis.__BASE_URL__ = '/';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,8 @@ try {
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
-  const base = process.env.BASE_URL || '/';
+  const envBase = process.env.BASE_URL;
+  const base = envBase && envBase.startsWith('/') ? envBase : '/';
   return {
   server: {
     host: '::',


### PR DESCRIPTION
## Summary
- sanitize BASE_URL to avoid invalid paths breaking translation loads
- expose BASE_URL in test env for i18n

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cf30cd52c832593f429a671a0328a