### PR TITLE
docs: add JSDoc for option translator

### DIFF
--- a/src/lib/optionTranslator.ts
+++ b/src/lib/optionTranslator.ts
@@ -1,5 +1,13 @@
 import { TFunction } from 'i18next';
 
+/**
+ * Returns the translated label for an option.
+ *
+ * @param {string} option - The option key to translate.
+ * @param {Record<string, string>} mapping - Map of option values to translation keys.
+ * @param {TFunction} t - i18next translation function.
+ * @returns {string} Translated label or the original option if no translation key is found.
+ */
 export const getOptionLabel = (
   option: string,
   mapping: Record<string, string>,


### PR DESCRIPTION
## Summary
- document option translator helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a24dd615a08325b63d2838289e0735