### PR TITLE
Enhance milestones tab with progress and tier names

### DIFF
--- a/src/lib/__tests__/generateJson.test.ts
+++ b/src/lib/__tests__/generateJson.test.ts
@@ -9,7 +9,7 @@ function parse(json: string) {
 
 describe('generateJson', () => {
   test('removes mapped options when their flags are false', () => {
-    const base: any = { ...DEFAULT_OPTIONS };
+    const base: SoraOptions = { ...DEFAULT_OPTIONS };
 
     // Enable all feature flags
     Object.keys(base).forEach((key) => {


### PR DESCRIPTION
## Summary
- show counts and remaining steps to next tier in milestones tab
- add Greek god tier names and wrap time milestones for more space
- fix lint in generateJson test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7a0beb00c8325b4382c057bf01d19