### PR TITLE
docs: document dark mode hook

### DIFF
--- a/src/hooks/use-dark-mode.ts
+++ b/src/hooks/use-dark-mode.ts
@@ -2,6 +2,16 @@ import { useEffect } from 'react';
 import { useLocalStorageState } from './use-local-storage-state';
 import { DARK_MODE } from '@/lib/storage-keys';
 
+/**
+ * Detects system dark-mode preference, persists the user's choice, and
+ * provides theme state management.
+ *
+ * The hook reads the operating system's preferred color scheme, saves
+ * overrides to `localStorage`, and returns the current dark-mode state
+ * alongside a setter function.
+ *
+ * @returns A tuple with the dark-mode boolean and a setter to update it.
+ */
 export function useDarkMode() {
   const prefersDark =
     typeof window !== 'undefined' && 'matchMedia' in window


### PR DESCRIPTION
## Summary
- document dark mode detection and persistence in `useDarkMode`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2532e09d88325953b4783974c9684