### PR TITLE
test: add urlOptions edge cases

### DIFF
--- a/src/lib/__tests__/urlOptions.test.ts
+++ b/src/lib/__tests__/urlOptions.test.ts
@@ -1,5 +1,10 @@
-import { serializeOptions, deserializeOptions, getOptionsFromUrl } from '../urlOptions';
+import {
+  serializeOptions,
+  deserializeOptions,
+  getOptionsFromUrl,
+} from '../urlOptions';
 import { DEFAULT_OPTIONS } from '../defaultOptions';
+import { compressToEncodedURIComponent } from 'lz-string';
 
 describe('urlOptions', () => {
   test('round trips via serialization', () => {
@@ -15,5 +20,26 @@ describe('urlOptions', () => {
     const url = `https://example.com/#${encoded}`;
     const parsed = getOptionsFromUrl(url);
     expect(parsed).toEqual(opts);
+  });
+
+  test('returns null for invalid compressed strings', () => {
+    expect(deserializeOptions('not-valid')).toBeNull();
+    const badJson = compressToEncodedURIComponent('not json');
+    expect(deserializeOptions(badJson)).toBeNull();
+  });
+
+  test('strips prototype pollution keys', () => {
+    const maliciousJson =
+      '{"__proto__":{"polluted":"yes"},"constructor":{"evil":true},"prototype":{"bad":1},"prompt":"safe"}';
+    const encoded = compressToEncodedURIComponent(maliciousJson);
+    const decoded = deserializeOptions(encoded);
+    expect(decoded).toEqual({ prompt: 'safe' });
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  test('getOptionsFromUrl handles malformed URLs', () => {
+    expect(getOptionsFromUrl('notaurl')).toBeNull();
+    expect(getOptionsFromUrl('https://example.com/#invalid')).toBeNull();
+    expect(getOptionsFromUrl('https://example.com/?o=invalid')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- verify deserializeOptions returns null for invalid strings
- ensure prototype pollution keys are stripped
- cover malformed URL cases in getOptionsFromUrl

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3bf50fa3c8325ad3a3fdc78c3e1bc