### PR TITLE
Wrap generated JSON output

### DIFF
--- a/src/components/GeneratedJson.tsx
+++ b/src/components/GeneratedJson.tsx
@@ -59,8 +59,11 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
   );
 
   return (
-    <div className="h-full overflow-y-auto" ref={containerRef}>
-      <pre className="p-6 text-sm font-mono whitespace-pre-wrap break-words leading-relaxed">
+    <div
+      className="h-full overflow-y-auto overflow-x-hidden"
+      ref={containerRef}
+    >
+      <pre className="p-6 text-sm font-mono whitespace-pre-wrap break-all leading-relaxed">
         {diffParts
           ? diffParts.map((part, idx) =>
               renderHighlighted(part.value, Boolean(part.added), idx),


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling in generated JSON window
- enable line wrapping for long JSON entries

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d059792e88325a9b619a61952c45b