### PR TITLE
fix: add word wrap style to highlighted JSON

### DIFF
--- a/src/components/GeneratedJson.tsx
+++ b/src/components/GeneratedJson.tsx
@@ -58,6 +58,7 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
           overflowX: 'hidden',
           whiteSpace: 'pre-wrap',
           wordBreak: 'break-word',
+          wordWrap: 'break-word',
         }}
       >
         {value}
@@ -66,7 +67,10 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
   );
 
   return (
-    <div className="h-full overflow-y-auto overflow-x-hidden" ref={containerRef}>
+    <div
+      className="h-full overflow-y-auto overflow-x-hidden"
+      ref={containerRef}
+    >
       <pre className="p-6 text-sm font-mono whitespace-pre-wrap break-words leading-relaxed">
         {diffParts
           ? diffParts.map((part, idx) =>

--- a/src/components/__tests__/GeneratedJson.test.tsx
+++ b/src/components/__tests__/GeneratedJson.test.tsx
@@ -53,7 +53,9 @@ describe('GeneratedJson', () => {
     expect(added[0].textContent).toBe(',"b":2');
     const token = div.querySelector('pre span span');
     expect(token).toBeTruthy();
-    expect(token?.getAttribute('style')).toBeTruthy();
+    const style = token?.getAttribute('style') || '';
+    expect(style).toBeTruthy();
+    expect(style).toContain('word-wrap: break-word');
 
     act(() => {
       jest.advanceTimersByTime(2000);


### PR DESCRIPTION
## Summary
- ensure highlighted JSON uses `word-wrap: break-word` for long line wrapping
- test now asserts the word-wrap style exists on highlighted spans

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d094d44d88325b67b42a8185b662b