### PR TITLE
feat: improve time milestone spacing

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -528,7 +528,8 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                         <div
                           className={cn(
                             'flex gap-1',
-                            cat.key === TIME_MILESTONES && 'flex-wrap max-w-[200px]'
+                            cat.key === TIME_MILESTONES &&
+                              'flex-wrap max-w-[200px] gap-2 mt-1'
                           )}
                         >
                           {cat.thresholds.map((th) => (


### PR DESCRIPTION
## Summary
- add gap and top margin to time milestone row

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a89e0481748325a735e41c4181d870