### PR TITLE
feat: support CLI output file and minify options

### DIFF
--- a/cli/__tests__/index.test.ts
+++ b/cli/__tests__/index.test.ts
@@ -42,3 +42,17 @@ test('reads options from stdin when no flags are given', () => {
   expect(obj.prompt).toBe('stdin');
   expect(obj.width).toBe(321);
 });
+
+test('writes output to file when --output is provided', () => {
+  const file = join(tmpdir(), 'cli-output.json');
+  const out = runCli(['--prompt', 'file test', '--output', file]);
+  expect(out).toBe('');
+  const obj = JSON.parse(fs.readFileSync(file, 'utf8'));
+  expect(obj.prompt).toBe('file test');
+});
+
+test('minifies JSON when --minify is set', () => {
+  const out = runCli(['--prompt', 'mini', '--minify']);
+  const parsed = JSON.parse(out);
+  expect(out).toBe(JSON.stringify(parsed));
+});

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,18 @@ Load options from a JSON file instead:
 npx ts-node cli/index.ts --file options.json
 ```
 
+Write the output to a file with `--output`:
+
+```sh
+npx ts-node cli/index.ts --prompt "A castle at dawn" --output out.json
+```
+
+Generate compact JSON with `--minify`:
+
+```sh
+npx ts-node cli/index.ts --prompt "A castle at dawn" --minify
+```
+
 When installed from npm, the CLI is exposed as `sora-crafter`:
 
 ```sh


### PR DESCRIPTION
## Summary
- add `--output` and `--minify` flags to CLI
- test new CLI flags and document them in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7568eb380832593751140a9454360