### PR TITLE
feat: add data export/import utilities

### DIFF
--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -120,7 +120,7 @@ afterEach(() => {
 describe('HistoryPanel basic actions', () => {
   test('exports to clipboard and file', async () => {
     renderPanel();
-    const exportBtn = screen.getByRole('button', { name: /export/i });
+    const exportBtn = screen.getByRole('button', { name: /^export$/i });
     fireEvent.mouseDown(exportBtn);
     fireEvent.click(exportBtn);
     fireEvent.click(screen.getByText(/copy all to clipboard/i));
@@ -145,7 +145,7 @@ describe('HistoryPanel basic actions', () => {
     renderPanel();
     (trackEvent as jest.Mock).mockClear();
 
-    const exportBtn = screen.getByRole('button', { name: /export/i });
+    const exportBtn = screen.getByRole('button', { name: /^export$/i });
     fireEvent.mouseDown(exportBtn);
     fireEvent.click(exportBtn);
     fireEvent.click(screen.getByText(/copy all to clipboard/i));
@@ -176,7 +176,7 @@ describe('HistoryPanel basic actions', () => {
     renderPanel({ onOpenChange });
     (trackEvent as jest.Mock).mockClear();
 
-    const exportBtn = screen.getByRole('button', { name: /export/i });
+    const exportBtn = screen.getByRole('button', { name: /^export$/i });
     fireEvent.mouseDown(exportBtn);
     fireEvent.click(exportBtn);
     fireEvent.click(screen.getByText(/copy all to clipboard/i));

--- a/src/lib/__tests__/storage-backup.test.ts
+++ b/src/lib/__tests__/storage-backup.test.ts
@@ -1,0 +1,27 @@
+import { exportAppData, importAppData } from '../storage';
+import { CURRENT_JSON, JSON_HISTORY, DARK_MODE } from '../storage-keys';
+
+describe('exportAppData/importAppData', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('round trips application data', () => {
+    const history = [{ id: 1, date: 'today', json: '{"a":1}' }];
+    localStorage.setItem(CURRENT_JSON, 'test');
+    localStorage.setItem(JSON_HISTORY, JSON.stringify(history));
+    localStorage.setItem(DARK_MODE, JSON.stringify(true));
+
+    const exported = exportAppData();
+    expect(exported.currentJson).toBe('test');
+    expect(exported.jsonHistory).toHaveLength(1);
+    expect(exported.preferences[DARK_MODE]).toBe(true);
+
+    localStorage.clear();
+    importAppData(exported);
+
+    expect(localStorage.getItem(CURRENT_JSON)).toBe('test');
+    expect(JSON.parse(localStorage.getItem(JSON_HISTORY) || '[]')).toHaveLength(1);
+    expect(JSON.parse(localStorage.getItem(DARK_MODE) || 'false')).toBe(true);
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -57,6 +57,8 @@ export enum AnalyticsEvent {
   HistoryViewPrompts = 'history_view_prompts',
   HistoryViewActions = 'history_view_actions',
   HistoryExport = 'history_export',
+  DataExport = 'data_export',
+  DataImport = 'data_import',
   HistoryImportOpen = 'history_import_open',
   HistoryExportClick = 'history_export_click',
   HistoryClearClick = 'history_clear_click',

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,3 +1,14 @@
+import {
+  ACTION_LABELS_ENABLED,
+  CURRENT_JSON,
+  DARK_MODE,
+  HEADER_BUTTONS_ENABLED,
+  JSON_HISTORY,
+  LOCALE,
+  LOGO_ENABLED,
+  SORA_TOOLS_ENABLED,
+  TRACKING_ENABLED,
+} from './storage-keys';
 /**
  * Safely retrieves a value from `localStorage`.
  *
@@ -102,5 +113,49 @@ export function setJson<T>(key: string, value: T): boolean {
   } catch (err) {
     console.warn(`setJson: failed for key "${key}"`, err);
     return false;
+  }
+}
+
+const PREFERENCE_KEYS = [
+  DARK_MODE,
+  SORA_TOOLS_ENABLED,
+  HEADER_BUTTONS_ENABLED,
+  LOGO_ENABLED,
+  ACTION_LABELS_ENABLED,
+  TRACKING_ENABLED,
+  LOCALE,
+];
+
+export interface AppData {
+  currentJson: string | null;
+  jsonHistory: unknown[];
+  preferences: Record<string, unknown>;
+}
+
+export function exportAppData(): AppData {
+  const preferences: Record<string, unknown> = {};
+  for (const key of PREFERENCE_KEYS) {
+    const value = getJson<unknown>(key);
+    if (value !== null) preferences[key] = value;
+  }
+  return {
+    currentJson: safeGet<string>(CURRENT_JSON, null) as string | null,
+    jsonHistory: getJson<unknown[]>(JSON_HISTORY, []) ?? [],
+    preferences,
+  };
+}
+
+export function importAppData(data: AppData) {
+  if (!data || typeof data !== 'object') return;
+  if (typeof data.currentJson === 'string') {
+    safeSet(CURRENT_JSON, data.currentJson);
+  }
+  if (Array.isArray(data.jsonHistory)) {
+    setJson(JSON_HISTORY, data.jsonHistory);
+  }
+  if (data.preferences && typeof data.preferences === 'object') {
+    for (const [key, value] of Object.entries(data.preferences)) {
+      setJson(key, value);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add storage helpers for exporting and restoring app data
- enable exporting/importing data from History panel with analytics events
- test data export/import round trip

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68a26dfc85c48325a53a7f8cb0a87ba2