### PR TITLE
docs: document clipboard hook

### DIFF
--- a/src/hooks/use-clipboard.ts
+++ b/src/hooks/use-clipboard.ts
@@ -1,9 +1,24 @@
 import { toast } from '@/components/ui/sonner-toast';
 import { useTranslation } from 'react-i18next';
 
+/**
+ * Custom hook that exposes clipboard copy functionality with toast feedback.
+ *
+ * @returns An object containing a `copy` function for writing text to the clipboard.
+ */
 export function useClipboard() {
   const { t } = useTranslation();
 
+  /**
+   * Writes text to the clipboard and displays success or error toasts.
+   *
+   * @param text - The text to copy to the clipboard.
+   * @param success - Optional success message shown if the copy succeeds.
+   * @returns A promise resolving to `true` on success and `false` on failure.
+   *
+   * Shows a success toast with the provided message, an error toast if the
+   * Clipboard API is unavailable, and another error toast if copying fails.
+   */
   const copy = async (text: string, success?: string) => {
     if (
       !('clipboard' in navigator) ||


### PR DESCRIPTION
## Summary
- add JSDoc for `useClipboard` hook
- document copy function arguments and toast behavior

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2532ff4288325b12f6a678077ea01