### PR TITLE
docs: clarify ControlPanel responsibilities

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -21,6 +21,18 @@ interface ControlPanelProps {
   trackingEnabled: boolean;
 }
 
+/**
+ * Renders the collection of sections that let users craft a Sora prompt.
+ *
+ * The panel consumes the current {@link SoraOptions} state and exposes
+ * callbacks for propagating changes:
+ *
+ * - `updateOptions` applies shallow updates to top-level options.
+ * - `updateNestedOptions` targets nested paths within `SoraOptions`.
+ *
+ * Tracking can be toggled via `trackingEnabled` to record interaction
+ * analytics in supported sections.
+ */
 export const ControlPanel: React.FC<ControlPanelProps> = ({
   options,
   updateOptions,


### PR DESCRIPTION
## Summary
- document ControlPanel's purpose and its SoraOptions update callbacks

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a26be3977483259a5a2859330c1344