### PR TITLE
feat(history): virtualize history list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,12 +56,16 @@
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
         "react-syntax-highlighter": "^15.6.1",
+        "react-window": "^1.8.10",
         "recharts": "^2.12.7",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.3",
         "zod": "^3.23.8"
+      },
+      "bin": {
+        "sora-crafter": "dist/cli/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -11519,6 +11523,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -12753,6 +12763,23 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz",
+      "integrity": "sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "react-syntax-highlighter": "^15.6.1",
+    "react-window": "^1.8.10",
     "recharts": "^2.12.7",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",

--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -76,7 +76,11 @@ jest.mock('@/components/ui/dropdown-menu', () => ({
   }) => <button onClick={onSelect}>{children}</button>,
 }));
 
-const sampleHistory = [{ id: 1, date: 'd', json: '{"prompt":"a"}' }];
+const sampleHistory = Array.from({ length: 20 }, (_, i) => ({
+  id: i + 1,
+  date: 'd',
+  json: `{"prompt":"p${i}"}`,
+}));
 const sampleActions = [{ date: 'd', action: 'a' }];
 
 function renderPanel(
@@ -182,12 +186,22 @@ describe('HistoryPanel basic actions', () => {
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 
-  test('delete and clear callbacks fire and timers reset', () => {
+  test('delete and clear callbacks fire and timers reset', async () => {
     const onDelete = jest.fn();
     const onClear = jest.fn();
     renderPanel({ onDelete, onClear });
 
-    const delBtn = screen.getByRole('button', { name: /delete/i });
+    const list = screen.getByTestId('history-list');
+    act(() => {
+      Object.defineProperty(list, 'scrollTop', {
+        configurable: true,
+        value: 0,
+        writable: true,
+      });
+      fireEvent.scroll(list);
+    });
+
+    const delBtn = screen.getAllByRole('button', { name: /delete/i })[0];
     expect(delBtn.textContent).toMatch(/delete/i);
     fireEvent.click(delBtn);
     expect(delBtn.textContent).toMatch(/confirm/i);

--- a/src/components/history/HistoryItem.tsx
+++ b/src/components/history/HistoryItem.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Clipboard, Trash2, Edit, Eye, Check } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { trackEvent } from '@/lib/analytics';
+import type { HistoryEntry } from '../HistoryPanel';
+
+interface HistoryItemProps {
+  entry: HistoryEntry;
+  onEdit: (json: string) => void;
+  onCopy: (json: string) => void;
+  onDelete: (id: number) => void;
+  onPreview: (entry: HistoryEntry) => void;
+  trackingEnabled: boolean;
+}
+
+const HistoryItem: React.FC<HistoryItemProps> = ({
+  entry,
+  onEdit,
+  onCopy,
+  onDelete,
+  onPreview,
+  trackingEnabled,
+}) => {
+  const { t } = useTranslation();
+  const [edited, setEdited] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  return (
+    <div className="border p-3 rounded-md space-y-2">
+      <div className="text-xs text-muted-foreground flex justify-between">
+        <span>{entry.date}</span>
+      </div>
+      {(() => {
+        try {
+          const obj = JSON.parse(entry.json);
+          return (
+            <div className="space-y-1 text-xs text-muted-foreground">
+              <div className="font-medium break-words">{obj.prompt}</div>
+            </div>
+          );
+        } catch {
+          return null;
+        }
+      })()}
+      <div className="flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => {
+            trackEvent(trackingEnabled, 'history_edit');
+            onEdit(entry.json);
+            setEdited(true);
+            setTimeout(() => setEdited(false), 1500);
+          }}
+          className={`gap-1 ${edited ? 'text-green-600 animate-pulse' : ''}`}
+        >
+          {edited ? <Check className="w-4 h-4" /> : <Edit className="w-4 h-4" />}{' '}
+          {edited ? t('edited') : t('edit')}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => {
+            trackEvent(trackingEnabled, 'history_copy');
+            onCopy(entry.json);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+          }}
+          className={`gap-1 ${copied ? 'text-green-600 animate-pulse' : ''}`}
+        >
+          {copied ? <Check className="w-4 h-4" /> : <Clipboard className="w-4 h-4" />}{' '}
+          {copied ? t('copied') : t('copy')}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => {
+            trackEvent(trackingEnabled, 'history_preview');
+            onPreview(entry);
+          }}
+          className="gap-1"
+        >
+          <Eye className="w-4 h-4" /> {t('preview')}
+        </Button>
+        <Button
+          size="sm"
+          variant="destructive"
+          onClick={() => {
+            if (confirmDelete) {
+              trackEvent(trackingEnabled, 'history_delete_confirm');
+              onDelete(entry.id);
+              setConfirmDelete(false);
+            } else {
+              setConfirmDelete(true);
+              setTimeout(() => setConfirmDelete(false), 1500);
+            }
+          }}
+          className={`gap-1 ${confirmDelete ? 'animate-pulse' : ''}`}
+        >
+          <Trash2 className="w-4 h-4" />
+          {confirmDelete ? t('confirm') : t('delete')}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default HistoryItem;


### PR DESCRIPTION
## Summary
- extract history entry UI into reusable `HistoryItem`
- use `react-window` to virtualize history list and improve performance
- update HistoryPanel tests for virtualized scrolling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d05b26e9c832597ca9976338d3f09