### PR TITLE
docs: add JSDoc for Index and NotFound pages

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,10 @@ import ErrorBoundary from '@/components/ErrorBoundary';
 
 const Dashboard = lazy(() => import('@/components/Dashboard'));
 
+/**
+ * Bootstraps the application and lazy-loads the `Dashboard` component
+ * to keep the initial bundle lightweight.
+ */
 const Index = () => {
   return (
     <ErrorBoundary>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,6 +1,10 @@
 import { useLocation, Navigate } from 'react-router-dom';
 import { useEffect } from 'react';
 
+/**
+ * Logs attempts to access unknown routes and redirects users
+ * back to the application's root.
+ */
 const NotFound = () => {
   const location = useLocation();
 


### PR DESCRIPTION
## Summary
- document `Index` bootstrap component and its lazy-loaded `Dashboard`
- describe `NotFound` redirect behavior and route logging

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3c0ace35c8325b7b06f480560fee1