### PR TITLE
Wrap generated JSON output to avoid horizontal scrolling

### DIFF
--- a/src/components/GeneratedJson.tsx
+++ b/src/components/GeneratedJson.tsx
@@ -51,7 +51,14 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
         PreTag="span"
         CodeTag="span"
         wrapLongLines
-        customStyle={{ margin: 0, padding: 0, background: 'none' }}
+        customStyle={{
+          margin: 0,
+          padding: 0,
+          background: 'none',
+          overflowX: 'hidden',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+        }}
       >
         {value}
       </SyntaxHighlighter>
@@ -59,7 +66,7 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
   );
 
   return (
-    <div className="h-full overflow-y-auto" ref={containerRef}>
+    <div className="h-full overflow-y-auto overflow-x-hidden" ref={containerRef}>
       <pre className="p-6 text-sm font-mono whitespace-pre-wrap break-words leading-relaxed">
         {diffParts
           ? diffParts.map((part, idx) =>


### PR DESCRIPTION
## Summary
- ensure generated JSON preview wraps long lines instead of scrolling horizontally

## Testing
- `npm test --silent | tail -n 20`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d059792e88325a9b619a61952c45b