### PR TITLE
docs: document formatDateTime default and output

### DIFF
--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,3 +1,9 @@
+/**
+ * Returns the provided date formatted as `YYYYMMDD-HHMMSS`.
+ *
+ * @param date - The date to format. Defaults to the current date and time.
+ * @returns The formatted date string.
+ */
 export function formatDateTime(date: Date = new Date()): string {
   const year = date.getFullYear();
   const month = (date.getMonth() + 1).toString().padStart(2, '0');


### PR DESCRIPTION
## Summary
- document formatDateTime with JSDoc explaining default date argument and output format

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a24dd37be883258c9a1d8bc8e55f8c