### PR TITLE
feat: auto-detect locale on startup

### DIFF
--- a/src/__tests__/i18n.test.tsx
+++ b/src/__tests__/i18n.test.tsx
@@ -1,30 +1,83 @@
 import { render, screen } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
-import i18n, { changeLanguageAsync } from '../i18n';
 
-afterEach(async () => {
-  await changeLanguageAsync('en-US');
+describe('i18n', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'language', {
+      value: 'en-US',
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'languages', {
+      value: ['en-US'],
+      configurable: true,
+    });
+  });
+
+  test('renders spanish translation', async () => {
+    const { default: i18n, changeLanguageAsync } = await import('../i18n');
+    await changeLanguageAsync('es-ES');
+    render(
+      <I18nextProvider i18n={i18n}>
+        <span>{i18n.t('copy')}</span>
+      </I18nextProvider>,
+    );
+    expect(screen.getByText('Copiar')).toBeTruthy();
+  });
+
+  test('falls back to english when language unsupported', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { default: i18n, changeLanguageAsync } = await import('../i18n');
+    await changeLanguageAsync('xx');
+    render(
+      <I18nextProvider i18n={i18n}>
+        <span>{i18n.t('copy')}</span>
+      </I18nextProvider>,
+    );
+    expect(screen.getByText('Copy')).toBeTruthy();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test('detects language from navigator.language', async () => {
+    Object.defineProperty(navigator, 'language', {
+      value: 'es-ES',
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'languages', {
+      value: ['es-ES'],
+      configurable: true,
+    });
+    const { default: i18n } = await import('../i18n');
+    await new Promise((r) => setTimeout(r, 0));
+    render(
+      <I18nextProvider i18n={i18n}>
+        <span>{i18n.t('copy')}</span>
+      </I18nextProvider>,
+    );
+    expect(screen.getByText('Copiar')).toBeTruthy();
+  });
+
+  test('falls back to navigator.languages list', async () => {
+    Object.defineProperty(navigator, 'language', {
+      value: 'xx-YY',
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'languages', {
+      value: ['xx-YY', 'de-DE'],
+      configurable: true,
+    });
+    const { default: i18n } = await import('../i18n');
+    await new Promise((r) => setTimeout(r, 0));
+    render(
+      <I18nextProvider i18n={i18n}>
+        <span>{i18n.t('copy')}</span>
+      </I18nextProvider>,
+    );
+    expect(screen.getByText('Kopieren')).toBeTruthy();
+  });
 });
 
-test('renders spanish translation', async () => {
-  await changeLanguageAsync('es-ES');
-  render(
-    <I18nextProvider i18n={i18n}>
-      <span>{i18n.t('copy')}</span>
-    </I18nextProvider>,
-  );
-  expect(screen.getByText('Copiar')).toBeTruthy();
-});
-
-test('falls back to english when language unsupported', async () => {
-  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-  await changeLanguageAsync('xx');
-  render(
-    <I18nextProvider i18n={i18n}>
-      <span>{i18n.t('copy')}</span>
-    </I18nextProvider>,
-  );
-  expect(screen.getByText('Copy')).toBeTruthy();
-  expect(warnSpy).toHaveBeenCalled();
-  warnSpy.mockRestore();
-});

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -3,6 +3,37 @@ import { initReactI18next } from 'react-i18next';
 import { PWA_CACHE } from '@/lib/cache-name';
 declare const __BASE_URL__: string;
 
+// Supported translation files shipped with the application.
+const SUPPORTED_LOCALES = [
+  'bn-IN',
+  'da-DK',
+  'de-AT',
+  'de-DE',
+  'el-GR',
+  'en-GB',
+  'en-PR',
+  'en-US',
+  'es-AR',
+  'es-ES',
+  'es-MX',
+  'et-EE',
+  'fi-FI',
+  'fr-BE',
+  'fr-FR',
+  'it-IT',
+  'ja-JP',
+  'ko-KR',
+  'ne-NP',
+  'pt-BR',
+  'pt-PT',
+  'ro-RO',
+  'ru-RU',
+  'sv-SE',
+  'th-TH',
+  'uk-UA',
+  'zh-CN',
+];
+
 // Initialize i18next without preloaded resources.
 
 i18n.use(initReactI18next).init({
@@ -37,7 +68,31 @@ export async function changeLanguageAsync(lng: string) {
   return i18n.changeLanguage(lng);
 }
 
-// Load the default language initially.
-void changeLanguageAsync('en-US');
+function detectLocale(): string {
+  if (typeof navigator === 'undefined') {
+    return 'en-US';
+  }
+  const candidates: string[] = [];
+  if (navigator.language) {
+    candidates.push(navigator.language);
+  }
+  if (navigator.languages) {
+    candidates.push(...navigator.languages);
+  }
+  for (const lang of candidates) {
+    if (SUPPORTED_LOCALES.includes(lang)) {
+      return lang;
+    }
+    const base = lang.split('-')[0];
+    const match = SUPPORTED_LOCALES.find((l) => l.startsWith(base));
+    if (match) {
+      return match;
+    }
+  }
+  return 'en-US';
+}
+
+// Load the detected language initially.
+void changeLanguageAsync(detectLocale());
 
 export default i18n;


### PR DESCRIPTION
## Summary
- detect browser locale on i18n startup and load the first supported translation
- add tests for automatic language detection via `navigator.language` and `navigator.languages`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3bc41c034832598bba3beb4275040