### PR TITLE
docs: add JSDoc for badge component

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -8,6 +8,12 @@ export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
+/**
+ * Styled `<div>` wrapper for displaying badge content.
+ *
+ * @param variant - Visual style variant defined in `badgeVariants`.
+ * @param className - Additional classes to apply to the badge.
+ */
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (
     <div className={cn(badgeVariants({ variant }), className)} {...props} />


### PR DESCRIPTION
## Summary
- document Badge as styled div wrapper
- explain variant and className props

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a260501dd4832582ade26f800e5ed2