### PR TITLE
feat: add icon to purge cache button

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -25,6 +25,7 @@ import {
   Shuffle,
   Eye,
   EyeOff,
+  Trash2,
 } from 'lucide-react';
 import { toast } from '@/components/ui/sonner-toast';
 import { trackEvent } from '@/lib/analytics';
@@ -221,7 +222,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                   trackEvent(trackingEnabled, 'purge_cache');
                 }}
               >
-                {t('purgeCache')}
+                <Trash2 className="w-4 h-4" /> {t('purgeCache')}
               </Button>
             </div>
           </ScrollArea>


### PR DESCRIPTION
## Summary
- add missing Trash icon to purge cache action in settings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d0e73f7d483259ac844cdf44c21d9