### PR TITLE
fix: enable wrapping in code highlighter

### DIFF
--- a/src/components/GeneratedJson.tsx
+++ b/src/components/GeneratedJson.tsx
@@ -58,9 +58,8 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
           overflowX: 'hidden',
           overflowY: 'auto',
           whiteSpace: 'pre-wrap',
-          wordBreak: 'break-word',
-          wordWrap: 'break-word',
-          overflowWrap: 'break-word',
+          wordBreak: 'break-all',
+          overflowWrap: 'anywhere',
         }}
       >
         {value}
@@ -73,7 +72,7 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
       className="h-full overflow-y-auto overflow-x-hidden"
       ref={containerRef}
     >
-      <pre className="p-6 text-sm font-mono whitespace-pre-wrap break-words leading-relaxed">
+      <pre className="p-6 text-sm font-mono whitespace-pre-wrap break-all leading-relaxed">
         {diffParts
           ? diffParts.map((part, idx) =>
               renderHighlighted(part.value, Boolean(part.added), idx),

--- a/src/components/__tests__/GeneratedJson.test.tsx
+++ b/src/components/__tests__/GeneratedJson.test.tsx
@@ -55,7 +55,8 @@ describe('GeneratedJson', () => {
     expect(token).toBeTruthy();
     const style = token?.getAttribute('style') || '';
     expect(style).toBeTruthy();
-    expect(style).toContain('word-wrap: break-word');
+    expect(style).toContain('word-break: break-all');
+    expect(style).toContain('overflow-wrap: anywhere');
 
     act(() => {
       jest.advanceTimersByTime(2000);


### PR DESCRIPTION
## Summary
- ensure JSON syntax highlighting wraps long tokens
- update tests for new wrapping style

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a59ceaec2c8325bb3cc717ec3b6f11