### PR TITLE
refactor: centralize pwa cache name

### DIFF
--- a/public/__tests__/sw.test.ts
+++ b/public/__tests__/sw.test.ts
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
+import { PWA_CACHE } from '@/lib/cache-name';
 
 const disclaimerDir = path.resolve(__dirname, '../disclaimers');
 function getLocalizedDisclaimers(): string[] {
@@ -93,9 +94,7 @@ describe('service worker', () => {
     };
     await listeners.install(installEvent);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((global as any).caches.open).toHaveBeenCalledWith(
-      'sora-prompt-cache-v2',
-    );
+    expect((global as any).caches.open).toHaveBeenCalledWith(PWA_CACHE);
     expect(cacheAddAll).toHaveBeenCalledWith(
       expect.arrayContaining([
         ...staticAssets,
@@ -166,10 +165,7 @@ describe('service worker', () => {
 
   test('deletes outdated caches on activate', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).caches.keys.mockResolvedValue([
-      'old-cache',
-      'sora-prompt-cache-v2',
-    ]);
+    (global as any).caches.keys.mockResolvedValue(['old-cache', PWA_CACHE]);
     await import('../sw.js');
     const waitUntil = jest.fn();
     const activateEvent = { waitUntil };

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,5 @@
-const cacheName = 'sora-prompt-cache-v2';
+import { PWA_CACHE } from '../src/lib/cache-name.ts';
+const cacheName = PWA_CACHE;
 // Basic app shell files that are always cached
 const staticAssets = [
   '/',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,5 +1,6 @@
 import i18n, { type Resource } from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import { PWA_CACHE } from '@/lib/cache-name';
 declare const __BASE_URL__: string;
 
 // Initialize i18next without preloaded resources.
@@ -23,7 +24,7 @@ export async function changeLanguageAsync(lng: string) {
           throw new Error(`Failed to fetch ${url}: ${response.status}`);
         }
         if (typeof caches !== 'undefined') {
-          const cache = await caches.open('sora-prompt-cache-v2');
+          const cache = await caches.open(PWA_CACHE);
           cache.put(url, response.clone());
         }
       }

--- a/src/lib/cache-name.ts
+++ b/src/lib/cache-name.ts
@@ -1,0 +1,1 @@
+export const PWA_CACHE = 'sora-prompt-cache-v2';


### PR DESCRIPTION
## Summary
- centralize PWA cache name constant
- reuse cache name in service worker and i18n
- update service worker test to import shared constant

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d11d036d08325b594d713ed20cfa2