### PR TITLE
feat: notify milestone achievements

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -20,6 +20,7 @@ import {
 
 import SettingsPanel from './SettingsPanel';
 import { useUpdateCheck } from '@/hooks/use-update-check';
+import { toast } from '@/components/ui/sonner-toast';
 import { useToast } from '@/components/ui/use-toast';
 import { ToastAction } from '@/components/ui/toast';
 import {
@@ -133,7 +134,7 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   const [clearing, setClearing] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const { checkForUpdate, updateAvailable } = useUpdateCheck();
-  const { toast } = useToast();
+const { toast: notify } = useToast();
 
   useEffect(() => {
     checkForUpdate();
@@ -141,7 +142,7 @@ export const ActionBar: React.FC<ActionBarProps> = ({
 
   useEffect(() => {
     if (updateAvailable) {
-      toast({
+      notify({
         title: 'Update available',
         description: 'Refresh the page to load the latest version.',
         action: (
@@ -154,7 +155,7 @@ export const ActionBar: React.FC<ActionBarProps> = ({
         ),
       });
     }
-  }, [updateAvailable, toast]);
+  }, [updateAvailable, notify]);
 
   /**
    * Collapses the action bar to a single restore button and records the
@@ -218,6 +219,7 @@ export const ActionBar: React.FC<ActionBarProps> = ({
             for (const [threshold, event] of UNDO_MILESTONE_EVENTS) {
               if (newCount >= threshold && !milestones.includes(threshold)) {
                 trackEvent(trackingEnabled, event);
+                toast.success(t('milestoneReached', { threshold }));
                 milestones.push(threshold);
               }
             }
@@ -248,6 +250,7 @@ export const ActionBar: React.FC<ActionBarProps> = ({
             for (const [threshold, event] of REDO_MILESTONE_EVENTS) {
               if (newCount >= threshold && !milestones.includes(threshold)) {
                 trackEvent(trackingEnabled, event);
+                toast.success(t('milestoneReached', { threshold }));
                 milestones.push(threshold);
               }
             }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -200,6 +200,7 @@ const Dashboard = () => {
         for (const [threshold, event] of COPY_MILESTONES) {
           if (newCount >= threshold && !milestones.includes(threshold)) {
             trackEvent(trackingEnabled, event);
+            toast.success(t('milestoneReached', { threshold }));
             milestones.push(threshold);
           }
         }

--- a/src/components/GeneratedJson.tsx
+++ b/src/components/GeneratedJson.tsx
@@ -9,6 +9,8 @@ import {
   JSON_CHANGE_COUNT,
   JSON_CHANGE_MILESTONES,
 } from '@/lib/storage-keys';
+import { toast } from '@/components/ui/sonner-toast';
+import { useTranslation } from 'react-i18next';
 
 SyntaxHighlighter.registerLanguage('json', jsonLang);
 
@@ -42,6 +44,7 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const prevRef = useRef(json);
   const [diffParts, setDiffParts] = useState<Change[] | null>(null);
+  const { t } = useTranslation();
 
   useEffect(() => {
     const diff = diffChars(prevRef.current, json).filter((p) => !p.removed);
@@ -60,6 +63,7 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
       for (const [threshold, event] of CHANGE_MILESTONES) {
         if (newCount >= threshold && !milestones.includes(threshold)) {
           trackEvent(trackingEnabled, event);
+          toast.success(t('milestoneReached', { threshold }));
           milestones.push(threshold);
         }
       }
@@ -69,7 +73,7 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
     }
     trackEvent(trackingEnabled, AnalyticsEvent.JsonChanged);
     return () => clearTimeout(timer);
-  }, [json, trackingEnabled]);
+  }, [json, trackingEnabled, t]);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/src/hooks/__tests__/use-total-time.test.ts
+++ b/src/hooks/__tests__/use-total-time.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from '@testing-library/react';
 import { useTotalTime } from '../use-total-time';
 import { TOTAL_SECONDS, TIME_MILESTONES } from '@/lib/storage-keys';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
+import { toast } from '@/components/ui/sonner-toast';
 
 jest.mock('../use-tracking', () => ({
   __esModule: true,
@@ -13,10 +14,15 @@ jest.mock('@/lib/analytics', () => {
   return { __esModule: true, ...actual, trackEvent: jest.fn() };
 });
 
+jest.mock('@/components/ui/sonner-toast', () => ({
+  toast: { success: jest.fn() },
+}));
+
 describe('useTotalTime', () => {
   beforeEach(() => {
     localStorage.clear();
     (trackEvent as jest.Mock).mockClear();
+    (toast.success as jest.Mock).mockClear();
     jest.useFakeTimers();
   });
 

--- a/src/hooks/use-total-time.ts
+++ b/src/hooks/use-total-time.ts
@@ -3,6 +3,8 @@ import { safeGet, safeSet } from '@/lib/storage';
 import { TOTAL_SECONDS, TIME_MILESTONES } from '@/lib/storage-keys';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
 import { useTracking } from './use-tracking';
+import { toast } from '@/components/ui/sonner-toast';
+import i18n from '@/i18n';
 
 const THRESHOLDS: [number, AnalyticsEvent][] = [
   [5 * 60, AnalyticsEvent.Time5Min],
@@ -46,6 +48,7 @@ export function useTotalTime() {
         for (const [threshold, event] of THRESHOLDS) {
           if (total >= threshold && !milestones.includes(threshold)) {
             trackEvent(trackingEnabled, event);
+            toast.success(i18n.t('milestoneReached', { threshold }));
             milestones.push(threshold);
           }
         }

--- a/src/lib/share-counter.ts
+++ b/src/lib/share-counter.ts
@@ -1,6 +1,8 @@
 import { safeGet, safeSet } from './storage';
 import { trackEvent, AnalyticsEvent } from './analytics';
 import { SHARE_COUNT, SHARE_MILESTONES } from './storage-keys';
+import { toast } from '@/components/ui/sonner-toast';
+import i18n from '@/i18n';
 
 const SHARE_MILESTONE_EVENTS: [number, AnalyticsEvent][] = [
   [5, AnalyticsEvent.Share5],
@@ -26,6 +28,7 @@ export function trackShare(enabled: boolean, event: AnalyticsEvent) {
     for (const [threshold, milestoneEvent] of SHARE_MILESTONE_EVENTS) {
       if (newCount >= threshold && !milestones.includes(threshold)) {
         trackEvent(enabled, milestoneEvent);
+        toast.success(i18n.t('milestoneReached', { threshold }));
         milestones.push(threshold);
       }
     }

--- a/src/locales/bn-IN.json
+++ b/src/locales/bn-IN.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "আমদানি",
   "reset": "রিসেট",
   "regenerate": "পুনরায় তৈরি করুন",

--- a/src/locales/da-DK.json
+++ b/src/locales/da-DK.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Importer",
   "reset": "Nulstil",
   "regenerate": "Generer igen",

--- a/src/locales/de-AT.json
+++ b/src/locales/de-AT.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Importieren",
   "reset": "Zurücksetzen",
   "regenerate": "Neu generieren",

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Importieren",
   "reset": "Zurücksetzen",
   "regenerate": "Neu generieren",

--- a/src/locales/el-GR.json
+++ b/src/locales/el-GR.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Εισαγωγή",
   "reset": "Επαναφορά",
   "regenerate": "Επαναδημιουργία",

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Import",
   "reset": "Reset",
   "regenerate": "Regenerate",

--- a/src/locales/en-PR.json
+++ b/src/locales/en-PR.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Smuggle In",
   "reset": "Scuttle",
   "regenerate": "Raise Again",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Import",
   "reset": "Reset",
   "regenerate": "Regenerate",

--- a/src/locales/es-AR.json
+++ b/src/locales/es-AR.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Importar",
   "reset": "Restablecer",
   "regenerate": "Regenerar",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Importar",
   "reset": "Restablecer",
   "regenerate": "Regenerar",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Importar",
   "reset": "Restablecer",
   "regenerate": "Regenerar",

--- a/src/locales/et-EE.json
+++ b/src/locales/et-EE.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Impordi",
   "reset": "Lähtesta",
   "regenerate": "Genereeri uuesti",

--- a/src/locales/fi-FI.json
+++ b/src/locales/fi-FI.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Tuo",
   "reset": "Palauta oletuksiin",
   "regenerate": "Luo uudelleen",

--- a/src/locales/fr-BE.json
+++ b/src/locales/fr-BE.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Importer",
   "reset": "Réinitialiser",
   "regenerate": "Régénérer",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Importer",
   "reset": "Réinitialiser",
   "regenerate": "Régénérer",

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Importa",
   "reset": "Ripristina",
   "regenerate": "Rigenera",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "インポート",
   "reset": "リセット",
   "regenerate": "再生成",

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "가져오기",
   "reset": "초기화",
   "regenerate": "재생성",

--- a/src/locales/ne-NP.json
+++ b/src/locales/ne-NP.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "आयात गर्नुहोस्",
   "reset": "रीसेट",
   "regenerate": "पुनः उत्पन्न गर्नुहोस्",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Importar",
   "reset": "Restaurar",
   "regenerate": "Regenerar",

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Importar",
   "reset": "Repor",
   "regenerate": "Regenerar",

--- a/src/locales/ro-RO.json
+++ b/src/locales/ro-RO.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Importă",
   "reset": "Resetează",
   "regenerate": "Regenerare",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Импорт",
   "reset": "Сброс",
   "regenerate": "Сгенерировать заново",

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Importera",
   "reset": "Återställ",
   "regenerate": "Regenerera",

--- a/src/locales/th-TH.json
+++ b/src/locales/th-TH.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "นำเข้า",
   "reset": "รีเซ็ต",
   "regenerate": "สร้างใหม่",

--- a/src/locales/uk-UA.json
+++ b/src/locales/uk-UA.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "Імпортувати",
   "reset": "Скинути",
   "regenerate": "Згенерувати знову",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -11,6 +11,7 @@
   "manage": "Manage",
   "general": "General",
   "milestones": "Milestones",
+  "milestoneReached": "Milestone {{threshold}} reached!",
   "import": "导入",
   "reset": "重置",
   "regenerate": "重新生成",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,8 @@ import {
   APP_RELOAD_MILESTONES,
   TRACKING_ENABLED,
 } from '@/lib/storage-keys';
+import { toast } from '@/components/ui/sonner-toast';
+import i18n from '@/i18n';
 
 const RELOAD_MILESTONES: [number, AnalyticsEvent][] = [
   [10, AnalyticsEvent.AppReload10],
@@ -32,6 +34,7 @@ try {
   for (const [threshold, event] of RELOAD_MILESTONES) {
     if (newCount >= threshold && !milestones.includes(threshold)) {
       trackEvent(trackingEnabled, event);
+      toast.success(i18n.t('milestoneReached', { threshold }));
       milestones.push(threshold);
     }
   }


### PR DESCRIPTION
## Summary
- add Sonner toast calls when milestone thresholds are reached
- internationalize milestone toasts via new `milestoneReached` key

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8b74cd2e08325afa0e8a28efac524