### PR TITLE
Revert "fix: ensure syntax highlighted JSON wraps long lines"

### DIFF
--- a/src/components/GeneratedJson.tsx
+++ b/src/components/GeneratedJson.tsx
@@ -51,19 +51,16 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
         PreTag="span"
         CodeTag="span"
         wrapLongLines
-        codeTagProps={{
-          style: {
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word',
-            overflowWrap: 'anywhere',
-          },
-        }}
         customStyle={{
           margin: 0,
           padding: 0,
           background: 'none',
           overflowX: 'hidden',
           overflowY: 'auto',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          wordWrap: 'break-word',
+          overflowWrap: 'break-word',
         }}
       >
         {value}

--- a/src/components/__tests__/GeneratedJson.test.tsx
+++ b/src/components/__tests__/GeneratedJson.test.tsx
@@ -51,11 +51,11 @@ describe('GeneratedJson', () => {
     const added = div.querySelectorAll('span.animate-highlight');
     expect(added.length).toBeGreaterThan(0);
     expect(added[0].textContent).toBe(',"b":2');
-    const token = div.querySelector('pre span span span');
+    const token = div.querySelector('pre span span');
     expect(token).toBeTruthy();
     const style = token?.getAttribute('style') || '';
     expect(style).toBeTruthy();
-    expect(style).toContain('word-break: break-word');
+    expect(style).toContain('word-wrap: break-word');
 
     act(() => {
       jest.advanceTimersByTime(2000);


### PR DESCRIPTION
Reverts supermarsx/sora-json-prompt-crafter#512