### PR TITLE
fix: wrap long lines in JSON highlighter

### DIFF
--- a/src/components/GeneratedJson.tsx
+++ b/src/components/GeneratedJson.tsx
@@ -51,15 +51,19 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
         PreTag="span"
         CodeTag="span"
         wrapLongLines
+        codeTagProps={{
+          style: {
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            overflowWrap: 'anywhere',
+          },
+        }}
         customStyle={{
           margin: 0,
           padding: 0,
           background: 'none',
           overflowX: 'hidden',
           overflowY: 'auto',
-          whiteSpace: 'pre-wrap',
-          wordBreak: 'break-all',
-          overflowWrap: 'anywhere',
         }}
       >
         {value}
@@ -72,7 +76,7 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
       className="h-full overflow-y-auto overflow-x-hidden"
       ref={containerRef}
     >
-      <pre className="p-6 text-sm font-mono whitespace-pre-wrap break-all leading-relaxed">
+      <pre className="p-6 text-sm font-mono whitespace-pre-wrap break-words leading-relaxed">
         {diffParts
           ? diffParts.map((part, idx) =>
               renderHighlighted(part.value, Boolean(part.added), idx),

--- a/src/components/__tests__/GeneratedJson.test.tsx
+++ b/src/components/__tests__/GeneratedJson.test.tsx
@@ -51,11 +51,11 @@ describe('GeneratedJson', () => {
     const added = div.querySelectorAll('span.animate-highlight');
     expect(added.length).toBeGreaterThan(0);
     expect(added[0].textContent).toBe(',"b":2');
-    const token = div.querySelector('pre span span');
+    const token = div.querySelector('pre span span span');
     expect(token).toBeTruthy();
     const style = token?.getAttribute('style') || '';
     expect(style).toBeTruthy();
-    expect(style).toContain('word-break: break-all');
+    expect(style).toContain('word-break: break-word');
     expect(style).toContain('overflow-wrap: anywhere');
 
     act(() => {


### PR DESCRIPTION
## Summary
- ensure JSON diff highlighting wraps long lines
- adjust test to match updated word wrapping

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7092c42cc8325801ec76470d6e61c