### PR TITLE
feat: add tier tooltips to milestone medals

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -9,6 +9,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -510,16 +511,19 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                           )}
                         >
                           {cat.thresholds.map((th) => (
-                            <Medal
-                              key={th.value}
-                              className={cn(
-                                'w-4 h-4',
-                                achieved.includes(th.value)
-                                  ? 'text-yellow-500'
-                                  : 'text-gray-300',
-                              )}
-                              title={`${th.label} - ${th.tier}`}
-                            />
+                            <Tooltip key={th.value}>
+                              <TooltipTrigger asChild>
+                                <Medal
+                                  className={cn(
+                                    'w-4 h-4',
+                                    achieved.includes(th.value)
+                                      ? 'text-yellow-500'
+                                      : 'text-gray-300',
+                                  )}
+                                />
+                              </TooltipTrigger>
+                              <TooltipContent>{th.tier}</TooltipContent>
+                            </Tooltip>
                           ))}
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- wrap milestone medals with tooltip primitives to display tier names
- remove native title attribute and use tooltip content for tiers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a88c006b288325899cbd7a0a93138c