### PR TITLE
docs: document responsive hooks

### DIFF
--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
 import { MOBILE_BREAKPOINT } from '@/lib/breakpoints';
 
+/**
+ * Determines if the viewport should be treated as mobile.
+ *
+ * A mobile viewport is defined as one with a width below
+ * `MOBILE_BREAKPOINT` (768px).
+ *
+ * @returns {boolean} `true` if the viewport width is less than
+ * `MOBILE_BREAKPOINT`, otherwise `false`.
+ */
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState(false);
 

--- a/src/hooks/use-single-column.tsx
+++ b/src/hooks/use-single-column.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
 import { SINGLE_COLUMN_BREAKPOINT } from '@/lib/breakpoints';
 
+/**
+ * Tracks whether the viewport width is below the single-column breakpoint.
+ *
+ * The single-column layout is activated when the viewport is narrower than
+ * `SINGLE_COLUMN_BREAKPOINT` (1024px).
+ *
+ * @returns {boolean} `true` if the viewport width is less than
+ * `SINGLE_COLUMN_BREAKPOINT`, otherwise `false`.
+ */
 export function useIsSingleColumn() {
   const [isSingle, setIsSingle] = React.useState(false);
 


### PR DESCRIPTION
## Summary
- add JSDoc for single-column hook referencing 1024px breakpoint
- add JSDoc for mobile hook referencing 768px breakpoint

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2575a4ca88325bc049d96ba1e6108