### PR TITLE
feat(cli): add stdin support

### DIFF
--- a/cli/__tests__/index.test.ts
+++ b/cli/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment node */
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { readFileSync, writeFileSync } from 'node:fs';
+import * as fs from 'node:fs';
 import { runCli } from '../index.ts';
 
 test('generates JSON from flags', () => {
@@ -13,7 +13,7 @@ test('generates JSON from flags', () => {
 
 test('generates JSON from file', () => {
   const file = join(tmpdir(), 'options.json');
-  writeFileSync(file, JSON.stringify({ prompt: 'from file', width: 456 }));
+  fs.writeFileSync(file, JSON.stringify({ prompt: 'from file', width: 456 }));
   const out = runCli(['--file', file]);
   const obj = JSON.parse(out);
   expect(obj.prompt).toBe('from file');
@@ -27,11 +27,18 @@ test('shows help with --help', () => {
 
 test('prints version with --version', () => {
   const version = JSON.parse(
-    readFileSync(join(__dirname, '../../package.json'), 'utf8'),
+    fs.readFileSync(join(__dirname, '../../package.json'), 'utf8'),
   ).version;
   expect(runCli(['--version']).trim()).toBe(version);
 });
 
 test('throws on unknown flag', () => {
   expect(() => runCli(['--unknown'])).toThrow(/Unknown flag/);
+});
+
+test('reads options from stdin when no flags are given', () => {
+  const out = runCli([], JSON.stringify({ prompt: 'stdin', width: 321 }));
+  const obj = JSON.parse(out);
+  expect(obj.prompt).toBe('stdin');
+  expect(obj.width).toBe(321);
 });

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -56,7 +56,7 @@ function buildOptionsFromFlags(
   return { ...DEFAULT_OPTIONS, ...updates };
 }
 
-export function runCli(argv: string[]): string {
+export function runCli(argv: string[], stdinInput?: string): string {
   const args = parseArgs(argv);
 
   if (args.help) {
@@ -88,6 +88,13 @@ export function runCli(argv: string[]): string {
   if (typeof args.file === 'string') {
     try {
       const json = readFileSync(args.file, 'utf8');
+      options = loadOptionsFromJson(json);
+    } catch {
+      options = null;
+    }
+  } else if (Object.keys(args).length === 0) {
+    try {
+      const json = stdinInput ?? readFileSync(0, 'utf8');
       options = loadOptionsFromJson(json);
     } catch {
       options = null;


### PR DESCRIPTION
## Summary
- read JSON from stdin when no CLI flags or file are provided
- parse stdin input with loadOptionsFromJson
- test stdin-based option loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d11bdb7d48325af306c7d4509c414