### PR TITLE
docs: add JSDoc comments for ToggleField

### DIFF
--- a/src/components/ToggleField.tsx
+++ b/src/components/ToggleField.tsx
@@ -10,6 +10,14 @@ interface ToggleFieldProps {
   children: React.ReactNode;
 }
 
+/**
+ * Recursively clone the provided React node tree, applying a `disabled` prop to each element.
+ * This ensures that all nested interactive components reflect the disabled state consistently.
+ *
+ * @param children - The React children to clone.
+ * @param disabled - Whether the cloned elements should be disabled.
+ * @returns A new React node tree with `disabled` applied to every element.
+ */
 const cloneChildrenWithDisabled = (
   children: React.ReactNode,
   disabled: boolean,
@@ -29,6 +37,14 @@ const cloneChildrenWithDisabled = (
   });
 };
 
+/**
+ * Render a checkbox that toggles the disabled state of its child elements.
+ * When the checkbox is unchecked, all nested fields become disabled, preventing user interaction.
+ *
+ * @param props - {@link ToggleFieldProps} containing the checkbox `id`, display `label`,
+ * `checked` state, change handler, and child elements to be conditionally disabled.
+ * @returns JSX fragment with a toggleable checkbox and its associated children.
+ */
 export const ToggleField: React.FC<ToggleFieldProps> = ({
   id,
   label,


### PR DESCRIPTION
## Summary
- document recursive children cloning logic in ToggleField
- describe ToggleField purpose and props with JSDoc

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a26be150688325a76c77b7b479e170