### PR TITLE
docs: add jsdoc for import modals

### DIFF
--- a/src/components/BulkFileImportModal.tsx
+++ b/src/components/BulkFileImportModal.tsx
@@ -21,6 +21,18 @@ interface BulkFileImportModalProps {
   onImport: (jsons: string[]) => void;
 }
 
+/**
+ * Modal dialog for importing one or more JSON prompts from a selected file.
+ *
+ * @param {BulkFileImportModalProps} props - Component props.
+ * @param {boolean} props.open - Whether the dialog is visible.
+ * @param {(open: boolean) => void} props.onOpenChange - Change handler for dialog visibility.
+ * @param {(jsons: string[]) => void} props.onImport - Invoked with validated JSON strings.
+ *
+ * @remarks
+ * Shows toast notifications for success or failure and sends an analytics event
+ * when imports complete.
+ */
 const BulkFileImportModal: React.FC<BulkFileImportModalProps> = ({
   open,
   onOpenChange,

--- a/src/components/ClipboardImportModal.tsx
+++ b/src/components/ClipboardImportModal.tsx
@@ -22,6 +22,20 @@ interface ClipboardImportModalProps {
   title: string;
 }
 
+/**
+ * Modal dialog for importing JSON prompt configurations from clipboard text.
+ * Automatically attempts to read clipboard contents when opened.
+ *
+ * @param {ClipboardImportModalProps} props - Component props.
+ * @param {boolean} props.open - Whether the dialog is visible.
+ * @param {(open: boolean) => void} props.onOpenChange - Change handler for dialog visibility.
+ * @param {(jsons: string[]) => void} props.onImport - Called with validated JSON strings.
+ * @param {string} props.title - Title displayed in the dialog header.
+ *
+ * @remarks
+ * Reads from the system clipboard, shows toast errors for invalid input or
+ * unsupported clipboard access, and emits analytics events for history imports.
+ */
 const ClipboardImportModal: React.FC<ClipboardImportModalProps> = ({
   open,
   onOpenChange,

--- a/src/components/ImportModal.tsx
+++ b/src/components/ImportModal.tsx
@@ -22,6 +22,18 @@ interface ImportModalProps {
   onImport: (json: string) => void;
 }
 
+/**
+ * Modal for importing JSON prompt options via manual input, URL fetch, or file upload.
+ *
+ * @param {ImportModalProps} props - Component props.
+ * @param {boolean} props.isOpen - Whether the dialog is displayed.
+ * @param {() => void} props.onClose - Callback when the dialog is closed.
+ * @param {(json: string) => void} props.onImport - Called with a validated JSON string.
+ *
+ * @remarks
+ * Displays toast notifications on validation failure or blocked requests and
+ * emits an analytics event when importing from a URL.
+ */
 export const ImportModal: React.FC<ImportModalProps> = ({
   isOpen,
   onClose,


### PR DESCRIPTION
## Summary
- document ImportModal props and side effects
- add JSDoc for bulk file import modal
- describe clipboard import modal behavior and analytics in JSDoc

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74f23333483258b2dc73eebe28b22