### PR TITLE
docs: add JSDoc to section components

### DIFF
--- a/src/components/sections/CameraCompositionSection.tsx
+++ b/src/components/sections/CameraCompositionSection.tsx
@@ -35,10 +35,24 @@ interface CameraCompositionSectionProps {
   onToggle: (enabled: boolean) => void;
 }
 
+/**
+ * Section for configuring camera positioning and composition rules.
+ *
+ * @param props - Component props.
+ * @param props.options - Current Sora options object.
+ * @param props.updateOptions - Callback to update the options state.
+ * @param props.isEnabled - Whether this section is active.
+ * @param props.onToggle - Handler invoked when the section is toggled.
+ */
 export const CameraCompositionSection: React.FC<
   CameraCompositionSectionProps
 > = ({ options, updateOptions, isEnabled, onToggle }) => {
   const { t } = useTranslation();
+  /**
+   * Updates the set of composition rules selected by the user.
+   *
+   * @param selectedRules - The chosen composition rule identifiers.
+   */
   const handleCompositionRulesChange = (selectedRules: string[]) => {
     updateOptions({ composition_rules: selectedRules });
   };

--- a/src/components/sections/ColorGradingSection.tsx
+++ b/src/components/sections/ColorGradingSection.tsx
@@ -11,6 +11,13 @@ interface ColorGradingSectionProps {
   updateOptions: (updates: Partial<SoraOptions>) => void;
 }
 
+/**
+ * Section for selecting overall color grading presets.
+ *
+ * @param props - Component props.
+ * @param props.options - Current Sora options.
+ * @param props.updateOptions - Callback to update the options state.
+ */
 export const ColorGradingSection: React.FC<ColorGradingSectionProps> = ({
   options,
   updateOptions,

--- a/src/components/sections/CoreSettingsSection.tsx
+++ b/src/components/sections/CoreSettingsSection.tsx
@@ -39,6 +39,16 @@ const qualityOptions = [
   'defective',
 ];
 
+/**
+ * Section for adjusting fundamental generation parameters such as seed,
+ * quality, and guidance settings.
+ *
+ * @param props - Component props.
+ * @param props.options - Current Sora options.
+ * @param props.updateOptions - Function to update the options state.
+ * @param props.isEnabled - Whether this section is active.
+ * @param props.onToggle - Handler to enable or disable the section.
+ */
 export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
   options,
   updateOptions,

--- a/src/components/sections/DimensionsFormatSection.tsx
+++ b/src/components/sections/DimensionsFormatSection.tsx
@@ -20,6 +20,15 @@ interface DimensionsFormatSectionProps {
   onToggle: (enabled: boolean) => void;
 }
 
+/**
+ * Section for choosing output dimensions and file format settings.
+ *
+ * @param props - Component props.
+ * @param props.options - Current Sora options.
+ * @param props.updateOptions - Function to update the options state.
+ * @param props.isEnabled - Whether the section is enabled.
+ * @param props.onToggle - Toggle handler to enable or disable the section.
+ */
 export const DimensionsFormatSection: React.FC<
   DimensionsFormatSectionProps
 > = ({ options, updateOptions, isEnabled, onToggle }) => {

--- a/src/components/sections/DnDSection.tsx
+++ b/src/components/sections/DnDSection.tsx
@@ -23,6 +23,16 @@ interface DnDSectionProps {
   onToggle: (enabled: boolean) => void;
 }
 
+/**
+ * Section for configuring Dungeons & Dragons themed options such as race,
+ * class, and environment.
+ *
+ * @param props - Component props.
+ * @param props.options - Current Sora options.
+ * @param props.updateOptions - Callback to update the options state.
+ * @param props.isEnabled - Whether the section is enabled.
+ * @param props.onToggle - Handler for enabling or disabling the section.
+ */
 export const DnDSection: React.FC<DnDSectionProps> = ({
   options,
   updateOptions,

--- a/src/components/sections/EnhancementsSection.tsx
+++ b/src/components/sections/EnhancementsSection.tsx
@@ -19,6 +19,15 @@ interface EnhancementsSectionProps {
   onToggle: (enabled: boolean) => void;
 }
 
+/**
+ * Section for optional output enhancements and safety filters.
+ *
+ * @param props - Component props.
+ * @param props.options - Current Sora options.
+ * @param props.updateOptions - Function to update the options state.
+ * @param props.isEnabled - Whether the section is active.
+ * @param props.onToggle - Handler to enable or disable the section.
+ */
 export const EnhancementsSection: React.FC<EnhancementsSectionProps> = ({
   options,
   updateOptions,
@@ -26,6 +35,11 @@ export const EnhancementsSection: React.FC<EnhancementsSectionProps> = ({
   onToggle,
 }) => {
   const { t } = useTranslation();
+  /**
+   * Maps the dropdown value to a valid safety filter option.
+   *
+   * @param value - Selected safety filter option text.
+   */
   const handleSafetyFilterChange = (value: string) => {
     // Map string values to the expected type
     let safetyFilter: SoraOptions['safety_filter'];

--- a/src/components/sections/FaceSection.tsx
+++ b/src/components/sections/FaceSection.tsx
@@ -19,6 +19,13 @@ interface FaceSectionProps {
   updateOptions: (updates: Partial<SoraOptions>) => void;
 }
 
+/**
+ * Section for managing facial features, gender, makeup, and mood.
+ *
+ * @param props - Component props.
+ * @param props.options - Current Sora options.
+ * @param props.updateOptions - Function to update the options state.
+ */
 export const FaceSection: React.FC<FaceSectionProps> = ({
   options,
   updateOptions,

--- a/src/components/sections/LightingSection.tsx
+++ b/src/components/sections/LightingSection.tsx
@@ -11,6 +11,13 @@ interface LightingSectionProps {
   updateOptions: (updates: Partial<SoraOptions>) => void;
 }
 
+/**
+ * Section for selecting lighting presets to influence scene illumination.
+ *
+ * @param props - Component props.
+ * @param props.options - Current Sora options.
+ * @param props.updateOptions - Callback to update the options state.
+ */
 export const LightingSection: React.FC<LightingSectionProps> = ({
   options,
   updateOptions,

--- a/src/components/sections/MaterialSection.tsx
+++ b/src/components/sections/MaterialSection.tsx
@@ -12,6 +12,13 @@ interface MaterialSectionProps {
   updateOptions: (updates: Partial<SoraOptions>) => void;
 }
 
+/**
+ * Section for specifying primary and secondary materials for objects.
+ *
+ * @param props - Component props.
+ * @param props.options - Current Sora options.
+ * @param props.updateOptions - Callback to update the options state.
+ */
 export const MaterialSection: React.FC<MaterialSectionProps> = ({
   options,
   updateOptions,

--- a/src/components/sections/PromptSection.tsx
+++ b/src/components/sections/PromptSection.tsx
@@ -13,6 +13,14 @@ interface PromptSectionProps {
   trackingEnabled: boolean;
 }
 
+/**
+ * Section for entering the main prompt and optional negative prompt text.
+ *
+ * @param props - Component props.
+ * @param props.options - Current Sora options.
+ * @param props.updateOptions - Function to update option values.
+ * @param props.trackingEnabled - Whether analytics tracking is enabled.
+ */
 export const PromptSection: React.FC<PromptSectionProps> = ({
   options,
   updateOptions,

--- a/src/components/sections/SettingsLocationSection.tsx
+++ b/src/components/sections/SettingsLocationSection.tsx
@@ -18,6 +18,13 @@ interface SettingsLocationSectionProps {
   updateOptions: (updates: Partial<SoraOptions>) => void;
 }
 
+/**
+ * Section for configuring environmental and location-based settings.
+ *
+ * @param props - Component props.
+ * @param props.options - Current Sora options.
+ * @param props.updateOptions - Function to update the options state.
+ */
 export const SettingsLocationSection: React.FC<
   SettingsLocationSectionProps
 > = ({ options, updateOptions }) => {

--- a/src/components/sections/StyleSection.tsx
+++ b/src/components/sections/StyleSection.tsx
@@ -19,12 +19,26 @@ interface StyleSectionProps {
   updateOptions: (updates: Partial<SoraOptions>) => void;
 }
 
+/**
+ * Section for selecting and enabling preset artistic styles.
+ *
+ * @param props - Component props.
+ * @param props.options - Current Sora options.
+ * @param props.updateNestedOptions - Setter for nested style preset fields.
+ * @param props.updateOptions - Updates top-level option flags.
+ */
 export const StyleSection: React.FC<StyleSectionProps> = ({
   options,
   updateNestedOptions,
   updateOptions,
 }) => {
   const { t } = useTranslation();
+  /**
+   * Converts a style value into a human-readable label.
+   *
+   * @param value - Raw style preset value.
+   * @returns Capitalized label for display.
+   */
   const formatLabel = (value: string) => {
     return value
       .split(' ')

--- a/src/components/sections/VideoMotionSection.tsx
+++ b/src/components/sections/VideoMotionSection.tsx
@@ -22,6 +22,16 @@ interface VideoMotionSectionProps {
   onToggle: (enabled: boolean) => void;
 }
 
+/**
+ * Section for configuring video-specific motion settings such as duration,
+ * frame rate, and camera movement.
+ *
+ * @param props - Component props.
+ * @param props.options - Current Sora options.
+ * @param props.updateOptions - Updates the options state.
+ * @param props.isEnabled - Whether the section is enabled.
+ * @param props.onToggle - Toggle handler for enabling or disabling the section.
+ */
 export const VideoMotionSection: React.FC<VideoMotionSectionProps> = ({
   options,
   updateOptions,


### PR DESCRIPTION
## Summary
- document camera/composition settings props and handler
- add JSDoc to all section components
- cover specialized handlers like safety filter mapping

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7365223d4832588df5f0ab302e383