### PR TITLE
fix generated json vertical overflow

### DIFF
--- a/src/components/GeneratedJson.tsx
+++ b/src/components/GeneratedJson.tsx
@@ -56,9 +56,11 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
           padding: 0,
           background: 'none',
           overflowX: 'hidden',
+          overflowY: 'auto',
           whiteSpace: 'pre-wrap',
           wordBreak: 'break-word',
           wordWrap: 'break-word',
+          overflowWrap: 'break-word',
         }}
       >
         {value}


### PR DESCRIPTION
## Summary
- enable vertical auto overflow for generated JSON view
- ensure long lines wrap in the syntax highlighter

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d0bb07a008325bc77c96bee4b2396