### PR TITLE
Refactor storage utilities to unify JSON handling

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -234,7 +234,7 @@ A mapping from option keys to their enabling flags (e.g., `lighting` → `use_li
 - **postMessage misuse**: Current flow filters by `event.source === openedWindow` and message `type`; **must** also check `event.origin` against an allowlist (e.g., `https://sora.chatgpt.com`) when possible. Consider including a random **nonce** in the handshake payload for CSRF‑style protection.
 - **Clipboard**: Detect and fail gracefully; do not log copied content.
 - **Analytics**: Default off when `VITE_DISABLE_ANALYTICS=true`. Even when on, events contain **no prompt data**; only action metadata is stored. Local action history should be user‑clearable.
-- **Local storage**: Wrap all accesses in try/catch (already implemented); prefer `setJson/getJson` for structured values.
+- **Local storage**: Wrap all accesses in try/catch (already implemented); prefer `safeSet`/`safeGet` with the `json` option for structured values.
 - **SW caching**: Precache only static assets and disclaimer text; avoid caching third‑party responses by default.
 
 **Compliance**

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -88,7 +88,7 @@ const Dashboard = () => {
   const [showDisclaimer, setShowDisclaimer] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [history, setHistory] = useState<HistoryEntry[]>(() =>
-    safeGet<HistoryEntry[]>('jsonHistory', [], true),
+    safeGet<HistoryEntry[]>('jsonHistory', [], { json: true }),
   );
   const isSingleColumn = useIsSingleColumn();
   const [darkMode, setDarkMode] = useDarkMode();
@@ -116,7 +116,7 @@ const Dashboard = () => {
   }, [trackingEnabled]);
 
   useEffect(() => {
-    safeSet('jsonHistory', history, true);
+    safeSet('jsonHistory', history, { json: true });
   }, [history]);
 
   useEffect(() => {

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -160,10 +160,10 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
     const list = safeGet<{ date: string; action: string }[]>(
       TRACKING_HISTORY,
       [],
-      true,
+      { json: true },
     );
     list.splice(idx, 1);
-    safeSet(TRACKING_HISTORY, list, true);
+    safeSet(TRACKING_HISTORY, list, { json: true });
     window.dispatchEvent(new Event('trackingHistoryUpdate'));
     toast.success(t('actionDeleted'));
   };

--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -38,8 +38,6 @@ jest.mock('@/lib/storage', () => ({
   safeGet: jest.fn(),
   safeSet: jest.fn(),
   safeRemove: jest.fn(),
-  getJson: jest.fn(),
-  setJson: jest.fn(),
 }));
 
 jest.mock('../ClipboardImportModal', () => ({
@@ -271,7 +269,7 @@ describe('HistoryPanel action history', () => {
     expect(deleteBtn.getAttribute('aria-label')).toBe(i18n.t('confirm'));
     fireEvent.click(deleteBtn);
 
-    expect(safeSet).toHaveBeenCalledWith(TRACKING_HISTORY, [], true);
+    expect(safeSet).toHaveBeenCalledWith(TRACKING_HISTORY, [], { json: true });
     expect(events).toHaveLength(1);
   });
 });

--- a/src/hooks/__tests__/use-locale.test.ts
+++ b/src/hooks/__tests__/use-locale.test.ts
@@ -11,8 +11,8 @@ jest.mock('@/i18n', () => ({
 
 jest.mock('@/lib/storage', () => ({
   __esModule: true,
-  getJson: jest.fn(),
-  setJson: jest.fn(),
+  safeGet: jest.fn(),
+  safeSet: jest.fn(),
   safeRemove: jest.fn(),
 }));
 
@@ -28,26 +28,30 @@ describe('useLocale', () => {
   });
 
   test('initializes state from localStorage', () => {
-    (storage.getJson as jest.Mock).mockReturnValue('es-ES');
+    (storage.safeGet as jest.Mock).mockReturnValue('es-ES');
     const { result } = renderHook(() => useLocale());
     expect(result.current[0]).toBe('es-ES');
-    expect(storage.getJson).toHaveBeenCalledWith(LOCALE, 'en-US');
+    expect(storage.safeGet).toHaveBeenCalledWith(LOCALE, 'en-US', {
+      json: true,
+    });
   });
 
   test('auto-detects locale from navigator.language', () => {
-    (storage.getJson as jest.Mock).mockReturnValue(undefined);
+    (storage.safeGet as jest.Mock).mockReturnValue(undefined);
     Object.defineProperty(window.navigator, 'language', {
       value: 'fr-CA',
       configurable: true,
     });
     const { result } = renderHook(() => useLocale());
     expect(result.current[0]).toBe('fr-FR');
-    expect(storage.getJson).toHaveBeenCalledWith(LOCALE, 'fr-FR');
+    expect(storage.safeGet).toHaveBeenCalledWith(LOCALE, 'fr-FR', {
+      json: true,
+    });
     expect(changeLanguageAsync).toHaveBeenLastCalledWith('fr-FR');
   });
 
   test('updates locale and persists value', () => {
-    (storage.getJson as jest.Mock).mockReturnValue('en-US');
+    (storage.safeGet as jest.Mock).mockReturnValue('en-US');
     const { result } = renderHook(() => useLocale());
 
     act(() => {
@@ -55,7 +59,9 @@ describe('useLocale', () => {
     });
 
     expect(changeLanguageAsync).toHaveBeenLastCalledWith('fr-FR');
-    expect(storage.setJson).toHaveBeenLastCalledWith(LOCALE, 'fr-FR');
+    expect(storage.safeSet).toHaveBeenLastCalledWith(LOCALE, 'fr-FR', {
+      json: true,
+    });
     expect(result.current[0]).toBe('fr-FR');
   });
 });

--- a/src/hooks/use-action-history.ts
+++ b/src/hooks/use-action-history.ts
@@ -9,12 +9,12 @@ export interface ActionEntry {
 
 export function useActionHistory() {
   const [history, setHistory] = useState<ActionEntry[]>(() => {
-    return safeGet<ActionEntry[]>(TRACKING_HISTORY, [], true);
+    return safeGet<ActionEntry[]>(TRACKING_HISTORY, [], { json: true });
   });
 
   useEffect(() => {
     const handler = () => {
-      setHistory(safeGet<ActionEntry[]>(TRACKING_HISTORY, [], true));
+      setHistory(safeGet<ActionEntry[]>(TRACKING_HISTORY, [], { json: true }));
     };
     window.addEventListener('trackingHistoryUpdate', handler);
     return () => window.removeEventListener('trackingHistoryUpdate', handler);

--- a/src/hooks/use-github-stats.ts
+++ b/src/hooks/use-github-stats.ts
@@ -16,8 +16,8 @@ export function useGithubStats() {
 
   useEffect(() => {
     if (DISABLE_STATS) return;
-    const cached = safeGet<GithubStats>('githubStats', null, true);
-    const cachedTs = safeGet<number>('githubStatsTimestamp', 0, true);
+    const cached = safeGet<GithubStats>('githubStats', null, { json: true });
+    const cachedTs = safeGet<number>('githubStatsTimestamp', 0, { json: true });
     if (
       cached &&
       typeof cachedTs === 'number' &&
@@ -51,8 +51,8 @@ export function useGithubStats() {
             issues: issuesData.total_count,
           };
           setStats(data);
-          safeSet('githubStats', data, true);
-          safeSet('githubStatsTimestamp', Date.now(), true);
+          safeSet('githubStats', data, { json: true });
+          safeSet('githubStatsTimestamp', Date.now(), { json: true });
         }
       } catch (err) {
         if ((err as Error).name !== 'AbortError') {

--- a/src/hooks/use-local-storage-state.ts
+++ b/src/hooks/use-local-storage-state.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState, Dispatch, SetStateAction } from 'react';
-import { getJson, setJson, safeRemove } from '@/lib/storage';
+import { safeGet, safeSet, safeRemove } from '@/lib/storage';
 
 /**
  * Sync a stateful value with `localStorage`.
@@ -15,7 +15,7 @@ export function useLocalStorageState<T>(
   defaultValue: T,
 ): [T, Dispatch<SetStateAction<T>>] {
   const [state, setState] = useState<T>(() => {
-    const stored = getJson<T>(key, defaultValue);
+    const stored = safeGet<T>(key, defaultValue, { json: true });
     return stored ?? defaultValue;
   });
 
@@ -24,7 +24,7 @@ export function useLocalStorageState<T>(
       safeRemove(key);
       return;
     }
-    setJson(key, state);
+    safeSet(key, state, { json: true });
   }, [key, state, defaultValue]);
 
   useEffect(() => {

--- a/src/lib/__tests__/storage.test.ts
+++ b/src/lib/__tests__/storage.test.ts
@@ -1,4 +1,4 @@
-import { safeGet, safeSet, safeRemove, getJson, setJson } from '../storage';
+import { safeGet, safeSet, safeRemove } from '../storage';
 
 describe('storage utils', () => {
   beforeEach(() => {
@@ -13,13 +13,13 @@ describe('storage utils', () => {
   test('safeGet returns default when JSON.parse throws', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     localStorage.setItem('bad', '{oops');
-    expect(safeGet('bad', 'fallback', true)).toBe('fallback');
+    expect(safeGet('bad', 'fallback', { json: true })).toBe('fallback');
     expect(warnSpy).toHaveBeenCalled();
   });
 
   test('safeGet parses JSON when present', () => {
     localStorage.setItem('obj', '{"a":1}');
-    expect(safeGet<{ a: number }>('obj', null, true)).toEqual({ a: 1 });
+    expect(safeGet<{ a: number }>('obj', null, { json: true })).toEqual({ a: 1 });
   });
 
   test('safeSet logs warning when setItem fails', () => {
@@ -39,7 +39,7 @@ describe('storage utils', () => {
     expect(spy).toHaveBeenCalledWith('k', 'v');
   });
 
-  test('safeSet logs warning when value is not string and stringify is false', () => {
+  test('safeSet logs warning when value is not string and json is false', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     expect(safeSet('k', { a: 1 })).toBe(false);
     expect(warnSpy).toHaveBeenCalled();
@@ -62,32 +62,21 @@ describe('storage utils', () => {
     expect(spy).toHaveBeenCalledWith('k');
   });
 
-  test('getJson returns default when parsing fails', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    localStorage.setItem('bad', '{oops');
-    expect(getJson('bad', { a: 1 })).toEqual({ a: 1 });
-    expect(warnSpy).toHaveBeenCalled();
-  });
 
-  test('getJson parses JSON when present', () => {
-    localStorage.setItem('obj', '{"a":1}');
-    expect(getJson<{ a: number }>('obj', null)).toEqual({ a: 1 });
-  });
-
-  test('setJson stringifies value before storing', () => {
+  test('safeSet stringifies value when json option is true', () => {
     const spy = jest
       .spyOn(Storage.prototype, 'setItem')
       .mockImplementation(() => {});
-    expect(setJson('obj', { a: 1 })).toBe(true);
+    expect(safeSet('obj', { a: 1 }, { json: true })).toBe(true);
     expect(spy).toHaveBeenCalledWith('obj', '{"a":1}');
   });
 
-  test('setJson logs warning when setItem fails', () => {
+  test('safeSet logs warning when setItem fails with json option', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw new Error('fail');
     });
-    expect(setJson('k', { a: 1 })).toBe(false);
+    expect(safeSet('k', { a: 1 }, { json: true })).toBe(false);
     expect(warnSpy).toHaveBeenCalled();
   });
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -17,11 +17,11 @@ export function trackEvent(
     const list = safeGet<{ date: string; action: string }[]>(
       TRACKING_HISTORY,
       [],
-      true,
+      { json: true },
     ) as { date: string; action: string }[];
     list.unshift({ date: new Date().toLocaleString(), action: event });
     if (list.length > 100) list.length = 100;
-    if (!safeSet(TRACKING_HISTORY, list, true)) throw new Error('fail');
+    if (!safeSet(TRACKING_HISTORY, list, { json: true })) throw new Error('fail');
     window.dispatchEvent(new Event('trackingHistoryUpdate'));
   } catch {
     console.error('Tracking History: There was an error.');

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,12 +1,12 @@
 export function safeGet<T = string>(
   key: string,
   defaultValue: T | null = null,
-  parse = false,
+  opts: { json?: boolean } = {},
 ): T | string | null {
   try {
     const value = localStorage.getItem(key);
     if (value === null) return defaultValue;
-    if (parse) return JSON.parse(value) as T;
+    if (opts.json) return JSON.parse(value) as T;
     return value;
   } catch (err) {
     console.warn('safeGet failed', key, err);
@@ -17,16 +17,16 @@ export function safeGet<T = string>(
 export function safeSet(
   key: string,
   value: unknown,
-  stringify = false,
+  opts: { json?: boolean } = {},
 ): boolean {
-  if (!stringify && typeof value !== 'string') {
+  if (!opts.json && typeof value !== 'string') {
     console.warn(
-      `safeSet: value for key "${key}" must be a string when stringify is false`,
+      `safeSet: value for key "${key}" must be a string when json is false`,
     );
     return false;
   }
   try {
-    const data = stringify ? JSON.stringify(value) : (value as string);
+    const data = opts.json ? JSON.stringify(value) : (value as string);
     localStorage.setItem(key, data);
     return true;
   } catch (e) {
@@ -41,27 +41,6 @@ export function safeRemove(key: string): boolean {
     return true;
   } catch (e) {
     console.warn(`safeRemove: failed for key "${key}"`, e);
-    return false;
-  }
-}
-
-export function getJson<T>(key: string, defaultValue: T | null = null): T | null {
-  try {
-    const value = localStorage.getItem(key);
-    if (value === null) return defaultValue;
-    return JSON.parse(value) as T;
-  } catch (err) {
-    console.warn('getJson failed', key, err);
-    return defaultValue;
-  }
-}
-
-export function setJson<T>(key: string, value: T): boolean {
-  try {
-    localStorage.setItem(key, JSON.stringify(value));
-    return true;
-  } catch (err) {
-    console.warn(`setJson: failed for key "${key}"`, err);
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- unify `safeGet`/`safeSet` JSON handling with a `{ json: true }` option
- remove deprecated `getJson`/`setJson` and update all call sites
- update tests and documentation for new API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a23dcfae408325985658f93b4b89a8