### PR TITLE
fix: handle missing active service worker during update check

### DIFF
--- a/src/hooks/__tests__/use-update-check.test.ts
+++ b/src/hooks/__tests__/use-update-check.test.ts
@@ -14,7 +14,10 @@ describe('useUpdateCheck', () => {
 
   it('calls update on registration', async () => {
     const update = jest.fn().mockResolvedValue(undefined);
-    const getRegistration = jest.fn().mockResolvedValue({ update });
+    const getRegistration = jest.fn().mockResolvedValue({
+      update,
+      active: {},
+    });
     Object.defineProperty(navigator, 'serviceWorker', {
       configurable: true,
       value: { getRegistration },
@@ -30,7 +33,11 @@ describe('useUpdateCheck', () => {
   it('sets updateAvailable when registration has waiting worker', async () => {
     const update = jest.fn().mockResolvedValue(undefined);
     const waiting = {};
-    const getRegistration = jest.fn().mockResolvedValue({ update, waiting });
+    const getRegistration = jest.fn().mockResolvedValue({
+      update,
+      waiting,
+      active: {},
+    });
     Object.defineProperty(navigator, 'serviceWorker', {
       configurable: true,
       value: { getRegistration },
@@ -41,5 +48,19 @@ describe('useUpdateCheck', () => {
       await result.current.checkForUpdate();
     });
     expect(result.current.updateAvailable).toBe(true);
+  });
+
+  it('skips update when registration has no active worker', async () => {
+    const update = jest.fn().mockResolvedValue(undefined);
+    const getRegistration = jest.fn().mockResolvedValue({ update });
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: { getRegistration },
+    });
+    const { result } = renderHook(() => useUpdateCheck());
+    await act(async () => {
+      await result.current.checkForUpdate();
+    });
+    expect(update).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/use-update-check.ts
+++ b/src/hooks/use-update-check.ts
@@ -7,7 +7,7 @@ export function useUpdateCheck() {
     if (!('serviceWorker' in navigator) || !navigator.serviceWorker) return;
     try {
       const registration = await navigator.serviceWorker.getRegistration();
-      if (!registration) return;
+      if (!registration || !registration.active) return;
       await registration.update();
       if (registration.waiting) {
         setUpdateAvailable(true);


### PR DESCRIPTION
## Summary
- avoid DOMException when service worker cache is purged by checking for an active registration before calling update
- test useUpdateCheck to ensure update is skipped without an active worker

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d052ecacc83258d9ece81076ff0b9