### PR TITLE
Add Loading component with Suspense fallback and test

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { useDarkMode } from '@/hooks/use-dark-mode';
 const Index = lazy(() => import('./pages/Index'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 import ErrorBoundary from './components/ErrorBoundary';
+import Loading from './components/Loading';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -38,7 +39,7 @@ const App = () => {
             <BrowserRouter
               future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
             >
-              <Suspense fallback={null}>
+              <Suspense fallback={<Loading />}>
                 <Routes>
                   <Route path="/" element={<Index />} />
                   {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/__tests__/Loading.test.tsx
+++ b/src/__tests__/Loading.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Loading from '../components/Loading';
+
+describe('Loading', () => {
+  test('renders spinner', () => {
+    render(<Loading />);
+    expect(screen.getByRole('status')).toBeTruthy();
+  });
+});

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+
+const Loading: React.FC = () => (
+  <div className="flex items-center justify-center p-4" role="status">
+    <Loader2 className="h-6 w-6 animate-spin" />
+    <span className="sr-only">Loading...</span>
+  </div>
+);
+
+export default Loading;


### PR DESCRIPTION
## Summary
- add lightweight `<Loading />` component with spinner
- use `<Loading />` as the `Suspense` fallback in `App`
- add basic render test for `<Loading />`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d11dc4b9083259192747cdab4f432