### PR TITLE
docs: document history panel utilities

### DIFF
--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -71,9 +71,10 @@ interface HistoryPanelProps {
 }
 
 /**
- * Renders a dialog for browsing and managing stored prompt history and recent
- * user actions. Provides import/export functionality, previews, and the ability
- * to restore or remove entries.
+ * HistoryPanel renders a modal dialog that acts as the central hub for
+ * history management. It shows both previously copied JSON prompts and a log
+ * of recent user actions, offering utilities to import, export, restore or
+ * remove entries.
  *
  * @param open - Whether the history panel dialog is visible.
  * @param onOpenChange - Callback invoked when the open state changes.
@@ -84,7 +85,7 @@ interface HistoryPanelProps {
  * @param onCopy - Copies a prompt JSON string to the clipboard.
  * @param onEdit - Loads a prompt JSON into the editor for modification.
  * @param onImport - Imports prompt JSON strings from external sources.
- * @returns Modal dialog UI for managing history and actions.
+ * @returns React element representing the history-management modal dialog.
  */
 export const HistoryPanel: React.FC<HistoryPanelProps> = ({
   open,
@@ -130,6 +131,8 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
   /**
    * Copies the entire prompt history to the system clipboard.
    * Shows a toast message and records an analytics event on success.
+   *
+   * @returns A promise that resolves when the copy action finishes.
    */
   const exportClipboard = async () => {
     if (!('clipboard' in navigator)) {
@@ -150,6 +153,8 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
   /**
    * Downloads the prompt history as a JSON file using a timestamped filename.
    * Records an analytics event for the file export action.
+   *
+   * @returns void
    */
   const exportFile = () => {
     const data = JSON.stringify(history, null, 2);
@@ -171,6 +176,8 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
   /**
    * Downloads the recent action history as a JSON file.
    * The file name includes a timestamp to avoid collisions.
+   *
+   * @returns void
    */
   const exportActions = () => {
     const data = JSON.stringify(actionHistory, null, 2);
@@ -188,6 +195,8 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
 
   /**
    * Downloads all stored application data as a JSON file.
+   *
+   * @returns void
    */
   const exportDataFile = () => {
     const blob = new Blob([JSON.stringify(exportAppData(), null, 2)], {
@@ -207,6 +216,8 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
 
   /**
    * Restores application data from a JSON file selected by the user.
+   *
+   * @returns void
    */
   const importDataFile = () => {
     const input = document.createElement('input');
@@ -231,6 +242,8 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
 
   /**
    * Clears all stored action history and notifies listeners of the update.
+   *
+   * @returns void
    */
   const clearActions = () => {
     safeRemove(TRACKING_HISTORY);
@@ -240,6 +253,8 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
 
   /**
    * Opens the confirmation dialog to clear all tracked actions.
+   *
+   * @returns void
    */
   const requestClearActions = () => setConfirmClearActions(true);
 
@@ -247,6 +262,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
    * Removes a single action from storage at the specified index.
    *
    * @param idx - Index of the action to delete.
+   * @returns void
    */
   const deleteAction = (idx: number) => {
     const list = safeGet<{ date: string; action: string }[]>(
@@ -265,6 +281,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
    * is requested twice within a short timeframe, the action is deleted.
    *
    * @param idx - Index of the action to remove.
+   * @returns void
    */
   const requestDeleteAction = (idx: number) => {
     if (confirmDeleteActionIdx === idx) {


### PR DESCRIPTION
## Summary
- document `HistoryPanel` props and history management behavior
- add JSDoc for history export/import helpers and action cleanup utilities

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a36ee249388325bce757c4ea9255ae