### PR TITLE
refactor: centralize storage keys

### DIFF
--- a/src/__tests__/app.integration.test.tsx
+++ b/src/__tests__/app.integration.test.tsx
@@ -7,6 +7,7 @@ import {
 } from '@testing-library/react';
 import App from '../App';
 import '@/i18n';
+import { CURRENT_JSON, JSON_HISTORY } from '@/lib/storage-keys';
 
 jest.mock('../components/Footer', () => ({
   __esModule: true,
@@ -81,11 +82,11 @@ describe('App integration flow', () => {
 
     await waitFor(() => {
       expect(
-        JSON.parse(localStorage.getItem('jsonHistory') || '[]'),
+        JSON.parse(localStorage.getItem(JSON_HISTORY) || '[]'),
       ).toHaveLength(1);
     });
 
-    const current = JSON.parse(localStorage.getItem('currentJson') || '{}');
+    const current = JSON.parse(localStorage.getItem(CURRENT_JSON) || '{}');
     expect(current.prompt).toBe('Integration test prompt');
     expect(current).toHaveProperty('style_preset');
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -46,6 +46,7 @@ import { useGithubStats } from '@/hooks/use-github-stats';
 import { useClipboard } from '@/hooks/use-clipboard';
 import { useTranslation } from 'react-i18next';
 import { useLocale } from '@/hooks/use-locale';
+import { CURRENT_JSON, JSON_HISTORY } from '@/lib/storage-keys';
 
 const Dashboard = () => {
   const { t } = useTranslation();
@@ -54,7 +55,7 @@ const Dashboard = () => {
     try {
       const fromUrl = getOptionsFromUrl();
       if (fromUrl) return fromUrl;
-      const stored = safeGet('currentJson');
+      const stored = safeGet(CURRENT_JSON);
       if (stored) {
         const parsed = loadOptionsFromJson(stored);
         if (parsed) return parsed;
@@ -88,7 +89,7 @@ const Dashboard = () => {
   const [showDisclaimer, setShowDisclaimer] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [history, setHistory] = useState<HistoryEntry[]>(() =>
-    safeGet<HistoryEntry[]>('jsonHistory', [], true),
+    safeGet<HistoryEntry[]>(JSON_HISTORY, [], true),
   );
   const isSingleColumn = useIsSingleColumn();
   const [darkMode, setDarkMode] = useDarkMode();
@@ -119,24 +120,24 @@ const Dashboard = () => {
   }, [trackingEnabled]);
 
   useEffect(() => {
-    safeSet('jsonHistory', history, true);
+    safeSet(JSON_HISTORY, history, true);
   }, [history]);
 
   useEffect(() => {
-    safeSet('currentJson', jsonString);
+    safeSet(CURRENT_JSON, jsonString);
   }, [jsonString, trackingEnabled]);
 
   const firstLoadRef = React.useRef(true);
   useEffect(() => {
     if (firstLoadRef.current) {
       firstLoadRef.current = false;
-      const stored = safeGet('currentJson');
+      const stored = safeGet(CURRENT_JSON);
       if (stored) return;
     }
     try {
       const json = generateJson(options);
       setJsonString(json);
-      safeSet('currentJson', json);
+      safeSet(CURRENT_JSON, json);
     } catch (error) {
       console.error('Error generating JSON:', error);
       setJsonString('{}');

--- a/src/components/__tests__/Dashboard.stats-cache.test.tsx
+++ b/src/components/__tests__/Dashboard.stats-cache.test.tsx
@@ -1,5 +1,6 @@
 import { render, waitFor } from '@testing-library/react';
 import Dashboard from '../Dashboard';
+import { GITHUB_STATS, GITHUB_STATS_TIMESTAMP } from '@/lib/storage-keys';
 
 jest.mock('../HistoryPanel', () => ({ __esModule: true, default: () => null }));
 jest.mock('../ControlPanel', () => ({
@@ -60,10 +61,10 @@ afterEach(() => {
 
 test('uses cached stats when fresh', async () => {
   localStorage.setItem(
-    'githubStats',
+    GITHUB_STATS,
     JSON.stringify({ stars: 1, forks: 2, issues: 3 }),
   );
-  localStorage.setItem('githubStatsTimestamp', JSON.stringify(Date.now()));
+  localStorage.setItem(GITHUB_STATS_TIMESTAMP, JSON.stringify(Date.now()));
   const mockFetch = jest.fn();
   global.fetch = mockFetch as unknown as typeof fetch;
   const { findByText } = render(<Dashboard />);
@@ -75,11 +76,11 @@ test('uses cached stats when fresh', async () => {
 
 test('fetches stats when cache expired', async () => {
   localStorage.setItem(
-    'githubStats',
+    GITHUB_STATS,
     JSON.stringify({ stars: 1, forks: 2, issues: 3 }),
   );
   localStorage.setItem(
-    'githubStatsTimestamp',
+    GITHUB_STATS_TIMESTAMP,
     JSON.stringify(Date.now() - 7200000),
   );
   global.fetch = jest
@@ -97,7 +98,7 @@ test('fetches stats when cache expired', async () => {
   expect(await findByText('Fork 5')).toBeTruthy();
   expect(await findByText('Issues 6')).toBeTruthy();
   await waitFor(() => {
-    const cached = JSON.parse(localStorage.getItem('githubStats') || '{}');
+    const cached = JSON.parse(localStorage.getItem(GITHUB_STATS) || '{}');
     expect(cached).toEqual({ stars: 4, forks: 5, issues: 6 });
   });
 });

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -12,6 +12,7 @@ import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
 import type { SoraOptions } from '@/lib/soraOptions';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { useSoraUserscript } from '@/hooks/use-sora-userscript';
+import { CURRENT_JSON, JSON_HISTORY } from '@/lib/storage-keys';
 
 let copyFn: ((json: string) => void) | null = null;
 let updateFn: ((opts: Partial<SoraOptions>) => void) | null = null;
@@ -277,7 +278,7 @@ describe('Dashboard interactions', () => {
     (trackEvent as jest.Mock).mockClear();
 
     await waitFor(() => {
-      const json = JSON.parse(localStorage.getItem('currentJson') || '{}');
+      const json = JSON.parse(localStorage.getItem(CURRENT_JSON) || '{}');
       expect(json.prompt).toBe('foo');
       expect(json.negative_prompt).toBe('bar');
     });
@@ -289,7 +290,7 @@ describe('Dashboard interactions', () => {
     });
 
     await waitFor(() => {
-      const history = JSON.parse(localStorage.getItem('jsonHistory') || '[]');
+      const history = JSON.parse(localStorage.getItem(JSON_HISTORY) || '[]');
       expect(history).toHaveLength(1);
       expect(history[0].json).toContain('foo');
     });
@@ -304,7 +305,7 @@ describe('Dashboard interactions', () => {
     });
 
     await waitFor(() => {
-      const json = JSON.parse(localStorage.getItem('currentJson') || '{}');
+      const json = JSON.parse(localStorage.getItem(CURRENT_JSON) || '{}');
       expect(json.prompt).toBe('foo');
     });
 
@@ -314,7 +315,7 @@ describe('Dashboard interactions', () => {
     });
 
     await waitFor(() => {
-      const json = JSON.parse(localStorage.getItem('currentJson') || '{}');
+      const json = JSON.parse(localStorage.getItem(CURRENT_JSON) || '{}');
       expect(json.prompt).toBe(DEFAULT_OPTIONS.prompt);
     });
 
@@ -324,7 +325,7 @@ describe('Dashboard interactions', () => {
     });
 
     await waitFor(() => {
-      const json = JSON.parse(localStorage.getItem('currentJson') || '{}');
+      const json = JSON.parse(localStorage.getItem(CURRENT_JSON) || '{}');
       expect(json.prompt).toBe('foo');
     });
   });

--- a/src/components/__tests__/DashboardHistory.test.tsx
+++ b/src/components/__tests__/DashboardHistory.test.tsx
@@ -11,6 +11,7 @@ import { useDarkMode } from '@/hooks/use-dark-mode';
 import { useTracking } from '@/hooks/use-tracking';
 import { useActionHistory } from '@/hooks/use-action-history';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
+import { JSON_HISTORY } from '@/lib/storage-keys';
 
 let importFn: ((jsons: string[]) => void) | null = null;
 
@@ -94,7 +95,7 @@ describe('Dashboard history limit', () => {
   });
 
   test('caps history at 100 entries', async () => {
-    localStorage.setItem('jsonHistory', JSON.stringify(createEntries(95)));
+    localStorage.setItem(JSON_HISTORY, JSON.stringify(createEntries(95)));
 
     render(<Dashboard />);
 
@@ -108,7 +109,7 @@ describe('Dashboard history limit', () => {
 
     await waitFor(() => {
       expect(
-        JSON.parse(localStorage.getItem('jsonHistory') || '[]'),
+        JSON.parse(localStorage.getItem(JSON_HISTORY) || '[]'),
       ).toHaveLength(100);
     });
 
@@ -118,7 +119,7 @@ describe('Dashboard history limit', () => {
 
     await waitFor(() => {
       expect(
-        JSON.parse(localStorage.getItem('jsonHistory') || '[]'),
+        JSON.parse(localStorage.getItem(JSON_HISTORY) || '[]'),
       ).toHaveLength(100);
     });
   });

--- a/src/components/__tests__/updateNestedOptions.test.tsx
+++ b/src/components/__tests__/updateNestedOptions.test.tsx
@@ -1,5 +1,6 @@
 import { render, act } from '@testing-library/react';
 import Dashboard from '../Dashboard';
+import { CURRENT_JSON } from '@/lib/storage-keys';
 
 let updater: (path: string, value: unknown) => void = () => {};
 
@@ -69,7 +70,7 @@ beforeEach(() => {
 });
 
 test('updateNestedOptions handles missing objects', async () => {
-  localStorage.setItem('currentJson', '{"style_preset":"bad"}');
+  localStorage.setItem(CURRENT_JSON, '{"style_preset":"bad"}');
   render(<Dashboard />);
   await act(async () => {
     updater('style_preset.category', 'cinematic');
@@ -80,12 +81,12 @@ test('updateNestedOptions handles missing objects', async () => {
 test('updateNestedOptions warns and skips __proto__ or constructor keys', async () => {
   const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   render(<Dashboard />);
-  const before = localStorage.getItem('currentJson');
+  const before = localStorage.getItem(CURRENT_JSON);
   await act(async () => {
     updater('__proto__.foo', 'bar');
     await Promise.resolve();
   });
-  expect(localStorage.getItem('currentJson')).toBe(before);
+  expect(localStorage.getItem(CURRENT_JSON)).toBe(before);
   expect(warnSpy).toHaveBeenCalledWith(
     'Blocked unsafe property name: __proto__',
   );
@@ -94,7 +95,7 @@ test('updateNestedOptions warns and skips __proto__ or constructor keys', async 
     updater('constructor.foo', 'bar');
     await Promise.resolve();
   });
-  expect(localStorage.getItem('currentJson')).toBe(before);
+  expect(localStorage.getItem(CURRENT_JSON)).toBe(before);
   expect(warnSpy).toHaveBeenCalledWith(
     'Blocked unsafe property name: constructor',
   );

--- a/src/hooks/__tests__/use-github-stats.test.tsx
+++ b/src/hooks/__tests__/use-github-stats.test.tsx
@@ -3,6 +3,7 @@ import { useGithubStats } from '../use-github-stats';
 import { toast } from '@/components/ui/sonner-toast';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '@/i18n';
+import { GITHUB_STATS, GITHUB_STATS_TIMESTAMP } from '@/lib/storage-keys';
 
 jest.mock('@/components/ui/sonner-toast', () => ({
   __esModule: true,
@@ -25,10 +26,10 @@ describe('useGithubStats', () => {
 
   test('uses cache when fresh', () => {
     localStorage.setItem(
-      'githubStats',
+      GITHUB_STATS,
       JSON.stringify({ stars: 1, forks: 2, issues: 3 }),
     );
-    localStorage.setItem('githubStatsTimestamp', JSON.stringify(Date.now()));
+    localStorage.setItem(GITHUB_STATS_TIMESTAMP, JSON.stringify(Date.now()));
     const fetchMock = jest.fn();
     global.fetch = fetchMock as unknown as typeof fetch;
     const { result } = renderHook(() => useGithubStats(), { wrapper });
@@ -38,7 +39,7 @@ describe('useGithubStats', () => {
 
   test('fetches stats when cache expired', async () => {
     localStorage.setItem(
-      'githubStatsTimestamp',
+      GITHUB_STATS_TIMESTAMP,
       JSON.stringify(Date.now() - 7200000),
     );
     global.fetch = jest

--- a/src/hooks/use-github-stats.ts
+++ b/src/hooks/use-github-stats.ts
@@ -3,6 +3,7 @@ import { toast } from '@/components/ui/sonner-toast';
 import { useTranslation } from 'react-i18next';
 import { DISABLE_STATS } from '@/lib/config';
 import { safeGet, safeSet } from '@/lib/storage';
+import { GITHUB_STATS, GITHUB_STATS_TIMESTAMP } from '@/lib/storage-keys';
 
 export interface GithubStats {
   stars: number;
@@ -28,8 +29,8 @@ export function useGithubStats() {
 
   useEffect(() => {
     if (DISABLE_STATS) return;
-    const cached = safeGet<GithubStats>('githubStats', null, true);
-    const cachedTs = safeGet<number>('githubStatsTimestamp', 0, true);
+    const cached = safeGet<GithubStats>(GITHUB_STATS, null, true);
+    const cachedTs = safeGet<number>(GITHUB_STATS_TIMESTAMP, 0, true);
     if (
       cached &&
       typeof cachedTs === 'number' &&
@@ -63,8 +64,8 @@ export function useGithubStats() {
             issues: issuesData.total_count,
           };
           setStats(data);
-          safeSet('githubStats', data, true);
-          safeSet('githubStatsTimestamp', Date.now(), true);
+          safeSet(GITHUB_STATS, data, true);
+          safeSet(GITHUB_STATS_TIMESTAMP, Date.now(), true);
         }
       } catch (err) {
         if ((err as Error).name !== 'AbortError') {

--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -6,7 +6,12 @@ import {
   LOGO_ENABLED,
   ACTION_LABELS_ENABLED,
   TRACKING_ENABLED,
+  TRACKING_HISTORY,
   LOCALE,
+  CURRENT_JSON,
+  JSON_HISTORY,
+  GITHUB_STATS,
+  GITHUB_STATS_TIMESTAMP,
 } from '../storage-keys';
 
 describe('constants', () => {
@@ -22,6 +27,11 @@ describe('constants', () => {
     expect(LOGO_ENABLED).toBe('logoEnabled');
     expect(ACTION_LABELS_ENABLED).toBe('actionLabelsEnabled');
     expect(TRACKING_ENABLED).toBe('trackingEnabled');
+    expect(TRACKING_HISTORY).toBe('trackingHistory');
     expect(LOCALE).toBe('locale');
+    expect(CURRENT_JSON).toBe('currentJson');
+    expect(JSON_HISTORY).toBe('jsonHistory');
+    expect(GITHUB_STATS).toBe('githubStats');
+    expect(GITHUB_STATS_TIMESTAMP).toBe('githubStatsTimestamp');
   });
 });

--- a/src/lib/__tests__/purgeCache.test.ts
+++ b/src/lib/__tests__/purgeCache.test.ts
@@ -1,4 +1,11 @@
 import { purgeCache } from '../purgeCache';
+import {
+  CURRENT_JSON,
+  JSON_HISTORY,
+  GITHUB_STATS,
+  GITHUB_STATS_TIMESTAMP,
+  TRACKING_HISTORY,
+} from '../storage-keys';
 
 describe('purgeCache', () => {
   beforeEach(() => {
@@ -18,11 +25,11 @@ describe('purgeCache', () => {
         ]),
       ),
     };
-    localStorage.setItem('currentJson', 'v');
-    localStorage.setItem('jsonHistory', 'v');
-    localStorage.setItem('githubStats', 'v');
-    localStorage.setItem('githubStatsTimestamp', 'v');
-    localStorage.setItem('trackingHistory', 'v');
+    localStorage.setItem(CURRENT_JSON, 'v');
+    localStorage.setItem(JSON_HISTORY, 'v');
+    localStorage.setItem(GITHUB_STATS, 'v');
+    localStorage.setItem(GITHUB_STATS_TIMESTAMP, 'v');
+    localStorage.setItem(TRACKING_HISTORY, 'v');
   });
 
   afterEach(() => {
@@ -34,7 +41,7 @@ describe('purgeCache', () => {
     await purgeCache();
     expect(caches.keys).toHaveBeenCalled();
     expect(caches.delete).toHaveBeenCalledTimes(2);
-    expect(localStorage.getItem('currentJson')).toBeNull();
+    expect(localStorage.getItem(CURRENT_JSON)).toBeNull();
     expect(navigator.serviceWorker.getRegistrations).toHaveBeenCalled();
     expect(caches.delete).toHaveBeenCalledTimes(2);
   });

--- a/src/lib/purgeCache.ts
+++ b/src/lib/purgeCache.ts
@@ -1,3 +1,11 @@
+import {
+  CURRENT_JSON,
+  JSON_HISTORY,
+  GITHUB_STATS,
+  GITHUB_STATS_TIMESTAMP,
+  TRACKING_HISTORY,
+} from './storage-keys';
+
 /**
  * Purges client-side caches and storage, unregisters service workers, and reloads the page.
  *
@@ -16,11 +24,11 @@ export async function purgeCache(): Promise<void> {
   }
 
   const lsKeys = [
-    'currentJson',
-    'jsonHistory',
-    'githubStats',
-    'githubStatsTimestamp',
-    'trackingHistory',
+    CURRENT_JSON,
+    JSON_HISTORY,
+    GITHUB_STATS,
+    GITHUB_STATS_TIMESTAMP,
+    TRACKING_HISTORY,
   ];
 
   for (const key of lsKeys) {

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -6,3 +6,7 @@ export const ACTION_LABELS_ENABLED = 'actionLabelsEnabled';
 export const TRACKING_ENABLED = 'trackingEnabled';
 export const TRACKING_HISTORY = 'trackingHistory';
 export const LOCALE = 'locale';
+export const CURRENT_JSON = 'currentJson';
+export const JSON_HISTORY = 'jsonHistory';
+export const GITHUB_STATS = 'githubStats';
+export const GITHUB_STATS_TIMESTAMP = 'githubStatsTimestamp';


### PR DESCRIPTION
## Summary
- add constants for frequently used storage keys
- use these constants in purgeCache, dashboard, and github stats logic
- update tests to reference shared storage keys

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a26308eb988325a88b4de610df7f63