### PR TITLE
docs: document getEnvVar environment lookup

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,5 +1,12 @@
 type Env = Record<string, string | undefined> | undefined;
 
+/**
+ * Retrieves an environment variable by key.
+ * Checks both `import.meta.env` and `process.env` to support browser and Node contexts.
+ *
+ * @param {string} key - Environment variable name.
+ * @returns {string | undefined} Value of the environment variable, if defined.
+ */
 function getEnvVar(key: string): string | undefined {
   const metaEnv = (globalThis as { import?: { meta?: { env?: Env } } }).import
     ?.meta?.env as Env;


### PR DESCRIPTION
## Summary
- add JSDoc to describe getEnvVar and its browser/Node environment sources

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2604867008325a736218bc77d06d5