### PR TITLE
docs: document GitHub stats hook

### DIFF
--- a/src/hooks/use-github-stats.ts
+++ b/src/hooks/use-github-stats.ts
@@ -10,6 +10,18 @@ export interface GithubStats {
   issues: number;
 }
 
+/**
+ * Retrieves basic repository statistics from GitHub for display in the app.
+ *
+ * Fetches the following endpoints:
+ * - `https://api.github.com/repos/supermarsx/sora-json-prompt-crafter` for star and fork counts.
+ * - `https://api.github.com/search/issues?q=repo:supermarsx/sora-json-prompt-crafter+type:issue+state:open` for the number of open issues.
+ *
+ * Results are cached in `localStorage` for one hour using `safeGet`/`safeSet`.
+ * Subsequent calls within that period reuse the cached values to avoid extra network requests.
+ *
+ * @returns A `GithubStats` object with `stars`, `forks`, and `issues` or `undefined` while loading/if disabled.
+ */
 export function useGithubStats() {
   const { t } = useTranslation();
   const [stats, setStats] = useState<GithubStats>();


### PR DESCRIPTION
## Summary
- document GitHub stats hook with endpoints, caching, and returned data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a253348f588325b64cd9f00af24101