### PR TITLE
docs: document tracking hook

### DIFF
--- a/src/hooks/use-tracking.ts
+++ b/src/hooks/use-tracking.ts
@@ -2,6 +2,16 @@ import { DISABLE_ANALYTICS } from '@/lib/config';
 import { useLocalStorageState } from './use-local-storage-state';
 import { TRACKING_ENABLED } from '@/lib/storage-keys';
 
+/**
+ * Manage the user's analytics tracking preference.
+ *
+ * Persists the state in `localStorage` using the `TRACKING_ENABLED` key.
+ * The default value is `true` unless analytics are globally disabled via
+ * `DISABLE_ANALYTICS`, in which case it defaults to `false`.
+ *
+ * @returns A tuple `[enabled, setEnabled]` with the current tracking state
+ * and a setter to update it.
+ */
 export function useTracking() {
   return useLocalStorageState(
     TRACKING_ENABLED,


### PR DESCRIPTION
## Summary
- document tracking hook storage key and default value

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a253313e0c83259eb2b9aebd536b84