### PR TITLE
feat: add purge cache confirmation

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -97,6 +97,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   onToggleActionLabels,
 }) => {
   const { t } = useTranslation();
+  const [confirmPurgeCache, setConfirmPurgeCache] = useState(false);
   const [confirmDisableTracking, setConfirmDisableTracking] = useState(false);
   const [confirmEnableTracking, setConfirmEnableTracking] = useState(false);
   const { checkForUpdate } = useUpdateCheck();
@@ -319,8 +320,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 variant="outline"
                 className="w-full justify-start gap-2"
                 onClick={() => {
-                  purgeCache();
-                  trackEvent(trackingEnabled, AnalyticsEvent.PurgeCache);
+                  setConfirmPurgeCache(true);
                 }}
                 title={t('purgeCache')}
               >
@@ -330,6 +330,29 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
           </ScrollArea>
         </DialogContent>
       </Dialog>
+
+      <AlertDialog
+        open={confirmPurgeCache}
+        onOpenChange={setConfirmPurgeCache}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('purgeCacheTitle')}</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                purgeCache();
+                trackEvent(trackingEnabled, AnalyticsEvent.PurgeCache);
+                setConfirmPurgeCache(false);
+              }}
+            >
+              {t('purgeCacheConfirm')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <AlertDialog
         open={confirmDisableTracking}

--- a/src/components/__tests__/SettingsPanel.test.tsx
+++ b/src/components/__tests__/SettingsPanel.test.tsx
@@ -63,6 +63,10 @@ jest.mock('@/components/ui/alert-dialog', () => ({
   AlertDialogCancel: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
 }));
 
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 function renderPanel(overrides: Partial<React.ComponentProps<typeof SettingsPanel>> = {}) {
   const props = {
     open: true,
@@ -87,11 +91,15 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof SettingsPane
 }
 
 describe('SettingsPanel', () => {
-  test('purge cache button triggers utility', () => {
+  test('purge cache requires confirmation', () => {
     renderPanel();
     const purgeBtn = screen.getByRole('button', { name: /purge cache/i });
     expect(purgeBtn.getAttribute('title')).toBe(i18n.t('purgeCache'));
     fireEvent.click(purgeBtn);
+    const confirmBtn = screen.getByRole('button', {
+      name: i18n.t('purgeCacheConfirm'),
+    });
+    fireEvent.click(confirmBtn);
     expect(purgeCache).toHaveBeenCalled();
     expect(trackEvent).toHaveBeenCalledWith(
       true,

--- a/src/locales/bn-IN.json
+++ b/src/locales/bn-IN.json
@@ -14,6 +14,8 @@
   "regenerate": "পুনরায় তৈরি করুন",
   "randomize": "এলোমেলো করুন",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "আনডু",
   "redo": "রিডু",
   "enableTracking": "ট্র্যাকিং সক্রিয় করুন",

--- a/src/locales/da-DK.json
+++ b/src/locales/da-DK.json
@@ -14,6 +14,8 @@
   "regenerate": "Generer igen",
   "randomize": "Tilfældiggør",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Fortryd",
   "redo": "Gentag",
   "enableTracking": "Aktivér sporing",

--- a/src/locales/de-AT.json
+++ b/src/locales/de-AT.json
@@ -14,6 +14,8 @@
   "regenerate": "Neu generieren",
   "randomize": "Zufällig",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Rückgängig",
   "redo": "Wiederholen",
   "enableTracking": "Tracking aktivieren",

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -14,6 +14,8 @@
   "regenerate": "Neu generieren",
   "randomize": "Zufällig",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Rückgängig",
   "redo": "Wiederholen",
   "enableTracking": "Tracking aktivieren",

--- a/src/locales/el-GR.json
+++ b/src/locales/el-GR.json
@@ -14,6 +14,8 @@
   "regenerate": "Επαναδημιουργία",
   "randomize": "Τυχαιοποίηση",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Αναίρεση",
   "redo": "Επανάληψη",
   "enableTracking": "Ενεργοποίηση παρακολούθησης",

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -14,6 +14,8 @@
   "regenerate": "Regenerate",
   "randomize": "Randomise",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Undo",
   "redo": "Redo",
   "enableTracking": "Enable Tracking",

--- a/src/locales/en-PR.json
+++ b/src/locales/en-PR.json
@@ -14,6 +14,8 @@
   "regenerate": "Raise Again",
   "randomize": "Yo‑ho Shuffle",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Belay That",
   "redo": "Do 'er Again",
   "enableTracking": "Set Sails fer Trackin'",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -14,6 +14,8 @@
   "regenerate": "Regenerate",
   "randomize": "Randomize",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Undo",
   "redo": "Redo",
   "enableTracking": "Enable Tracking",

--- a/src/locales/es-AR.json
+++ b/src/locales/es-AR.json
@@ -14,6 +14,8 @@
   "regenerate": "Regenerar",
   "randomize": "Aleatorizar",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Deshacer",
   "redo": "Rehacer",
   "enableTracking": "Habilitar seguimiento",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -14,6 +14,8 @@
   "regenerate": "Regenerar",
   "randomize": "Aleatorizar",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Deshacer",
   "redo": "Rehacer",
   "enableTracking": "Habilitar seguimiento",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -14,6 +14,8 @@
   "regenerate": "Regenerar",
   "randomize": "Aleatorizar",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Deshacer",
   "redo": "Rehacer",
   "enableTracking": "Habilitar seguimiento",

--- a/src/locales/et-EE.json
+++ b/src/locales/et-EE.json
@@ -14,6 +14,8 @@
   "regenerate": "Genereeri uuesti",
   "randomize": "Juhuslikusta",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Võta tagasi",
   "redo": "Tee uuesti",
   "enableTracking": "Luba jälgimine",

--- a/src/locales/fi-FI.json
+++ b/src/locales/fi-FI.json
@@ -14,6 +14,8 @@
   "regenerate": "Luo uudelleen",
   "randomize": "Satunnaista",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Kumoa",
   "redo": "Tee uudelleen",
   "enableTracking": "Ota seuranta käyttöön",

--- a/src/locales/fr-BE.json
+++ b/src/locales/fr-BE.json
@@ -14,6 +14,8 @@
   "regenerate": "Régénérer",
   "randomize": "Aléatoiriser",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Annuler",
   "redo": "Rétablir",
   "enableTracking": "Activer le suivi",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -14,6 +14,8 @@
   "regenerate": "Régénérer",
   "randomize": "Randomiser",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Annuler",
   "redo": "Rétablir",
   "enableTracking": "Activer le suivi",

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -14,6 +14,8 @@
   "regenerate": "Rigenera",
   "randomize": "Casualizza",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Annulla",
   "redo": "Ripeti",
   "enableTracking": "Abilita tracciamento",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -14,6 +14,8 @@
   "regenerate": "再生成",
   "randomize": "ランダム化",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "元に戻す",
   "redo": "やり直す",
   "enableTracking": "トラッキングを有効化",

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -14,6 +14,8 @@
   "regenerate": "재생성",
   "randomize": "무작위화",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "실행 취소",
   "redo": "다시 실행",
   "enableTracking": "추적 활성화",

--- a/src/locales/ne-NP.json
+++ b/src/locales/ne-NP.json
@@ -14,6 +14,8 @@
   "regenerate": "पुनः उत्पन्न गर्नुहोस्",
   "randomize": "अनियमित बनाउनुहोस्",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "पूर्वस्थितिमा फर्काउनुहोस्",
   "redo": "पुनः गर्नुहोस्",
   "enableTracking": "ट्र्याकिङ सक्षम गर्नुहोस्",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -14,6 +14,8 @@
   "regenerate": "Regenerar",
   "randomize": "Aleatorizar",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Desfazer",
   "redo": "Refazer",
   "enableTracking": "Ativar monitoramento",

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -14,6 +14,8 @@
   "regenerate": "Regenerar",
   "randomize": "Aleatorizar",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Anular",
   "redo": "Refazer",
   "enableTracking": "Ativar Monitorização",

--- a/src/locales/ro-RO.json
+++ b/src/locales/ro-RO.json
@@ -14,6 +14,8 @@
   "regenerate": "Regenerare",
   "randomize": "Randomizează",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Anulează",
   "redo": "Refă",
   "enableTracking": "Activează urmărire",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -14,6 +14,8 @@
   "regenerate": "Сгенерировать заново",
   "randomize": "Случайно",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Отменить",
   "redo": "Повторить",
   "enableTracking": "Включить отслеживание",

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -14,6 +14,8 @@
   "regenerate": "Regenerera",
   "randomize": "Slumpa",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Ångra",
   "redo": "Gör om",
   "enableTracking": "Aktivera spårning",

--- a/src/locales/th-TH.json
+++ b/src/locales/th-TH.json
@@ -14,6 +14,8 @@
   "regenerate": "สร้างใหม่",
   "randomize": "สุ่ม",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "เลิกทำ",
   "redo": "ทำซ้ำ",
   "enableTracking": "เปิดการติดตาม",

--- a/src/locales/uk-UA.json
+++ b/src/locales/uk-UA.json
@@ -14,6 +14,8 @@
   "regenerate": "Згенерувати знову",
   "randomize": "Випадково",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "Скасувати",
   "redo": "Повторити",
   "enableTracking": "Увімкнути відстеження",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -14,6 +14,8 @@
   "regenerate": "重新生成",
   "randomize": "随机化",
   "purgeCache": "Purge Cache",
+  "purgeCacheTitle": "Purge cache?",
+  "purgeCacheConfirm": "Purge",
   "undo": "撤销",
   "redo": "重做",
   "enableTracking": "启用跟踪",


### PR DESCRIPTION
## Summary
- confirm before purging local cache and tracking purge
- add i18n strings for purge dialog
- cover purge confirmation in settings panel tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a74853540c832593cf09f17f868c0b