### PR TITLE
feat: show loading bar

### DIFF
--- a/src/__tests__/Loading.test.tsx
+++ b/src/__tests__/Loading.test.tsx
@@ -6,5 +6,6 @@ describe('Loading', () => {
     render(<Loading />);
     expect(screen.getByRole('status')).toBeTruthy();
     expect(await screen.findByText('Loading...')).toBeTruthy();
+    expect(screen.getByRole('progressbar')).toBeTruthy();
   });
 });

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -13,11 +13,22 @@ const Loading: React.FC = () => {
 
   return (
     <div
-      className="flex h-screen w-screen items-center justify-center transition-opacity duration-50"
+      className="flex h-screen w-screen flex-col items-center justify-center transition-opacity duration-50"
       role="status"
     >
-      <Loader2 className="h-10 w-10 animate-spin bg-gradient-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent" />
-      <span className="ml-3 text-lg font-medium">{t('loading')}</span>
+      <div className="flex items-center">
+        <Loader2 className="h-10 w-10 animate-spin bg-gradient-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent" />
+        <span className="ml-3 text-lg font-medium">{t('loading')}</span>
+      </div>
+      <div
+        className="mt-4 h-1 w-48 overflow-hidden rounded bg-muted"
+        role="progressbar"
+        aria-label="loading progress"
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div className="h-full w-1/3 animate-loading-bar bg-gradient-to-r from-purple-500 to-pink-500" />
+      </div>
     </div>
   );
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -90,6 +90,10 @@ export default {
           '0%': { backgroundColor: 'rgba(253, 224, 71, 0.4)' },
           '100%': { backgroundColor: 'transparent' },
         },
+        'loading-bar': {
+          '0%': { transform: 'translateX(-100%)' },
+          '100%': { transform: 'translateX(100%)' },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
@@ -97,6 +101,7 @@ export default {
         rainbow: 'rainbow 10s linear infinite',
         'rainbow-dark': 'rainbow-dark 10s linear infinite',
         highlight: 'highlight 2s ease-in-out',
+        'loading-bar': 'loading-bar 1s ease-in-out infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary
- show a progress bar on the loading screen with Sora's gradient
- drive an indeterminate animation for the loader bar
- verify loading bar presence in tests

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a74b0aa7008325ac0efcafdba49ca1