### PR TITLE
refactor: replace title tooltips with styled tooltip components

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -9,6 +9,19 @@ globalThis.__BASE_URL__ = '/';
 import { jest } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
+import React from 'react';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+jest.mock('@testing-library/react', () => {
+  const actual = jest.requireActual('@testing-library/react');
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(TooltipProvider, { delayDuration: 0 }, children);
+  return {
+    ...actual,
+    render: (ui: React.ReactElement, options?: Parameters<typeof actual.render>[1]) =>
+      actual.render(ui, { wrapper, ...options }),
+  };
+});
 
 // Provide minimal fetch and Cache API stubs for tests
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ const App = () => {
     <I18nextProvider i18n={i18n}>
       <ErrorBoundary>
         <QueryClientProvider client={queryClient}>
-          <TooltipProvider>
+          <TooltipProvider delayDuration={5000}>
             <Toaster />
             <Sonner />
             <BrowserRouter

--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -17,6 +17,11 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from '@/components/ui/dropdown-menu';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 import SettingsPanel from './SettingsPanel';
 import { useUpdateCheck } from '@/hooks/use-update-check';
@@ -178,16 +183,20 @@ const { toast: notify } = useToast();
   if (minimized) {
     return (
       <div className="fixed bottom-4 right-4 z-50">
-        <Button
-          onClick={handleRestore}
-          variant="default"
-          size="sm"
-          className="gap-1"
-          title={t('actions')}
-        >
-          {t('actions')}
-          <ChevronUp className="w-4 h-4" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              onClick={handleRestore}
+              variant="default"
+              size="sm"
+              className="gap-1"
+            >
+              {t('actions')}
+              <ChevronUp className="w-4 h-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('actions')}</TooltipContent>
+        </Tooltip>
       </div>
     );
   }
@@ -195,134 +204,166 @@ const { toast: notify } = useToast();
   return (
     <div className="fixed bottom-4 right-4 z-50 bg-card border rounded-md shadow-lg p-3 flex flex-wrap items-center gap-2">
       {soraToolsEnabled && userscriptInstalled && (
-        <Button
-          onClick={onSendToSora}
-          variant="outline"
-          size="sm"
-          className={cn({ 'gap-2': actionLabelsEnabled })}
-          title={t('sendToSora')}
-        >
-          <Send className="w-4 h-4" />
-          {actionLabelsEnabled && t('sendToSora')}
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              onClick={onSendToSora}
+              variant="outline"
+              size="sm"
+              className={cn({ 'gap-2': actionLabelsEnabled })}
+            >
+              <Send className="w-4 h-4" />
+              {actionLabelsEnabled && t('sendToSora')}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('sendToSora')}</TooltipContent>
+        </Tooltip>
       )}
-      <Button
-        onClick={() => {
-          onUndo();
-          trackEvent(trackingEnabled, AnalyticsEvent.UndoButton);
-          try {
-            const count = (safeGet<number>(UNDO_COUNT, 0, true) as number) ?? 0;
-            const newCount = count + 1;
-            safeSet(UNDO_COUNT, newCount, true);
-            const milestones =
-              (safeGet<number[]>(UNDO_MILESTONES, [], true) as number[]) ?? [];
-            for (const [threshold, event] of UNDO_MILESTONE_EVENTS) {
-              if (newCount >= threshold && !milestones.includes(threshold)) {
-                trackEvent(trackingEnabled, event);
-                toast.success(t('milestoneReached', { threshold }));
-                milestones.push(threshold);
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            onClick={() => {
+              onUndo();
+              trackEvent(trackingEnabled, AnalyticsEvent.UndoButton);
+              try {
+                const count = (safeGet<number>(UNDO_COUNT, 0, true) as number) ?? 0;
+                const newCount = count + 1;
+                safeSet(UNDO_COUNT, newCount, true);
+                const milestones =
+                  (safeGet<number[]>(UNDO_MILESTONES, [], true) as number[]) ?? [];
+                for (const [threshold, event] of UNDO_MILESTONE_EVENTS) {
+                  if (newCount >= threshold && !milestones.includes(threshold)) {
+                    trackEvent(trackingEnabled, event);
+                    toast.success(t('milestoneReached', { threshold }));
+                    milestones.push(threshold);
+                  }
+                }
+                safeSet(UNDO_MILESTONES, milestones, true);
+              } catch {
+                console.error('Undo counter: There was an error.');
               }
-            }
-            safeSet(UNDO_MILESTONES, milestones, true);
-          } catch {
-            console.error('Undo counter: There was an error.');
-          }
-        }}
-        variant="outline"
-        size="sm"
-        disabled={!canUndo}
-        className={cn({ 'gap-2': actionLabelsEnabled })}
-        title={t('undo')}
-      >
-        <Undo2 className="w-4 h-4" />
-        {actionLabelsEnabled && t('undo')}
-      </Button>
-      <Button
-        onClick={() => {
-          onRedo();
-          trackEvent(trackingEnabled, AnalyticsEvent.RedoButton);
-          try {
-            const count = (safeGet<number>(REDO_COUNT, 0, true) as number) ?? 0;
-            const newCount = count + 1;
-            safeSet(REDO_COUNT, newCount, true);
-            const milestones =
-              (safeGet<number[]>(REDO_MILESTONES, [], true) as number[]) ?? [];
-            for (const [threshold, event] of REDO_MILESTONE_EVENTS) {
-              if (newCount >= threshold && !milestones.includes(threshold)) {
-                trackEvent(trackingEnabled, event);
-                toast.success(t('milestoneReached', { threshold }));
-                milestones.push(threshold);
+            }}
+            variant="outline"
+            size="sm"
+            disabled={!canUndo}
+            className={cn({ 'gap-2': actionLabelsEnabled })}
+          >
+            <Undo2 className="w-4 h-4" />
+            {actionLabelsEnabled && t('undo')}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t('undo')}</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            onClick={() => {
+              onRedo();
+              trackEvent(trackingEnabled, AnalyticsEvent.RedoButton);
+              try {
+                const count = (safeGet<number>(REDO_COUNT, 0, true) as number) ?? 0;
+                const newCount = count + 1;
+                safeSet(REDO_COUNT, newCount, true);
+                const milestones =
+                  (safeGet<number[]>(REDO_MILESTONES, [], true) as number[]) ?? [];
+                for (const [threshold, event] of REDO_MILESTONE_EVENTS) {
+                  if (newCount >= threshold && !milestones.includes(threshold)) {
+                    trackEvent(trackingEnabled, event);
+                    toast.success(t('milestoneReached', { threshold }));
+                    milestones.push(threshold);
+                  }
+                }
+                safeSet(REDO_MILESTONES, milestones, true);
+              } catch {
+                console.error('Redo counter: There was an error.');
               }
-            }
-            safeSet(REDO_MILESTONES, milestones, true);
-          } catch {
-            console.error('Redo counter: There was an error.');
-          }
-        }}
-        variant="outline"
-        size="sm"
-        disabled={!canRedo}
-        className={cn({ 'gap-2': actionLabelsEnabled })}
-        title={t('redo')}
-      >
-        <Redo2 className="w-4 h-4" />
-        {actionLabelsEnabled && t('redo')}
-      </Button>
-      <Button
-        onClick={onCopy}
-        variant="outline"
-        size="sm"
-        className={cn({ 'gap-2': actionLabelsEnabled })}
-        title={t('copy')}
-      >
-        {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-        {actionLabelsEnabled && t('copy')}
-      </Button>
-      <Button
-        onClick={() => {
+            }}
+            variant="outline"
+            size="sm"
+            disabled={!canRedo}
+            className={cn({ 'gap-2': actionLabelsEnabled })}
+          >
+            <Redo2 className="w-4 h-4" />
+            {actionLabelsEnabled && t('redo')}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t('redo')}</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            onClick={onCopy}
+            variant="outline"
+            size="sm"
+            className={cn({ 'gap-2': actionLabelsEnabled })}
+          >
+            {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+            {actionLabelsEnabled && t('copy')}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t('copy')}</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            onClick={() => {
           setClearing(true);
           onClear();
           setTimeout(() => setClearing(false), 500);
         }}
-        variant="outline"
-        size="sm"
-        className={cn({ 'gap-2': actionLabelsEnabled })}
-        title={t('clear')}
-      >
-        <Trash2 className={`w-4 h-4 ${clearing ? 'animate-spin' : ''}`} />
-        {actionLabelsEnabled && t('clear')}
-      </Button>
-      <Button
-        onClick={onShare}
-        variant="outline"
-        size="sm"
-        className={cn({ 'gap-2': actionLabelsEnabled })}
-        title={t('share')}
-      >
-        <Share className="w-4 h-4" />
-        {actionLabelsEnabled && t('share')}
-      </Button>
-      <Button
-        onClick={() => setShowSettings(true)}
-        variant="outline"
-        size="sm"
-        className={cn({ 'gap-2': actionLabelsEnabled })}
-        title={t('manage')}
-      >
-        <Cog className="w-4 h-4" /> {actionLabelsEnabled && t('manage')}
-      </Button>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
             variant="outline"
             size="sm"
             className={cn({ 'gap-2': actionLabelsEnabled })}
-            title={t('language')}
           >
-            <Languages className="w-4 h-4" />
-            {actionLabelsEnabled && t('language')}
+            <Trash2 className={`w-4 h-4 ${clearing ? 'animate-spin' : ''}`} />
+            {actionLabelsEnabled && t('clear')}
           </Button>
-        </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>{t('clear')}</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            onClick={onShare}
+            variant="outline"
+            size="sm"
+            className={cn({ 'gap-2': actionLabelsEnabled })}
+          >
+            <Share className="w-4 h-4" />
+            {actionLabelsEnabled && t('share')}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t('share')}</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            onClick={() => setShowSettings(true)}
+            variant="outline"
+            size="sm"
+            className={cn({ 'gap-2': actionLabelsEnabled })}
+          >
+            <Cog className="w-4 h-4" /> {actionLabelsEnabled && t('manage')}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t('manage')}</TooltipContent>
+      </Tooltip>
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className={cn({ 'gap-2': actionLabelsEnabled })}
+              >
+                <Languages className="w-4 h-4" />
+                {actionLabelsEnabled && t('language')}
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>{t('language')}</TooltipContent>
+        </Tooltip>
         <DropdownMenuContent className="max-h-screen sm:max-h-[50vh] overflow-y-auto">
           <DropdownMenuItem
             onSelect={() => setLocale('en-US')}
@@ -615,30 +656,38 @@ const { toast: notify } = useToast();
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <Button
-        onClick={onHistory}
-        variant="outline"
-        size="sm"
-        className={cn({ 'gap-2': actionLabelsEnabled })}
-        title={t('history')}
-      >
-        <History className="w-4 h-4" />
-        {actionLabelsEnabled && t('history')}
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            onClick={onHistory}
+            variant="outline"
+            size="sm"
+            className={cn({ 'gap-2': actionLabelsEnabled })}
+          >
+            <History className="w-4 h-4" />
+            {actionLabelsEnabled && t('history')}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t('history')}</TooltipContent>
+      </Tooltip>
       {showJumpToJson && (
-        <Button
-          onClick={() => {
-            onJumpToJson?.();
-            trackEvent(trackingEnabled, AnalyticsEvent.JumpToJson);
-          }}
-          variant="outline"
-          size="sm"
-          className={cn({ 'gap-2': actionLabelsEnabled })}
-          title={t('jumpToJson')}
-        >
-          <MoveDown className="w-4 h-4" />
-          {actionLabelsEnabled && t('jumpToJson')}
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              onClick={() => {
+                onJumpToJson?.();
+                trackEvent(trackingEnabled, AnalyticsEvent.JumpToJson);
+              }}
+              variant="outline"
+              size="sm"
+              className={cn({ 'gap-2': actionLabelsEnabled })}
+            >
+              <MoveDown className="w-4 h-4" />
+              {actionLabelsEnabled && t('jumpToJson')}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('jumpToJson')}</TooltipContent>
+        </Tooltip>
       )}
       <Button
         onClick={handleMinimize}

--- a/src/components/BulkFileImportModal.tsx
+++ b/src/components/BulkFileImportModal.tsx
@@ -14,6 +14,11 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { toast } from '@/components/ui/sonner-toast';
 import { isValidOptions } from '@/lib/validateOptions';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 interface BulkFileImportModalProps {
   open: boolean;
@@ -100,16 +105,25 @@ const BulkFileImportModal: React.FC<BulkFileImportModalProps> = ({
           onChange={(e) => setFile(e.target.files?.[0] || null)}
         />
         <DialogFooter>
-          <Button
-            variant="secondary"
-            onClick={() => onOpenChange(false)}
-            title={t('cancel')}
-          >
-            {t('cancel')}
-          </Button>
-          <Button onClick={handleImport} title={t('import')}>
-            {t('import')}
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="secondary"
+                onClick={() => onOpenChange(false)}
+              >
+                {t('cancel')}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('cancel')}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button onClick={handleImport}>
+                {t('import')}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('import')}</TooltipContent>
+          </Tooltip>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/ClipboardImportModal.tsx
+++ b/src/components/ClipboardImportModal.tsx
@@ -14,6 +14,11 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/components/ui/sonner-toast';
 import { isValidOptions } from '@/lib/validateOptions';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 interface ClipboardImportModalProps {
   open: boolean;
@@ -121,16 +126,25 @@ const ClipboardImportModal: React.FC<ClipboardImportModalProps> = ({
           className="my-4"
         />
         <DialogFooter>
-          <Button
-            variant="secondary"
-            onClick={() => onOpenChange(false)}
-            title={t('cancel')}
-          >
-            {t('cancel')}
-          </Button>
-          <Button onClick={handleImport} title={t('import')}>
-            {t('import')}
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="secondary"
+                onClick={() => onOpenChange(false)}
+              >
+                {t('cancel')}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('cancel')}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button onClick={handleImport}>
+                {t('import')}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('import')}</TooltipContent>
+          </Tooltip>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -38,6 +38,11 @@ import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { generateJson } from '@/lib/generateJson';
 import type { SoraOptions } from '@/lib/soraOptions';
 import { loadOptionsFromJson } from '@/lib/loadOptionsFromJson';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 import { OPTION_FLAG_MAP } from '@/lib/optionFlagMap';
 import { isValidOptions } from '@/lib/validateOptions';
 import { safeGet, safeSet } from '@/lib/storage';
@@ -513,176 +518,211 @@ const Dashboard = () => {
             <p className="text-muted-foreground select-none">{t('tagline')}</p>
             {headerButtonsEnabled && (
               <div className="flex flex-wrap items-center gap-2 mt-2">
-                <Button asChild variant="outline" size="sm" className="gap-1">
-                  <a
-                    href="https://github.com/sponsors/supermarsx"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-1"
-                    onClick={() =>
-                      trackEvent(trackingEnabled, AnalyticsEvent.ClickSponsor)
-                    }
-                    title={t('sponsor')}
-                  >
-                    <Heart className="w-4 h-4" /> {t('sponsor')}
-                  </a>
-                </Button>
-                <Button asChild variant="outline" size="sm" className="gap-1">
-                  <a
-                    href="https://github.com/supermarsx/sora-json-prompt-crafter"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-1"
-                    onClick={() =>
-                      trackEvent(trackingEnabled, AnalyticsEvent.SeeGithub)
-                    }
-                    title={t('github')}
-                  >
-                    <Github className="w-4 h-4" /> {t('github')}
-                  </a>
-                </Button>
-                <Button asChild variant="outline" size="sm" className="gap-1">
-                  <a
-                    href="https://github.com/supermarsx/sora-json-prompt-crafter"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-1"
-                    onClick={() =>
-                      trackEvent(trackingEnabled, AnalyticsEvent.StarGithub)
-                    }
-                    title={t('star')}
-                  >
-                    <Star className="w-4 h-4" />
-                    {t('star')}
-                    {githubStats?.stars ? ` ${githubStats.stars}` : ''}
-                  </a>
-                </Button>
-                <Button asChild variant="outline" size="sm" className="gap-1">
-                  <a
-                    href="https://github.com/supermarsx/sora-json-prompt-crafter/fork"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-1"
-                    onClick={() =>
-                      trackEvent(trackingEnabled, AnalyticsEvent.ForkGithub)
-                    }
-                    title={t('fork')}
-                  >
-                    <GitFork className="w-4 h-4" />
-                    {t('fork')}
-                    {githubStats?.forks ? ` ${githubStats.forks}` : ''}
-                  </a>
-                </Button>
-                <Button asChild variant="outline" size="sm" className="gap-1">
-                  <a
-                    href="https://github.com/supermarsx/sora-json-prompt-crafter/issues/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-1"
-                    onClick={() =>
-                      trackEvent(trackingEnabled, AnalyticsEvent.OpenIssues)
-                    }
-                    title={t('issues')}
-                  >
-                    <Bug className="w-4 h-4" />
-                    {t('issues')}
-                    {githubStats?.issues ? ` ${githubStats.issues}` : ''}
-                  </a>
-                </Button>
-                <Button asChild variant="outline" size="sm" className="gap-1">
-                  <a
-                    href="https://lovable.dev/projects/385b40c5-6b5e-49fc-9f0a-e6a0f9a36181"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-1"
-                    onClick={() =>
-                      trackEvent(trackingEnabled, AnalyticsEvent.ViewOnLovable)
-                    }
-                    title={t('viewOnLovable')}
-                  >
-                    <Heart className="w-4 h-4" />
-                    {t('viewOnLovable')}
-                  </a>
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button asChild variant="outline" size="sm" className="gap-1">
+                      <a
+                        href="https://github.com/sponsors/supermarsx"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-1"
+                        onClick={() =>
+                          trackEvent(trackingEnabled, AnalyticsEvent.ClickSponsor)
+                        }
+                      >
+                        <Heart className="w-4 h-4" /> {t('sponsor')}
+                      </a>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('sponsor')}</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button asChild variant="outline" size="sm" className="gap-1">
+                      <a
+                        href="https://github.com/supermarsx/sora-json-prompt-crafter"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-1"
+                        onClick={() =>
+                          trackEvent(trackingEnabled, AnalyticsEvent.SeeGithub)
+                        }
+                      >
+                        <Github className="w-4 h-4" /> {t('github')}
+                      </a>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('github')}</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button asChild variant="outline" size="sm" className="gap-1">
+                      <a
+                        href="https://github.com/supermarsx/sora-json-prompt-crafter"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-1"
+                        onClick={() =>
+                          trackEvent(trackingEnabled, AnalyticsEvent.StarGithub)
+                        }
+                      >
+                        <Star className="w-4 h-4" />
+                        {t('star')}
+                        {githubStats?.stars ? ` ${githubStats.stars}` : ''}
+                      </a>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('star')}</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button asChild variant="outline" size="sm" className="gap-1">
+                      <a
+                        href="https://github.com/supermarsx/sora-json-prompt-crafter/fork"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-1"
+                        onClick={() =>
+                          trackEvent(trackingEnabled, AnalyticsEvent.ForkGithub)
+                        }
+                      >
+                        <GitFork className="w-4 h-4" />
+                        {t('fork')}
+                        {githubStats?.forks ? ` ${githubStats.forks}` : ''}
+                      </a>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('fork')}</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button asChild variant="outline" size="sm" className="gap-1">
+                      <a
+                        href="https://github.com/supermarsx/sora-json-prompt-crafter/issues/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-1"
+                        onClick={() =>
+                          trackEvent(trackingEnabled, AnalyticsEvent.OpenIssues)
+                        }
+                      >
+                        <Bug className="w-4 h-4" />
+                        {t('issues')}
+                        {githubStats?.issues ? ` ${githubStats.issues}` : ''}
+                      </a>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('issues')}</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button asChild variant="outline" size="sm" className="gap-1">
+                      <a
+                        href="https://lovable.dev/projects/385b40c5-6b5e-49fc-9f0a-e6a0f9a36181"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-1"
+                        onClick={() =>
+                          trackEvent(trackingEnabled, AnalyticsEvent.ViewOnLovable)
+                        }
+                      >
+                        <Heart className="w-4 h-4" />
+                        {t('viewOnLovable')}
+                      </a>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('viewOnLovable')}</TooltipContent>
+                </Tooltip>
                 {soraToolsEnabled && !userscriptInstalled && (
-                  <Button asChild variant="outline" size="sm" className="gap-1">
-                    <a
-                      href="/sora-userscript.user.js"
-                      className="flex items-center gap-1"
-                      rel="noopener noreferrer"
-                      onClick={() =>
-                        trackEvent(
-                          trackingEnabled,
-                          AnalyticsEvent.InstallUserscript,
-                        )
-                      }
-                      title={t('installUserscript')}
-                    >
-                      <Download className="w-4 h-4" />
-                      {t('installUserscript')}
-                    </a>
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button asChild variant="outline" size="sm" className="gap-1">
+                        <a
+                          href="/sora-userscript.user.js"
+                          className="flex items-center gap-1"
+                          rel="noopener noreferrer"
+                          onClick={() =>
+                            trackEvent(
+                              trackingEnabled,
+                              AnalyticsEvent.InstallUserscript,
+                            )
+                          }
+                        >
+                          <Download className="w-4 h-4" />
+                          {t('installUserscript')}
+                        </a>
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('installUserscript')}</TooltipContent>
+                  </Tooltip>
                 )}
                 {soraToolsEnabled &&
                   userscriptInstalled &&
                   userscriptVersion !== USERSCRIPT_VERSION && (
-                    <Button
-                      asChild
-                      variant="outline"
-                      size="sm"
-                      className="gap-1"
-                    >
-                      <a
-                        href="/sora-userscript.user.js"
-                        className="flex items-center gap-1"
-                        rel="noopener noreferrer"
-                        onClick={() =>
-                          trackEvent(
-                            trackingEnabled,
-                            AnalyticsEvent.UpdateUserscript,
-                          )
-                        }
-                        title={t('updateUserscript')}
-                      >
-                        <RefreshCw className="w-4 h-4" />
-                        {t('updateUserscript')}
-                      </a>
-                    </Button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button asChild variant="outline" size="sm" className="gap-1">
+                          <a
+                            href="/sora-userscript.user.js"
+                            className="flex items-center gap-1"
+                            rel="noopener noreferrer"
+                            onClick={() =>
+                              trackEvent(
+                                trackingEnabled,
+                                AnalyticsEvent.UpdateUserscript,
+                              )
+                            }
+                          >
+                            <RefreshCw className="w-4 h-4" />
+                            {t('updateUserscript')}
+                          </a>
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>{t('updateUserscript')}</TooltipContent>
+                    </Tooltip>
                   )}
               </div>
             )}
             <p className="text-xs mt-2 text-muted-foreground">
               {t('agreeToDisclaimer')}{' '}
-              <button
-                onClick={() => {
-                  setShowDisclaimer(true);
-                  trackEvent(trackingEnabled, AnalyticsEvent.OpenDisclaimer);
-                }}
-                className="underline"
-                title={t('fullDisclaimer')}
-              >
-                {t('fullDisclaimer')}
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => {
+                      setShowDisclaimer(true);
+                      trackEvent(trackingEnabled, AnalyticsEvent.OpenDisclaimer);
+                    }}
+                    className="underline"
+                  >
+                    {t('fullDisclaimer')}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{t('fullDisclaimer')}</TooltipContent>
+              </Tooltip>
             </p>
           </div>
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={() => {
-              setDarkMode(!darkMode);
-              trackEvent(trackingEnabled, AnalyticsEvent.DarkModeToggle, {
-                enabled: !darkMode,
-              });
-            }}
-            aria-label="Toggle dark mode"
-            title="Toggle dark mode"
-          >
-            {darkMode ? (
-              <Sun className="w-5 h-5" />
-            ) : (
-              <Moon className="w-5 h-5" />
-            )}
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => {
+                  setDarkMode(!darkMode);
+                  trackEvent(trackingEnabled, AnalyticsEvent.DarkModeToggle, {
+                    enabled: !darkMode,
+                  });
+                }}
+                aria-label="Toggle dark mode"
+              >
+                {darkMode ? (
+                  <Sun className="w-5 h-5" />
+                ) : (
+                  <Moon className="w-5 h-5" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Toggle dark mode</TooltipContent>
+          </Tooltip>
         </div>
 
         <div className="grid lg:grid-cols-2 gap-6 flex-1">

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -3,6 +3,11 @@ import i18n from '@/i18n';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { RefreshCw, AlertCircle } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 interface Props {
   children: ReactNode;
@@ -51,14 +56,15 @@ class ErrorBoundary extends Component<Props, State> {
             <p className="text-sm text-muted-foreground">
               {this.state.error?.message || i18n.t('unexpectedError')}
             </p>
-            <Button
-              onClick={this.handleReset}
-              className="gap-2"
-              title={i18n.t('tryAgain')}
-            >
-              <RefreshCw className="w-4 h-4" />
-              {i18n.t('tryAgain')}
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button onClick={this.handleReset} className="gap-2">
+                  <RefreshCw className="w-4 h-4" />
+                  {i18n.t('tryAgain')}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{i18n.t('tryAgain')}</TooltipContent>
+            </Tooltip>
           </CardContent>
         </Card>
       );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 interface FooterProps {
   onShowDisclaimer: () => void;
@@ -30,13 +35,17 @@ const Footer: React.FC<FooterProps> = ({ onShowDisclaimer }) => {
         >
           {t('githubSource')}
         </a>{' '}
-        <button
-          onClick={onShowDisclaimer}
-          className="underline ml-2"
-          title={t('disclaimer')}
-        >
-          {t('disclaimer')}
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={onShowDisclaimer}
+              className="underline ml-2"
+            >
+              {t('disclaimer')}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>{t('disclaimer')}</TooltipContent>
+        </Tooltip>
       </p>
       <p className="mt-2 text-xs">{t('versionInfo', { commit, date })}</p>
       {/* Tracking scripts moved to index.html */}

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -27,6 +27,11 @@ import {
   Download,
   Check,
 } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 const HistoryListOuter = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   (props, ref) => <div ref={ref} data-testid="history-list" {...props} />,
 );
@@ -262,16 +267,20 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
               <div className="mb-4 flex justify-between items-center gap-2">
                 <div className="flex gap-2">
                   <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="gap-1"
-                        title={t('import')}
-                      >
-                        <ImportIcon className="w-4 h-4" /> {t('import')}
-                      </Button>
-                    </DropdownMenuTrigger>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="gap-1"
+                          >
+                            <ImportIcon className="w-4 h-4" /> {t('import')}
+                          </Button>
+                        </DropdownMenuTrigger>
+                      </TooltipTrigger>
+                      <TooltipContent>{t('import')}</TooltipContent>
+                    </Tooltip>
                     <DropdownMenuContent>
                       <DropdownMenuItem
                         onSelect={() => {
@@ -312,17 +321,21 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
                     </DropdownMenuContent>
                   </DropdownMenu>
                   <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="gap-1"
-                        disabled={noHistory}
-                        title={t('export')}
-                      >
-                        <Download className="w-4 h-4" /> {t('export')}
-                      </Button>
-                    </DropdownMenuTrigger>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="gap-1"
+                            disabled={noHistory}
+                          >
+                            <Download className="w-4 h-4" /> {t('export')}
+                          </Button>
+                        </DropdownMenuTrigger>
+                      </TooltipTrigger>
+                      <TooltipContent>{t('export')}</TooltipContent>
+                    </Tooltip>
                   <DropdownMenuContent>
                     <DropdownMenuItem
                       onSelect={() => {
@@ -350,18 +363,22 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={() => {
-                  trackEvent(trackingEnabled, AnalyticsEvent.HistoryClearClick);
-                  setConfirmClear(true);
-                }}
-                disabled={noHistory}
-                title={t('clearHistory')}
-              >
-                {t('clearHistory')}
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => {
+                      trackEvent(trackingEnabled, AnalyticsEvent.HistoryClearClick);
+                      setConfirmClear(true);
+                    }}
+                    disabled={noHistory}
+                  >
+                    {t('clearHistory')}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t('clearHistory')}</TooltipContent>
+              </Tooltip>
               </div>
               <div className="h-[60vh]">
                 {history.length > 0 ? (
@@ -402,25 +419,33 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
                   {t('latestActionsIntro')}
                 </p>
                 <div className="flex gap-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="gap-1"
-                    onClick={exportActions}
-                    disabled={noActions}
-                    title={t('export')}
-                  >
-                    <Download className="w-4 h-4" /> {t('export')}
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="destructive"
-                    onClick={requestClearActions}
-                    disabled={noActions}
-                    title={t('clearActions')}
-                  >
-                    {t('clearActions')}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="gap-1"
+                        onClick={exportActions}
+                        disabled={noActions}
+                      >
+                        <Download className="w-4 h-4" /> {t('export')}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('export')}</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={requestClearActions}
+                        disabled={noActions}
+                      >
+                        {t('clearActions')}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('clearActions')}</TooltipContent>
+                  </Tooltip>
                 </div>
               </div>
               <ScrollArea className="h-[60vh]">
@@ -433,28 +458,32 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
                       <span>{a.date}</span>
                       <span className="flex items-center gap-2">
                         {a.action}
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          className={`p-0 w-3.5 h-3.5 ${confirmDeleteActionIdx === idx ? 'text-destructive animate-pulse' : ''}`}
-                          onClick={() => requestDeleteAction(idx)}
-                          aria-label={
-                            confirmDeleteActionIdx === idx
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className={`p-0 w-3.5 h-3.5 ${confirmDeleteActionIdx === idx ? 'text-destructive animate-pulse' : ''}`}
+                              onClick={() => requestDeleteAction(idx)}
+                              aria-label={
+                                confirmDeleteActionIdx === idx
+                                  ? t('confirm')
+                                  : t('delete')
+                              }
+                            >
+                              {confirmDeleteActionIdx === idx ? (
+                                <Check className="w-3.5 h-3.5" />
+                              ) : (
+                                <Trash2 className="w-3.5 h-3.5" />
+                              )}
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            {confirmDeleteActionIdx === idx
                               ? t('confirm')
-                              : t('delete')
-                          }
-                          title={
-                            confirmDeleteActionIdx === idx
-                              ? t('confirm')
-                              : t('delete')
-                          }
-                        >
-                          {confirmDeleteActionIdx === idx ? (
-                            <Check className="w-3.5 h-3.5" />
-                          ) : (
-                            <Trash2 className="w-3.5 h-3.5" />
-                          )}
-                        </Button>
+                              : t('delete')}
+                          </TooltipContent>
+                        </Tooltip>
                       </span>
                     </div>
                   ))}

--- a/src/components/ImportModal.tsx
+++ b/src/components/ImportModal.tsx
@@ -15,6 +15,11 @@ import { toast } from '@/components/ui/sonner-toast';
 import { isValidOptions } from '@/lib/validateOptions';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
 import { useTracking } from '@/hooks/use-tracking';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 interface ImportModalProps {
   isOpen: boolean;
@@ -101,9 +106,14 @@ export const ImportModal: React.FC<ImportModalProps> = ({
               placeholder={t('urlPlaceholder')}
               className="flex-1"
             />
-            <Button onClick={handleFetch} title={t('fetch')}>
-              {t('fetch')}
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button onClick={handleFetch}>
+                  {t('fetch')}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('fetch')}</TooltipContent>
+            </Tooltip>
           </div>
           <Textarea
             value={text}
@@ -113,16 +123,22 @@ export const ImportModal: React.FC<ImportModalProps> = ({
           <Input type="file" accept=".json" onChange={handleFile} />
         </div>
         <DialogFooter>
-          <Button
-            variant="secondary"
-            onClick={onClose}
-            title={t('cancel')}
-          >
-            {t('cancel')}
-          </Button>
-          <Button onClick={handleImport} title={t('import')}>
-            {t('import')}
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="secondary" onClick={onClose}>
+                {t('cancel')}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('cancel')}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button onClick={handleImport}>
+                {t('import')}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('import')}</TooltipContent>
+          </Tooltip>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/MultiSelectDropdown.tsx
+++ b/src/components/MultiSelectDropdown.tsx
@@ -13,6 +13,11 @@ import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ChevronDown, Search } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 interface MultiSelectDropdownProps {
   options: readonly string[];
@@ -124,17 +129,21 @@ export const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
 
   return (
     <Dialog open={disabled ? false : isOpen} onOpenChange={handleOpenChange}>
-      <DialogTrigger asChild>
-        <Button
-          variant="outline"
-          className="w-full justify-between"
-          disabled={disabled}
-          title={displayValue}
-        >
-          <span className="truncate">{displayValue}</span>
-          <ChevronDown className="w-4 h-4 ml-2 flex-shrink-0" />
-        </Button>
-      </DialogTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <Button
+              variant="outline"
+              className="w-full justify-between"
+              disabled={disabled}
+            >
+              <span className="truncate">{displayValue}</span>
+              <ChevronDown className="w-4 h-4 ml-2 flex-shrink-0" />
+            </Button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>{displayValue}</TooltipContent>
+      </Tooltip>
       <DialogContent className="max-w-md max-h-[80vh]">
         <DialogHeader>
           <DialogTitle>{labelText}</DialogTitle>

--- a/src/components/SearchableDropdown.tsx
+++ b/src/components/SearchableDropdown.tsx
@@ -12,6 +12,11 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { ChevronDown, Search } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 interface SearchableDropdownProps {
   options: readonly string[];
@@ -83,19 +88,25 @@ export const SearchableDropdown: React.FC<SearchableDropdownProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !disabled && setIsOpen(open)}>
-      <DialogTrigger asChild>
-        <Button
-          variant="outline"
-          className="w-full justify-between"
-          disabled={disabled}
-          title={value ? formatLabel(value) : placeholderText}
-        >
-          <span className="truncate">
-            {value ? formatLabel(value) : placeholderText}
-          </span>
-          <ChevronDown className="w-4 h-4 ml-2 flex-shrink-0" />
-        </Button>
-      </DialogTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <Button
+              variant="outline"
+              className="w-full justify-between"
+              disabled={disabled}
+            >
+              <span className="truncate">
+                {value ? formatLabel(value) : placeholderText}
+              </span>
+              <ChevronDown className="w-4 h-4 ml-2 flex-shrink-0" />
+            </Button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          {value ? formatLabel(value) : placeholderText}
+        </TooltipContent>
+      </Tooltip>
       <DialogContent className="max-w-md max-h-[80vh]">
         <DialogHeader>
           <DialogTitle>{labelText}</DialogTitle>
@@ -115,16 +126,19 @@ export const SearchableDropdown: React.FC<SearchableDropdownProps> = ({
           <ScrollArea className="h-[300px]">
             <div className="space-y-1">
               {filteredOptions.map((option) => (
-                <Button
-                  key={option}
-                  variant={value === option ? 'default' : 'ghost'}
-                  className="w-full justify-start text-left h-auto py-2 px-3"
-                  onClick={() => handleSelect(option)}
-                  disabled={disabled}
-                  title={formatLabel(option)}
-                >
-                  <span className="break-words">{formatLabel(option)}</span>
-                </Button>
+                <Tooltip key={option}>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant={value === option ? 'default' : 'ghost'}
+                      className="w-full justify-start text-left h-auto py-2 px-3"
+                      onClick={() => handleSelect(option)}
+                      disabled={disabled}
+                    >
+                      <span className="break-words">{formatLabel(option)}</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{formatLabel(option)}</TooltipContent>
+                </Tooltip>
               ))}
             </div>
           </ScrollArea>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -297,231 +297,287 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
             <TabsContent value="manage">
               <ScrollArea className="max-h-[70vh]">
                 <div className="space-y-2 py-2">
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start gap-2"
-                    onClick={onImport}
-                    title={t('import')}
-                  >
-                    <ImportIcon className="w-4 h-4" /> {t('import')}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start gap-2"
-                    onClick={onReset}
-                    title={t('reset')}
-                  >
-                    <RotateCcw className="w-4 h-4" /> {t('reset')}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start gap-2"
-                    onClick={onRegenerate}
-                    title={t('regenerate')}
-                  >
-                    <RefreshCw className="w-4 h-4" /> {t('regenerate')}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start gap-2"
-                    onClick={onRandomize}
-                    title={t('randomize')}
-                  >
-                    <Shuffle className="w-4 h-4" /> {t('randomize')}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={onImport}
+                      >
+                        <ImportIcon className="w-4 h-4" /> {t('import')}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('import')}</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={onReset}
+                      >
+                        <RotateCcw className="w-4 h-4" /> {t('reset')}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('reset')}</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={onRegenerate}
+                      >
+                        <RefreshCw className="w-4 h-4" /> {t('regenerate')}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('regenerate')}</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={onRandomize}
+                      >
+                        <Shuffle className="w-4 h-4" /> {t('randomize')}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('randomize')}</TooltipContent>
+                  </Tooltip>
                 </div>
               </ScrollArea>
             </TabsContent>
             <TabsContent value="general">
               <ScrollArea className="max-h-[70vh]">
                 <div className="space-y-2 py-2">
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start gap-2"
-                    onClick={() => {
-                      if (trackingEnabled) {
-                        setConfirmDisableTracking(true);
-                      } else {
-                        setConfirmEnableTracking(true);
-                      }
-                    }}
-                    title={
-                      trackingEnabled
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={() => {
+                          if (trackingEnabled) {
+                            setConfirmDisableTracking(true);
+                          } else {
+                            setConfirmEnableTracking(true);
+                          }
+                        }}
+                      >
+                        {trackingEnabled ? (
+                          <>
+                            <EyeOff className="w-4 h-4" /> {t('disableTracking')}
+                          </>
+                        ) : (
+                          <>
+                            <Eye className="w-4 h-4" /> {t('enableTracking')}
+                          </>
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {trackingEnabled
                         ? t('disableTracking')
-                        : t('enableTracking')
-                    }
-                  >
-                    {trackingEnabled ? (
-                      <>
-                        <EyeOff className="w-4 h-4" /> {t('disableTracking')}
-                      </>
-                    ) : (
-                      <>
-                        <Eye className="w-4 h-4" /> {t('enableTracking')}
-                      </>
-                    )}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start gap-2 hidden"
-                    onClick={() => {
-                      try {
-                        onToggleSoraTools();
-                        toast.success(
-                          !soraToolsEnabled
-                            ? 'Sora integration enabled'
-                            : 'Sora integration disabled',
-                        );
-                      } catch {
-                        toast.error('Failed to toggle Sora integration');
-                      }
-                    }}
-                    title={
-                      soraToolsEnabled
+                        : t('enableTracking')}
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2 hidden"
+                        onClick={() => {
+                          try {
+                            onToggleSoraTools();
+                            toast.success(
+                              !soraToolsEnabled
+                                ? 'Sora integration enabled'
+                                : 'Sora integration disabled',
+                            );
+                          } catch {
+                            toast.error('Failed to toggle Sora integration');
+                          }
+                        }}
+                      >
+                        {soraToolsEnabled ? (
+                          <>
+                            <EyeOff className="w-4 h-4" /> Hide Sora Integration
+                          </>
+                        ) : (
+                          <>
+                            <Eye className="w-4 h-4" /> Show Sora Integration
+                          </>
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {soraToolsEnabled
                         ? 'Hide Sora Integration'
-                        : 'Show Sora Integration'
-                    }
-                  >
-                    {soraToolsEnabled ? (
-                      <>
-                        <EyeOff className="w-4 h-4" /> Hide Sora Integration
-                      </>
-                    ) : (
-                      <>
-                        <Eye className="w-4 h-4" /> Show Sora Integration
-                      </>
-                    )}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start gap-2"
-                    onClick={() => {
-                      try {
-                        onToggleHeaderButtons();
-                        toast.success(
-                          !headerButtonsEnabled
-                            ? t('showHeaderButtons')
-                            : t('hideHeaderButtons'),
-                        );
-                        trackEvent(
-                          trackingEnabled,
-                          AnalyticsEvent.ToggleHeaderButtons,
-                          {
-                            enabled: !headerButtonsEnabled,
-                          },
-                        );
-                      } catch {
-                        toast.error('Failed to toggle header buttons');
-                      }
-                    }}
-                    title={
-                      headerButtonsEnabled
+                        : 'Show Sora Integration'}
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={() => {
+                          try {
+                            onToggleHeaderButtons();
+                            toast.success(
+                              !headerButtonsEnabled
+                                ? t('showHeaderButtons')
+                                : t('hideHeaderButtons'),
+                            );
+                            trackEvent(
+                              trackingEnabled,
+                              AnalyticsEvent.ToggleHeaderButtons,
+                              {
+                                enabled: !headerButtonsEnabled,
+                              },
+                            );
+                          } catch {
+                            toast.error('Failed to toggle header buttons');
+                          }
+                        }}
+                      >
+                        {headerButtonsEnabled ? (
+                          <>
+                            <EyeOff className="w-4 h-4" /> {t('hideHeaderButtons')}
+                          </>
+                        ) : (
+                          <>
+                            <Eye className="w-4 h-4" /> {t('showHeaderButtons')}
+                          </>
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {headerButtonsEnabled
                         ? t('hideHeaderButtons')
-                        : t('showHeaderButtons')
-                    }
-                  >
-                    {headerButtonsEnabled ? (
-                      <>
-                        <EyeOff className="w-4 h-4" /> {t('hideHeaderButtons')}
-                      </>
-                    ) : (
-                      <>
-                        <Eye className="w-4 h-4" /> {t('showHeaderButtons')}
-                      </>
-                    )}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start gap-2"
-                    onClick={() => {
-                      try {
-                        onToggleLogo();
-                        toast.success(
-                          !logoEnabled ? t('showLogo') : t('hideLogo'),
-                        );
-                        trackEvent(trackingEnabled, AnalyticsEvent.ToggleLogo, {
-                          enabled: !logoEnabled,
-                        });
-                      } catch {
-                        toast.error('Failed to toggle logo');
-                      }
-                    }}
-                    title={logoEnabled ? t('hideLogo') : t('showLogo')}
-                  >
-                    {logoEnabled ? (
-                      <>
-                        <EyeOff className="w-4 h-4" /> {t('hideLogo')}
-                      </>
-                    ) : (
-                      <>
-                        <Eye className="w-4 h-4" /> {t('showLogo')}
-                      </>
-                    )}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start gap-2"
-                    onClick={() => {
-                      try {
-                        onToggleActionLabels();
-                        toast.success(
-                          !actionLabelsEnabled
-                            ? t('showLabels')
-                            : t('shortenButtons'),
-                        );
-                        trackEvent(
-                          trackingEnabled,
-                          AnalyticsEvent.ToggleActionLabels,
-                          {
-                            enabled: !actionLabelsEnabled,
-                          },
-                        );
-                      } catch {
-                        toast.error('Failed to toggle action labels');
-                      }
-                    }}
-                    title={
-                      actionLabelsEnabled ? t('shortenButtons') : t('showLabels')
-                    }
-                  >
-                    {actionLabelsEnabled ? (
-                      <>
-                        <EyeOff className="w-4 h-4" /> {t('shortenButtons')}
-                      </>
-                    ) : (
-                      <>
-                        <Eye className="w-4 h-4" /> {t('showLabels')}
-                      </>
-                    )}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start gap-2"
-                    onClick={exportDataFile}
-                    title={t('exportData', { defaultValue: 'Export data' })}
-                  >
-                    <Download className="w-4 h-4" />
-                    {t('exportData', { defaultValue: 'Export data' })}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start gap-2"
-                    onClick={importDataFile}
-                    title={t('importData', { defaultValue: 'Import data' })}
-                  >
-                    <ImportIcon className="w-4 h-4" />
-                    {t('importData', { defaultValue: 'Import data' })}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start gap-2"
-                    onClick={() => {
-                      setConfirmPurgeCache(true);
-                    }}
-                    title={t('purgeCache')}
-                  >
-                    <Trash2 className="w-4 h-4" /> {t('purgeCache')}
-                  </Button>
+                        : t('showHeaderButtons')}
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={() => {
+                          try {
+                            onToggleLogo();
+                            toast.success(
+                              !logoEnabled ? t('showLogo') : t('hideLogo'),
+                            );
+                            trackEvent(trackingEnabled, AnalyticsEvent.ToggleLogo, {
+                              enabled: !logoEnabled,
+                            });
+                          } catch {
+                            toast.error('Failed to toggle logo');
+                          }
+                        }}
+                      >
+                        {logoEnabled ? (
+                          <>
+                            <EyeOff className="w-4 h-4" /> {t('hideLogo')}
+                          </>
+                        ) : (
+                          <>
+                            <Eye className="w-4 h-4" /> {t('showLogo')}
+                          </>
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {logoEnabled ? t('hideLogo') : t('showLogo')}
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={() => {
+                          try {
+                            onToggleActionLabels();
+                            toast.success(
+                              !actionLabelsEnabled
+                                ? t('showLabels')
+                                : t('shortenButtons'),
+                            );
+                            trackEvent(
+                              trackingEnabled,
+                              AnalyticsEvent.ToggleActionLabels,
+                              {
+                                enabled: !actionLabelsEnabled,
+                              },
+                            );
+                          } catch {
+                            toast.error('Failed to toggle action labels');
+                          }
+                        }}
+                      >
+                        {actionLabelsEnabled ? (
+                          <>
+                            <EyeOff className="w-4 h-4" /> {t('shortenButtons')}
+                          </>
+                        ) : (
+                          <>
+                            <Eye className="w-4 h-4" /> {t('showLabels')}
+                          </>
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {actionLabelsEnabled
+                        ? t('shortenButtons')
+                        : t('showLabels')}
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={exportDataFile}
+                      >
+                        <Download className="w-4 h-4" />
+                        {t('exportData', { defaultValue: 'Export data' })}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {t('exportData', { defaultValue: 'Export data' })}
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={importDataFile}
+                      >
+                        <ImportIcon className="w-4 h-4" />
+                        {t('importData', { defaultValue: 'Import data' })}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {t('importData', { defaultValue: 'Import data' })}
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={() => {
+                          setConfirmPurgeCache(true);
+                        }}
+                      >
+                        <Trash2 className="w-4 h-4" /> {t('purgeCache')}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('purgeCache')}</TooltipContent>
+                  </Tooltip>
                 </div>
               </ScrollArea>
             </TabsContent>
@@ -569,7 +625,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                           )}
                         >
                           {cat.thresholds.map((th) => (
-                            <Tooltip key={th.value}>
+                            <Tooltip key={th.value} delayDuration={0}>
                               <TooltipTrigger asChild>
                                 <Medal
                                   className={cn(

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -25,6 +25,11 @@ import { QRCodeSVG } from 'qrcode.react';
 import { toast } from '@/components/ui/sonner-toast';
 import type { SoraOptions } from '@/lib/soraOptions';
 import { serializeOptions } from '@/lib/urlOptions';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 interface ShareModalProps {
   isOpen: boolean;
@@ -160,79 +165,109 @@ export const ShareModal: React.FC<ShareModalProps> = ({
         </DialogHeader>
         {nativeShareAvailable ? (
           <div className="py-4">
-            <Button
-              onClick={shareNative}
-              variant="outline"
-              className="w-full gap-2"
-              title={t('share')}
-            >
-              <Share2 className="w-4 h-4" />
-              {t('share')}…
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  onClick={shareNative}
+                  variant="outline"
+                  className="w-full gap-2"
+                >
+                  <Share2 className="w-4 h-4" />
+                  {t('share')}…
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('share')}</TooltipContent>
+            </Tooltip>
           </div>
         ) : (
           <div className="grid grid-cols-2 gap-4 py-4">
-            <Button
-              onClick={shareToFacebook}
-              variant="outline"
-              className="gap-2"
-              title={t('shareFacebook')}
-            >
-              <Facebook className="w-4 h-4 text-blue-600" />
-              {t('shareFacebook')}
-            </Button>
-            <Button
-              onClick={shareToTwitter}
-              variant="outline"
-              className="gap-2"
-              title={t('shareTwitter')}
-            >
-              <Twitter className="w-4 h-4 text-blue-400" />
-              {t('shareTwitter')}
-            </Button>
-            <Button
-              onClick={shareToWhatsApp}
-              variant="outline"
-              className="gap-2"
-              title={t('shareWhatsApp')}
-            >
-              <MessageCircle className="w-4 h-4 text-green-600" />
-              {t('shareWhatsApp')}
-            </Button>
-            <Button
-              onClick={shareToTelegram}
-              variant="outline"
-              className="gap-2"
-              title={t('shareTelegram')}
-            >
-              <Send className="w-4 h-4 text-blue-500" />
-              {t('shareTelegram')}
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  onClick={shareToFacebook}
+                  variant="outline"
+                  className="gap-2"
+                >
+                  <Facebook className="w-4 h-4 text-blue-600" />
+                  {t('shareFacebook')}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('shareFacebook')}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  onClick={shareToTwitter}
+                  variant="outline"
+                  className="gap-2"
+                >
+                  <Twitter className="w-4 h-4 text-blue-400" />
+                  {t('shareTwitter')}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('shareTwitter')}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  onClick={shareToWhatsApp}
+                  variant="outline"
+                  className="gap-2"
+                >
+                  <MessageCircle className="w-4 h-4 text-green-600" />
+                  {t('shareWhatsApp')}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('shareWhatsApp')}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  onClick={shareToTelegram}
+                  variant="outline"
+                  className="gap-2"
+                >
+                  <Send className="w-4 h-4 text-blue-500" />
+                  {t('shareTelegram')}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('shareTelegram')}</TooltipContent>
+            </Tooltip>
           </div>
         )}
         <div className="flex flex-col items-center gap-4 pt-4 border-t">
-          <Button
-            onClick={copyLink}
-            variant="default"
-            className="w-full gap-2"
-            title={t('copyLink')}
-          >
-            {copied ? (
-              <Check className="w-4 h-4 animate-pulse" />
-            ) : (
-              <Copy className="w-4 h-4" />
-            )}
-            {t('copyLink')}
-          </Button>
-          <Button
-            onClick={() => setShowQr((prev) => !prev)}
-            variant="outline"
-            className="w-full gap-2"
-            title={showQr ? t('hideQrCode') : t('showQrCode')}
-          >
-            <QrCode className="w-4 h-4" />
-            {showQr ? t('hideQrCode') : t('showQrCode')}
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                onClick={copyLink}
+                variant="default"
+                className="w-full gap-2"
+              >
+                {copied ? (
+                  <Check className="w-4 h-4 animate-pulse" />
+                ) : (
+                  <Copy className="w-4 h-4" />
+                )}
+                {t('copyLink')}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('copyLink')}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                onClick={() => setShowQr((prev) => !prev)}
+                variant="outline"
+                className="w-full gap-2"
+              >
+                <QrCode className="w-4 h-4" />
+                {showQr ? t('hideQrCode') : t('showQrCode')}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {showQr ? t('hideQrCode') : t('showQrCode')}
+            </TooltipContent>
+          </Tooltip>
           {showQr && <QRCodeSVG value={shareUrl} data-testid="share-qr-code" />}
         </div>
       </DialogContent>

--- a/src/components/__tests__/ActionBar.test.tsx
+++ b/src/components/__tests__/ActionBar.test.tsx
@@ -9,6 +9,7 @@ import {
   REDO_MILESTONES,
 } from '@/lib/storage-keys';
 import i18n from '@/i18n';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 jest.mock('@/lib/analytics', () => {
   const actual = jest.requireActual('@/lib/analytics');
@@ -164,18 +165,23 @@ afterEach(() => {
 });
 
 describe('ActionBar', () => {
+  const renderActionBar = (props: ReturnType<typeof createProps>) =>
+    render(
+      <TooltipProvider>
+        <ActionBar {...props} />
+      </TooltipProvider>,
+    );
   test('Copy calls onCopy', () => {
     const props = createProps();
-    const { unmount } = render(<ActionBar {...props} />);
+    const { unmount } = renderActionBar(props);
     const copyBtn = screen.getByRole('button', { name: /copy/i });
-    expect(copyBtn.getAttribute('title')).toBe(i18n.t('copy'));
     fireEvent.click(copyBtn);
     expect(props.onCopy).toHaveBeenCalled();
   });
 
   test('Undo and redo buttons call handlers', () => {
     const props = createProps();
-    render(<ActionBar {...props} />);
+    renderActionBar(props);
     fireEvent.click(screen.getByRole('button', { name: /undo/i }));
     expect(props.onUndo).toHaveBeenCalled();
     fireEvent.click(screen.getByRole('button', { name: /redo/i }));
@@ -184,7 +190,7 @@ describe('ActionBar', () => {
 
   test('undo/redo disabled states', () => {
     const props = createProps({ canUndo: false, canRedo: false });
-    render(<ActionBar {...props} />);
+    renderActionBar(props);
     const undoBtn = screen.getByRole('button', { name: /undo/i });
     const redoBtn = screen.getByRole('button', { name: /redo/i });
     expect(undoBtn.getAttribute('disabled')).not.toBeNull();
@@ -193,7 +199,7 @@ describe('ActionBar', () => {
 
   test('Clear spins then resets', () => {
     const props = createProps();
-    const { container } = render(<ActionBar {...props} />);
+    const { container } = renderActionBar(props);
     const btn = screen.getByRole('button', { name: /clear/i });
     const getIconClass = () =>
       btn.querySelector('svg')?.getAttribute('class') ?? '';
@@ -212,7 +218,7 @@ describe('ActionBar', () => {
 
   test('Settings disable/enable tracking confirms and toggles', async () => {
     const props = createProps();
-    const { unmount } = render(<ActionBar {...props} />);
+    const { unmount } = renderActionBar(props);
     fireEvent.pointerDown(screen.getByText(/manage/i));
     fireEvent.click(screen.getByText(/manage/i));
     fireEvent.click(screen.getByText(/disable tracking/i));
@@ -221,7 +227,7 @@ describe('ActionBar', () => {
     unmount();
 
     const props2 = createProps({ trackingEnabled: false });
-    render(<ActionBar {...props2} />);
+    renderActionBar(props2);
     fireEvent.pointerDown(screen.getByText(/manage/i));
     fireEvent.click(screen.getByText(/manage/i));
     fireEvent.click(screen.getByText(/enable tracking/i));
@@ -231,7 +237,7 @@ describe('ActionBar', () => {
   test('Jump to JSON appears and triggers event', () => {
     const onJumpToJson = jest.fn();
     const props = createProps({ showJumpToJson: true, onJumpToJson });
-    render(<ActionBar {...props} />);
+    renderActionBar(props);
     const btn = screen.getByRole('button', { name: /jump to json/i });
     fireEvent.click(btn);
     expect(onJumpToJson).toHaveBeenCalled();
@@ -245,21 +251,21 @@ describe('ActionBar', () => {
       soraToolsEnabled: true,
       userscriptInstalled: true,
     });
-    render(<ActionBar {...props} />);
+    renderActionBar(props);
     fireEvent.click(screen.getByRole('button', { name: /send to sora/i }));
     expect(onSend).toHaveBeenCalled();
   });
 
   test('Send to Sora button hidden when script missing', () => {
     const props = createProps({ userscriptInstalled: false });
-    render(<ActionBar {...props} />);
+    renderActionBar(props);
     expect(screen.queryByRole('button', { name: /send to sora/i })).toBeNull();
   });
 
   test('prompts to refresh when update is available and reloads on confirm', () => {
     mockUpdateAvailable = true;
     const props = createProps();
-    render(<ActionBar {...props} />);
+    renderActionBar(props);
     expect(toastFn).toHaveBeenCalled();
     const action = toastFn.mock.calls[0][0].action;
     expect(typeof action.props.onClick).toBe('function');
@@ -267,7 +273,7 @@ describe('ActionBar', () => {
 
   test('Minimize hides and restore shows bar again', () => {
     const props = createProps();
-    const { container } = render(<ActionBar {...props} />);
+    const { container } = renderActionBar(props);
     const minimize = container.querySelector(
       'button.ml-auto',
     ) as HTMLButtonElement;
@@ -283,7 +289,7 @@ describe('ActionBar', () => {
     localStorage.setItem(UNDO_MILESTONES, '[]');
     (trackEvent as jest.Mock).mockClear();
     const props = createProps();
-    const { unmount } = render(<ActionBar {...props} />);
+    const { unmount } = renderActionBar(props);
     const undoBtn = screen.getByRole('button', { name: /undo/i });
     fireEvent.click(undoBtn);
     expect(JSON.parse(localStorage.getItem(UNDO_COUNT) || '0')).toBe(100);
@@ -295,7 +301,7 @@ describe('ActionBar', () => {
       100,
     ]);
     unmount();
-    render(<ActionBar {...props} />);
+    renderActionBar(props);
     fireEvent.click(screen.getByRole('button', { name: /undo/i }));
     expect(JSON.parse(localStorage.getItem(UNDO_COUNT) || '0')).toBe(101);
     calls = (trackEvent as jest.Mock).mock.calls.filter(
@@ -312,7 +318,7 @@ describe('ActionBar', () => {
     localStorage.setItem(REDO_MILESTONES, '[]');
     (trackEvent as jest.Mock).mockClear();
     const props = createProps();
-    const { unmount } = render(<ActionBar {...props} />);
+    const { unmount } = renderActionBar(props);
     const redoBtn = screen.getByRole('button', { name: /redo/i });
     fireEvent.click(redoBtn);
     expect(JSON.parse(localStorage.getItem(REDO_COUNT) || '0')).toBe(100);
@@ -324,7 +330,7 @@ describe('ActionBar', () => {
       100,
     ]);
     unmount();
-    render(<ActionBar {...props} />);
+    renderActionBar(props);
     fireEvent.click(screen.getByRole('button', { name: /redo/i }));
     expect(JSON.parse(localStorage.getItem(REDO_COUNT) || '0')).toBe(101);
     calls = (trackEvent as jest.Mock).mock.calls.filter(

--- a/src/components/__tests__/BulkFileImportModal.test.tsx
+++ b/src/components/__tests__/BulkFileImportModal.test.tsx
@@ -54,7 +54,6 @@ describe('BulkFileImportModal', () => {
       target: { files: [file] },
     });
     const button = screen.getByRole('button', { name: /import/i });
-    expect(button.getAttribute('title')).toBe(i18n.t('import'));
     fireEvent.click(button);
     await waitFor(() =>
       expect(onImport).toHaveBeenCalledWith(['{"prompt":"test"}']),
@@ -90,7 +89,6 @@ describe('BulkFileImportModal', () => {
       target: { files: [file] },
     });
     const button = screen.getByRole('button', { name: /import/i });
-    expect(button.getAttribute('title')).toBe(i18n.t('import'));
     fireEvent.click(button);
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(i18n.t('failedImportFile')),
@@ -112,7 +110,6 @@ describe('BulkFileImportModal', () => {
     );
 
     const button = screen.getByRole('button', { name: /import/i });
-    expect(button.getAttribute('title')).toBe(i18n.t('import'));
     fireEvent.click(button);
 
     expect(toast.error).toHaveBeenCalledWith(i18n.t('pleaseSelectFile'));

--- a/src/components/__tests__/ClipboardImportModal.test.tsx
+++ b/src/components/__tests__/ClipboardImportModal.test.tsx
@@ -44,7 +44,6 @@ describe('ClipboardImportModal', () => {
     const textarea = screen.getByPlaceholderText(/paste json/i);
     fireEvent.change(textarea, { target: { value: '{"prompt":"test"}' } });
     const button = screen.getByRole('button', { name: /import/i });
-    expect(button.getAttribute('title')).toBe(i18n.t('import'));
     fireEvent.click(button);
 
     expect(onImport).toHaveBeenCalledWith(['{"prompt":"test"}']);
@@ -71,7 +70,6 @@ describe('ClipboardImportModal', () => {
       target: { value: arrayText },
     });
     const button = screen.getByRole('button', { name: /import/i });
-    expect(button.getAttribute('title')).toBe(i18n.t('import'));
     fireEvent.click(button);
 
     expect(onImport).toHaveBeenCalledWith([
@@ -104,7 +102,6 @@ describe('ClipboardImportModal', () => {
       target: { value: objectArrayText },
     });
     const button = screen.getByRole('button', { name: /import/i });
-    expect(button.getAttribute('title')).toBe(i18n.t('import'));
     fireEvent.click(button);
 
     expect(onImport).toHaveBeenCalledWith([
@@ -131,7 +128,6 @@ describe('ClipboardImportModal', () => {
     const textarea = screen.getByPlaceholderText(/paste json/i);
     fireEvent.change(textarea, { target: { value: '{bad json' } });
     const button = screen.getByRole('button', { name: /import/i });
-    expect(button.getAttribute('title')).toBe(i18n.t('import'));
     fireEvent.click(button);
 
     expect(toast.error).toHaveBeenCalledWith(i18n.t('invalidJson'));

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -36,7 +36,6 @@ describe('ErrorBoundary', () => {
     );
 
     const button = screen.getByRole('button', { name: i18n.t('tryAgain') });
-    expect(button.getAttribute('title')).toBe(i18n.t('tryAgain'));
     fireEvent.click(button);
 
     expect(screen.queryByText(i18n.t('somethingWentWrong'))).toBeNull();

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -54,7 +54,6 @@ describe('Footer', () => {
     const onShowDisclaimer = jest.fn();
     render(<Footer onShowDisclaimer={onShowDisclaimer} />);
     const button = screen.getByRole('button', { name: i18n.t('disclaimer') });
-    expect(button.getAttribute('title')).toBe(i18n.t('disclaimer'));
     fireEvent.click(button);
     expect(onShowDisclaimer).toHaveBeenCalledTimes(1);
   });

--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -14,6 +14,7 @@ import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
 import { formatDateTime } from '@/lib/date';
 import { safeGet, safeSet, safeRemove } from '@/lib/storage';
 import { TRACKING_HISTORY } from '@/lib/storage-keys';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 jest.mock('@/lib/analytics', () => {
   const actual = jest.requireActual('@/lib/analytics');
@@ -97,7 +98,11 @@ function renderPanel(
     onEdit: jest.fn(),
     onImport: jest.fn(),
   };
-  return render(<HistoryPanel {...defaultProps} {...props} />);
+  return render(
+    <TooltipProvider>
+      <HistoryPanel {...defaultProps} {...props} />
+    </TooltipProvider>,
+  );
 }
 
 beforeEach(() => {
@@ -121,7 +126,6 @@ describe('HistoryPanel basic actions', () => {
   test('exports to clipboard and file', async () => {
     renderPanel();
     const exportBtn = screen.getByRole('button', { name: /^export$/i });
-    expect(exportBtn.getAttribute('title')).toBe(i18n.t('export'));
     fireEvent.mouseDown(exportBtn);
     fireEvent.click(exportBtn);
     fireEvent.click(screen.getByText(/copy all to clipboard/i));
@@ -147,7 +151,6 @@ describe('HistoryPanel basic actions', () => {
     (trackEvent as jest.Mock).mockClear();
 
     const exportBtn = screen.getByRole('button', { name: /^export$/i });
-    expect(exportBtn.getAttribute('title')).toBe(i18n.t('export'));
     fireEvent.mouseDown(exportBtn);
     fireEvent.click(exportBtn);
     fireEvent.click(screen.getByText(/copy all to clipboard/i));
@@ -278,11 +281,7 @@ describe('HistoryPanel action history', () => {
     const deleteBtn = within(entry).getByRole('button', {
       name: i18n.t('delete'),
     });
-    expect(deleteBtn.getAttribute('aria-label')).toBe(i18n.t('delete'));
-    expect(deleteBtn.getAttribute('title')).toBe(i18n.t('delete'));
     fireEvent.click(deleteBtn);
-    expect(deleteBtn.getAttribute('aria-label')).toBe(i18n.t('confirm'));
-    expect(deleteBtn.getAttribute('title')).toBe(i18n.t('confirm'));
     fireEvent.click(deleteBtn);
 
     expect(safeSet).toHaveBeenCalledWith(TRACKING_HISTORY, [], true);

--- a/src/components/__tests__/ImportModal.test.tsx
+++ b/src/components/__tests__/ImportModal.test.tsx
@@ -35,7 +35,6 @@ describe('ImportModal', () => {
     const textarea = screen.getByPlaceholderText(/paste json/i);
     fireEvent.change(textarea, { target: { value: '{"prompt":"test"}' } });
     const button = screen.getByRole('button', { name: /import/i });
-    expect(button.getAttribute('title')).toBe(i18n.t('import'));
     fireEvent.click(button);
 
     expect(onImport).toHaveBeenCalledWith('{"prompt":"test"}');
@@ -74,7 +73,6 @@ describe('ImportModal', () => {
     await waitFor(() => expect(textarea.value).toBe(fileContent));
 
     const button = screen.getByRole('button', { name: /import/i });
-    expect(button.getAttribute('title')).toBe(i18n.t('import'));
     fireEvent.click(button);
 
     expect(onImport).toHaveBeenCalledWith(fileContent);
@@ -88,7 +86,6 @@ describe('ImportModal', () => {
     const textarea = screen.getByPlaceholderText(/paste json/i);
     fireEvent.change(textarea, { target: { value: '{bad json' } });
     const button = screen.getByRole('button', { name: /import/i });
-    expect(button.getAttribute('title')).toBe(i18n.t('import'));
     fireEvent.click(button);
 
     expect(toast.error).toHaveBeenCalledWith(i18n.t('invalidJson'));

--- a/src/components/__tests__/SettingsPanel.test.tsx
+++ b/src/components/__tests__/SettingsPanel.test.tsx
@@ -95,7 +95,6 @@ describe('SettingsPanel', () => {
   test('purge cache requires confirmation', async () => {
     renderPanel({ defaultTab: 'general' });
     const purgeBtn = screen.getByRole('button', { name: /purge cache/i });
-    expect(purgeBtn.getAttribute('title')).toBe(i18n.t('purgeCache'));
     fireEvent.click(purgeBtn);
     const confirmBtn = screen.getByRole('button', {
       name: i18n.t('purgeCacheConfirm'),
@@ -131,7 +130,6 @@ describe('SettingsPanel', () => {
     renderPanel({ defaultTab: 'general' });
 
     const exportBtn = screen.getByRole('button', { name: /export data/i });
-    expect(exportBtn.getAttribute('title')).toBe(i18n.t('exportData'));
     fireEvent.click(exportBtn);
     expect(exportAppData).toHaveBeenCalled();
     expect(URL.createObjectURL).toHaveBeenCalled();
@@ -144,7 +142,6 @@ describe('SettingsPanel', () => {
       }
     });
     const importBtn = screen.getByRole('button', { name: /import data/i });
-    expect(importBtn.getAttribute('title')).toBe(i18n.t('importData'));
     fireEvent.click(importBtn);
     await waitFor(() => expect(importAppData).toHaveBeenCalledWith({ b: 2 }));
     expect(toast.success).toHaveBeenCalledWith(i18n.t('dataImported'));

--- a/src/components/__tests__/ShareModal.test.tsx
+++ b/src/components/__tests__/ShareModal.test.tsx
@@ -15,6 +15,7 @@ import { toast } from '@/components/ui/sonner-toast';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { serializeOptions } from '@/lib/urlOptions';
 import { QRCodeSVG } from 'qrcode.react';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 jest.mock('qrcode.react', () => ({
   __esModule: true,
@@ -41,12 +42,14 @@ jest.mock('@/components/ui/sonner-toast', () => ({
 
 function renderModal() {
   return render(
-    <ShareModal
-      isOpen={true}
-      onClose={() => {}}
-      jsonContent="myjson"
-      options={DEFAULT_OPTIONS}
-    />,
+    <TooltipProvider>
+      <ShareModal
+        isOpen={true}
+        onClose={() => {}}
+        jsonContent="myjson"
+        options={DEFAULT_OPTIONS}
+      />
+    </TooltipProvider>,
   );
 }
 
@@ -70,12 +73,14 @@ describe('ShareModal', () => {
 
   test('does not render when closed', () => {
     render(
-      <ShareModal
-        isOpen={false}
-        onClose={() => {}}
-        jsonContent="myjson"
-        options={DEFAULT_OPTIONS}
-      />,
+      <TooltipProvider>
+        <ShareModal
+          isOpen={false}
+          onClose={() => {}}
+          jsonContent="myjson"
+          options={DEFAULT_OPTIONS}
+        />
+      </TooltipProvider>,
     );
     expect(screen.queryByText(/Share your JSON prompt/i)).toBeNull();
     expect(openSpy).not.toHaveBeenCalled();
@@ -226,7 +231,6 @@ describe('ShareModal', () => {
     });
     renderModal();
     const btn = screen.getByRole('button', { name: /copy link/i });
-    expect(btn.getAttribute('title')).toBe(i18n.t('copyLink'));
     fireEvent.click(btn);
     const shareUrl = new URL(window.location.href);
     shareUrl.searchParams.set('ref', 'share');

--- a/src/components/history/HistoryItem.tsx
+++ b/src/components/history/HistoryItem.tsx
@@ -4,6 +4,11 @@ import { Clipboard, Trash2, Edit, Eye, Check } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
 import type { HistoryEntry } from '../HistoryPanel';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 interface HistoryItemProps {
   entry: HistoryEntry;
@@ -45,67 +50,85 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
         }
       })()}
       <div className="flex flex-wrap gap-2">
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => {
-            trackEvent(trackingEnabled, AnalyticsEvent.HistoryEdit);
-            onEdit(entry.json);
-            setEdited(true);
-            setTimeout(() => setEdited(false), 1500);
-          }}
-          className={`gap-1 ${edited ? 'text-green-600 animate-pulse' : ''}`}
-          title={edited ? t('edited') : t('edit')}
-        >
-          {edited ? <Check className="w-4 h-4" /> : <Edit className="w-4 h-4" />}{' '}
-          {edited ? t('edited') : t('edit')}
-        </Button>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => {
-            trackEvent(trackingEnabled, AnalyticsEvent.HistoryCopy);
-            onCopy(entry.json);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1500);
-          }}
-          className={`gap-1 ${copied ? 'text-green-600 animate-pulse' : ''}`}
-          title={copied ? t('copied') : t('copy')}
-        >
-          {copied ? <Check className="w-4 h-4" /> : <Clipboard className="w-4 h-4" />}{' '}
-          {copied ? t('copied') : t('copy')}
-        </Button>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => {
-            trackEvent(trackingEnabled, AnalyticsEvent.HistoryPreview);
-            onPreview(entry);
-          }}
-          className="gap-1"
-          title={t('preview')}
-        >
-          <Eye className="w-4 h-4" /> {t('preview')}
-        </Button>
-        <Button
-          size="sm"
-          variant="destructive"
-          onClick={() => {
-            if (confirmDelete) {
-              trackEvent(trackingEnabled, AnalyticsEvent.HistoryDeleteConfirm);
-              onDelete(entry.id);
-              setConfirmDelete(false);
-            } else {
-              setConfirmDelete(true);
-              setTimeout(() => setConfirmDelete(false), 1500);
-            }
-          }}
-          className={`gap-1 ${confirmDelete ? 'animate-pulse' : ''}`}
-          title={confirmDelete ? t('confirm') : t('delete')}
-        >
-          <Trash2 className="w-4 h-4" />
-          {confirmDelete ? t('confirm') : t('delete')}
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                trackEvent(trackingEnabled, AnalyticsEvent.HistoryEdit);
+                onEdit(entry.json);
+                setEdited(true);
+                setTimeout(() => setEdited(false), 1500);
+              }}
+              className={`gap-1 ${edited ? 'text-green-600 animate-pulse' : ''}`}
+            >
+              {edited ? <Check className="w-4 h-4" /> : <Edit className="w-4 h-4" />}{' '}
+              {edited ? t('edited') : t('edit')}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{edited ? t('edited') : t('edit')}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                trackEvent(trackingEnabled, AnalyticsEvent.HistoryCopy);
+                onCopy(entry.json);
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1500);
+              }}
+              className={`gap-1 ${copied ? 'text-green-600 animate-pulse' : ''}`}
+            >
+              {copied ? <Check className="w-4 h-4" /> : <Clipboard className="w-4 h-4" />}{' '}
+              {copied ? t('copied') : t('copy')}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{copied ? t('copied') : t('copy')}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                trackEvent(trackingEnabled, AnalyticsEvent.HistoryPreview);
+                onPreview(entry);
+              }}
+              className="gap-1"
+            >
+              <Eye className="w-4 h-4" /> {t('preview')}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('preview')}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => {
+                if (confirmDelete) {
+                  trackEvent(trackingEnabled, AnalyticsEvent.HistoryDeleteConfirm);
+                  onDelete(entry.id);
+                  setConfirmDelete(false);
+                } else {
+                  setConfirmDelete(true);
+                  setTimeout(() => setConfirmDelete(false), 1500);
+                }
+              }}
+              className={`gap-1 ${confirmDelete ? 'animate-pulse' : ''}`}
+            >
+              <Trash2 className="w-4 h-4" />
+              {confirmDelete ? t('confirm') : t('delete')}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {confirmDelete ? t('confirm') : t('delete')}
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -6,6 +6,11 @@ import { ArrowLeft, ArrowRight } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 type CarouselApi = UseEmblaCarouselType[1];
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
@@ -199,25 +204,29 @@ const CarouselPrevious = React.forwardRef<
   const { orientation, scrollPrev, canScrollPrev } = useCarousel();
 
   return (
-    <Button
-      ref={ref}
-      variant={variant}
-      size={size}
-      className={cn(
-        'absolute  h-8 w-8 rounded-full',
-        orientation === 'horizontal'
-          ? '-left-12 top-1/2 -translate-y-1/2'
-          : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
-        className,
-      )}
-      disabled={!canScrollPrev}
-      onClick={scrollPrev}
-      title="Previous slide"
-      {...props}
-    >
-      <ArrowLeft className="h-4 w-4" />
-      <span className="sr-only">Previous slide</span>
-    </Button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          ref={ref}
+          variant={variant}
+          size={size}
+          className={cn(
+            'absolute  h-8 w-8 rounded-full',
+            orientation === 'horizontal'
+              ? '-left-12 top-1/2 -translate-y-1/2'
+              : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
+            className,
+          )}
+          disabled={!canScrollPrev}
+          onClick={scrollPrev}
+          {...props}
+        >
+          <ArrowLeft className="h-4 w-4" />
+          <span className="sr-only">Previous slide</span>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Previous slide</TooltipContent>
+    </Tooltip>
   );
 });
 CarouselPrevious.displayName = 'CarouselPrevious';
@@ -229,25 +238,29 @@ const CarouselNext = React.forwardRef<
   const { orientation, scrollNext, canScrollNext } = useCarousel();
 
   return (
-    <Button
-      ref={ref}
-      variant={variant}
-      size={size}
-      className={cn(
-        'absolute h-8 w-8 rounded-full',
-        orientation === 'horizontal'
-          ? '-right-12 top-1/2 -translate-y-1/2'
-          : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
-        className,
-      )}
-      disabled={!canScrollNext}
-      onClick={scrollNext}
-      title="Next slide"
-      {...props}
-    >
-      <ArrowRight className="h-4 w-4" />
-      <span className="sr-only">Next slide</span>
-    </Button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          ref={ref}
+          variant={variant}
+          size={size}
+          className={cn(
+            'absolute h-8 w-8 rounded-full',
+            orientation === 'horizontal'
+              ? '-right-12 top-1/2 -translate-y-1/2'
+              : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
+            className,
+          )}
+          disabled={!canScrollNext}
+          onClick={scrollNext}
+          {...props}
+        >
+          <ArrowRight className="h-4 w-4" />
+          <span className="sr-only">Next slide</span>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Next slide</TooltipContent>
+    </Tooltip>
   );
 });
 CarouselNext.displayName = 'CarouselNext';

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -4,6 +4,11 @@ import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ButtonProps } from '@/components/ui/button';
 import { buttonVariants } from '@/components/ui/button-variants';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (
   <nav
@@ -64,16 +69,20 @@ const PaginationPrevious = ({
   className,
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink
-    aria-label="Go to previous page"
-    size="default"
-    className={cn('gap-1 pl-2.5', className)}
-    title="Previous"
-    {...props}
-  >
-    <ChevronLeft className="h-4 w-4" />
-    <span>Previous</span>
-  </PaginationLink>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <PaginationLink
+        aria-label="Go to previous page"
+        size="default"
+        className={cn('gap-1 pl-2.5', className)}
+        {...props}
+      >
+        <ChevronLeft className="h-4 w-4" />
+        <span>Previous</span>
+      </PaginationLink>
+    </TooltipTrigger>
+    <TooltipContent>Previous</TooltipContent>
+  </Tooltip>
 );
 PaginationPrevious.displayName = 'PaginationPrevious';
 
@@ -81,16 +90,20 @@ const PaginationNext = ({
   className,
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink
-    aria-label="Go to next page"
-    size="default"
-    className={cn('gap-1 pr-2.5', className)}
-    title="Next"
-    {...props}
-  >
-    <span>Next</span>
-    <ChevronRight className="h-4 w-4" />
-  </PaginationLink>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <PaginationLink
+        aria-label="Go to next page"
+        size="default"
+        className={cn('gap-1 pr-2.5', className)}
+        {...props}
+      >
+        <span>Next</span>
+        <ChevronRight className="h-4 w-4" />
+      </PaginationLink>
+    </TooltipTrigger>
+    <TooltipContent>Next</TooltipContent>
+  </Tooltip>
 );
 PaginationNext.displayName = 'PaginationNext';
 

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -122,7 +122,7 @@ const SidebarProvider = React.forwardRef<
 
     return (
       <SidebarContext.Provider value={contextValue}>
-        <TooltipProvider delayDuration={0}>
+        <TooltipProvider delayDuration={5000}>
           <div
             style={
               {
@@ -257,22 +257,26 @@ const SidebarTrigger = React.forwardRef<
   const { toggleSidebar } = useSidebar();
 
   return (
-    <Button
-      ref={ref}
-      data-sidebar="trigger"
-      variant="ghost"
-      size="icon"
-      className={cn('h-7 w-7', className)}
-      onClick={(event) => {
-        onClick?.(event);
-        toggleSidebar();
-      }}
-      title="Toggle Sidebar"
-      {...props}
-    >
-      <PanelLeft />
-      <span className="sr-only">Toggle Sidebar</span>
-    </Button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          ref={ref}
+          data-sidebar="trigger"
+          variant="ghost"
+          size="icon"
+          className={cn('h-7 w-7', className)}
+          onClick={(event) => {
+            onClick?.(event);
+            toggleSidebar();
+          }}
+          {...props}
+        >
+          <PanelLeft />
+          <span className="sr-only">Toggle Sidebar</span>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Toggle Sidebar</TooltipContent>
+    </Tooltip>
   );
 });
 SidebarTrigger.displayName = 'SidebarTrigger';
@@ -284,24 +288,28 @@ const SidebarRail = React.forwardRef<
   const { toggleSidebar } = useSidebar();
 
   return (
-    <button
-      ref={ref}
-      data-sidebar="rail"
-      aria-label="Toggle Sidebar"
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title="Toggle Sidebar"
-      className={cn(
-        'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
-        '[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize',
-        '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
-        'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar',
-        '[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
-        '[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
-        className,
-      )}
-      {...props}
-    />
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          ref={ref}
+          data-sidebar="rail"
+          aria-label="Toggle Sidebar"
+          tabIndex={-1}
+          onClick={toggleSidebar}
+          className={cn(
+            'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
+            '[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize',
+            '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
+            'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar',
+            '[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
+            '[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
+            className,
+          )}
+          {...props}
+        />
+      </TooltipTrigger>
+      <TooltipContent>Toggle Sidebar</TooltipContent>
+    </Tooltip>
   );
 });
 SidebarRail.displayName = 'SidebarRail';


### PR DESCRIPTION
## Summary
- delay tooltip appearance globally to 5s while showing milestone badges instantly
- centralize TooltipProvider for tests to avoid missing context errors
- drop deprecated `title` attribute checks in component tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8b98a0d908325baa124de89167ccc