### PR TITLE
docs: add Toaster JSDoc

### DIFF
--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -8,6 +8,13 @@ import {
   ToastViewport,
 } from '@/components/ui/toast';
 
+/**
+ * Renders all queued toast notifications.
+ *
+ * Uses the `useToast` hook to retrieve pending toasts, wraps them in a
+ * `ToastProvider` for context, and includes a `ToastViewport` to manage
+ * their placement on the screen.
+ */
 export function Toaster() {
   const { toasts } = useToast();
 


### PR DESCRIPTION
## Summary
- document how `Toaster` displays queued notifications via `useToast`, `ToastProvider`, and `ToastViewport`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a262aebbb083259fc750a1e176e8fa