### PR TITLE
feat: add core action label toggle

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -89,6 +89,8 @@ interface ActionBarProps {
   onToggleLogo: () => void;
   actionLabelsEnabled: boolean;
   onToggleActionLabels: () => void;
+  coreActionLabelsOnly: boolean;
+  onToggleCoreActionLabels: () => void;
   copied: boolean;
   showJumpToJson?: boolean;
   onJumpToJson?: () => void;
@@ -129,6 +131,8 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   onToggleLogo,
   actionLabelsEnabled,
   onToggleActionLabels,
+  coreActionLabelsOnly,
+  onToggleCoreActionLabels,
   copied,
   showJumpToJson,
   onJumpToJson,
@@ -341,9 +345,10 @@ const { toast: notify } = useToast();
             onClick={() => setShowSettings(true)}
             variant="outline"
             size="sm"
-            className={cn({ 'gap-2': actionLabelsEnabled })}
+            className={cn({ 'gap-2': actionLabelsEnabled && !coreActionLabelsOnly })}
           >
-            <Cog className="w-4 h-4" /> {actionLabelsEnabled && t('manage')}
+            <Cog className="w-4 h-4" />
+            {actionLabelsEnabled && !coreActionLabelsOnly && t('manage')}
           </Button>
         </TooltipTrigger>
         <TooltipContent>{t('manage')}</TooltipContent>
@@ -355,10 +360,10 @@ const { toast: notify } = useToast();
               <Button
                 variant="outline"
                 size="sm"
-                className={cn({ 'gap-2': actionLabelsEnabled })}
+                className={cn({ 'gap-2': actionLabelsEnabled && !coreActionLabelsOnly })}
               >
                 <Languages className="w-4 h-4" />
-                {actionLabelsEnabled && t('language')}
+                {actionLabelsEnabled && !coreActionLabelsOnly && t('language')}
               </Button>
             </DropdownMenuTrigger>
           </TooltipTrigger>
@@ -662,10 +667,10 @@ const { toast: notify } = useToast();
             onClick={onHistory}
             variant="outline"
             size="sm"
-            className={cn({ 'gap-2': actionLabelsEnabled })}
+            className={cn({ 'gap-2': actionLabelsEnabled && !coreActionLabelsOnly })}
           >
             <History className="w-4 h-4" />
-            {actionLabelsEnabled && t('history')}
+            {actionLabelsEnabled && !coreActionLabelsOnly && t('history')}
           </Button>
         </TooltipTrigger>
         <TooltipContent>{t('history')}</TooltipContent>
@@ -680,10 +685,10 @@ const { toast: notify } = useToast();
               }}
               variant="outline"
               size="sm"
-              className={cn({ 'gap-2': actionLabelsEnabled })}
+              className={cn({ 'gap-2': actionLabelsEnabled && !coreActionLabelsOnly })}
             >
               <MoveDown className="w-4 h-4" />
-              {actionLabelsEnabled && t('jumpToJson')}
+              {actionLabelsEnabled && !coreActionLabelsOnly && t('jumpToJson')}
             </Button>
           </TooltipTrigger>
           <TooltipContent>{t('jumpToJson')}</TooltipContent>
@@ -715,6 +720,8 @@ const { toast: notify } = useToast();
         onToggleLogo={onToggleLogo}
         actionLabelsEnabled={actionLabelsEnabled}
         onToggleActionLabels={onToggleActionLabels}
+        coreActionLabelsOnly={coreActionLabelsOnly}
+        onToggleCoreActionLabels={onToggleCoreActionLabels}
       />
     </div>
   );

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -29,6 +29,7 @@ import { useSoraTools } from '@/hooks/use-sora-tools';
 import { useHeaderButtons } from '@/hooks/use-header-buttons';
 import { useLogo } from '@/hooks/use-logo';
 import { useActionLabels } from '@/hooks/use-action-labels';
+import { useCoreActionLabels } from '@/hooks/use-core-action-labels';
 import { useSoraUserscript } from '@/hooks/use-sora-userscript';
 import { useActionHistory } from '@/hooks/use-action-history';
 import { useUndoRedo } from '@/hooks/use-undo-redo';
@@ -133,6 +134,7 @@ const Dashboard = () => {
   const [headerButtonsEnabled, setHeaderButtonsEnabled] = useHeaderButtons();
   const [logoEnabled, setLogoEnabled] = useLogo();
   const [actionLabelsEnabled, setActionLabelsEnabled] = useActionLabels();
+  const [coreActionLabelsOnly, setCoreActionLabelsOnly] = useCoreActionLabels();
   const [userscriptInstalled, userscriptVersion] = useSoraUserscript();
   const actionHistory = useActionHistory();
   const githubStats = useGithubStats();
@@ -793,6 +795,10 @@ const Dashboard = () => {
         actionLabelsEnabled={actionLabelsEnabled}
         onToggleActionLabels={() =>
           setActionLabelsEnabled(!actionLabelsEnabled)
+        }
+        coreActionLabelsOnly={coreActionLabelsOnly}
+        onToggleCoreActionLabels={() =>
+          setCoreActionLabelsOnly(!coreActionLabelsOnly)
         }
         copied={copied}
         showJumpToJson={isSingleColumn}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -72,6 +72,8 @@ interface SettingsPanelProps {
   onToggleLogo: () => void;
   actionLabelsEnabled: boolean;
   onToggleActionLabels: () => void;
+  coreActionLabelsOnly: boolean;
+  onToggleCoreActionLabels: () => void;
   defaultTab?: 'manage' | 'general' | 'milestones';
 }
 
@@ -116,6 +118,8 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   onToggleLogo,
   actionLabelsEnabled,
   onToggleActionLabels,
+  coreActionLabelsOnly,
+  onToggleCoreActionLabels,
   defaultTab = 'manage',
 }) => {
   const { t } = useTranslation();
@@ -532,6 +536,48 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                       {actionLabelsEnabled
                         ? t('shortenButtons')
                         : t('showLabels')}
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={() => {
+                          try {
+                            onToggleCoreActionLabels();
+                            toast.success(
+                              !coreActionLabelsOnly
+                                ? t('coreLabelsOnly')
+                                : t('showAllLabels'),
+                            );
+                            trackEvent(
+                              trackingEnabled,
+                              AnalyticsEvent.ToggleCoreActionLabels,
+                              {
+                                enabled: !coreActionLabelsOnly,
+                              },
+                            );
+                          } catch {
+                            toast.error('Failed to toggle core action labels');
+                          }
+                        }}
+                      >
+                        {coreActionLabelsOnly ? (
+                          <>
+                            <Eye className="w-4 h-4" /> {t('showAllLabels')}
+                          </>
+                        ) : (
+                          <>
+                            <EyeOff className="w-4 h-4" /> {t('coreLabelsOnly')}
+                          </>
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {coreActionLabelsOnly
+                        ? t('showAllLabels')
+                        : t('coreLabelsOnly')}
                     </TooltipContent>
                   </Tooltip>
                   <Tooltip>

--- a/src/components/__tests__/ActionBar.test.tsx
+++ b/src/components/__tests__/ActionBar.test.tsx
@@ -148,6 +148,8 @@ function createProps(
     onToggleLogo: jest.fn(),
     actionLabelsEnabled: true,
     onToggleActionLabels: jest.fn(),
+    coreActionLabelsOnly: false,
+    onToggleCoreActionLabels: jest.fn(),
     copied: false,
     trackingEnabled: true,
     ...overrides,
@@ -242,6 +244,16 @@ describe('ActionBar', () => {
     fireEvent.click(btn);
     expect(onJumpToJson).toHaveBeenCalled();
     expect(trackEvent).toHaveBeenCalledWith(true, AnalyticsEvent.JumpToJson);
+  });
+
+  test('hides non-core labels when coreActionLabelsOnly is true', () => {
+    const props = createProps({ coreActionLabelsOnly: true, showJumpToJson: true });
+    renderActionBar(props);
+    expect(screen.getByText(/undo/i)).toBeTruthy();
+    expect(screen.queryByText(/manage/i)).toBeNull();
+    expect(screen.queryByText(/language/i)).toBeNull();
+    expect(screen.queryByText(/history/i)).toBeNull();
+    expect(screen.queryByText(/jump to json/i)).toBeNull();
   });
 
   test('Send to Sora button appears and calls handler', () => {

--- a/src/components/__tests__/Dashboard.sendToSoraTimeout.test.tsx
+++ b/src/components/__tests__/Dashboard.sendToSoraTimeout.test.tsx
@@ -59,6 +59,10 @@ jest.mock('@/hooks/use-action-labels', () => ({
   __esModule: true,
   useActionLabels: jest.fn(() => [false, jest.fn()] as const),
 }));
+jest.mock('@/hooks/use-core-action-labels', () => ({
+  __esModule: true,
+  useCoreActionLabels: jest.fn(() => [false, jest.fn()] as const),
+}));
 jest.mock('@/hooks/use-sora-userscript', () => ({
   __esModule: true,
   useSoraUserscript: jest.fn(() => [true, '1.0'] as const),

--- a/src/components/__tests__/SettingsPanel.test.tsx
+++ b/src/components/__tests__/SettingsPanel.test.tsx
@@ -86,6 +86,8 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof SettingsPane
     onToggleLogo: jest.fn(),
     actionLabelsEnabled: true,
     onToggleActionLabels: jest.fn(),
+    coreActionLabelsOnly: false,
+    onToggleCoreActionLabels: jest.fn(),
     ...overrides,
   };
   return render(<SettingsPanel {...props} />);

--- a/src/hooks/__tests__/use-core-action-labels.test.ts
+++ b/src/hooks/__tests__/use-core-action-labels.test.ts
@@ -1,0 +1,30 @@
+import { renderHook, act } from '@testing-library/react';
+import { useCoreActionLabels } from '../use-core-action-labels';
+
+describe('useCoreActionLabels', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  test('initializes state from localStorage', () => {
+    const getSpy = jest.spyOn(Storage.prototype, 'getItem');
+    localStorage.setItem('coreActionLabelsOnly', 'true');
+    const { result } = renderHook(() => useCoreActionLabels());
+    expect(result.current[0]).toBe(true);
+    expect(getSpy).toHaveBeenCalledWith('coreActionLabelsOnly');
+  });
+
+  test('persists state changes to localStorage', () => {
+    const setSpy = jest.spyOn(Storage.prototype, 'setItem');
+    const { result } = renderHook(() => useCoreActionLabels());
+
+    act(() => {
+      result.current[1](true);
+    });
+
+    expect(localStorage.getItem('coreActionLabelsOnly')).toBe('true');
+    expect(setSpy).toHaveBeenCalledWith('coreActionLabelsOnly', 'true');
+  });
+});
+

--- a/src/hooks/use-core-action-labels.ts
+++ b/src/hooks/use-core-action-labels.ts
@@ -1,0 +1,11 @@
+import { useLocalStorageState } from './use-local-storage-state';
+import { CORE_ACTION_LABELS_ONLY } from '@/lib/storage-keys';
+
+/**
+ * Toggles whether action labels are limited to core actions only.
+ * Defaults to `false` and persists the setting in localStorage.
+ */
+export function useCoreActionLabels() {
+  return useLocalStorageState(CORE_ACTION_LABELS_ONLY, false);
+}
+

--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -5,6 +5,7 @@ import {
   HEADER_BUTTONS_ENABLED,
   LOGO_ENABLED,
   ACTION_LABELS_ENABLED,
+  CORE_ACTION_LABELS_ONLY,
   TRACKING_ENABLED,
   TRACKING_HISTORY,
   LOCALE,
@@ -26,6 +27,7 @@ describe('constants', () => {
     expect(HEADER_BUTTONS_ENABLED).toBe('headerButtonsEnabled');
     expect(LOGO_ENABLED).toBe('logoEnabled');
     expect(ACTION_LABELS_ENABLED).toBe('actionLabelsEnabled');
+    expect(CORE_ACTION_LABELS_ONLY).toBe('coreActionLabelsOnly');
     expect(TRACKING_ENABLED).toBe('trackingEnabled');
     expect(TRACKING_HISTORY).toBe('trackingHistory');
     expect(LOCALE).toBe('locale');

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -20,6 +20,7 @@ export enum AnalyticsEvent {
   ToggleHeaderButtons = 'toggle_header_buttons',
   ToggleLogo = 'toggle_logo',
   ToggleActionLabels = 'toggle_action_labels',
+  ToggleCoreActionLabels = 'toggle_core_action_labels',
   PurgeCache = 'purge_cache',
   DisableTrackingConfirm = 'disable_tracking_confirm',
   ToggleTracking = 'toggle_tracking',

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -3,6 +3,7 @@ export const SORA_TOOLS_ENABLED = 'soraToolsEnabled';
 export const HEADER_BUTTONS_ENABLED = 'headerButtonsEnabled';
 export const LOGO_ENABLED = 'logoEnabled';
 export const ACTION_LABELS_ENABLED = 'actionLabelsEnabled';
+export const CORE_ACTION_LABELS_ONLY = 'coreActionLabelsOnly';
 export const TRACKING_ENABLED = 'trackingEnabled';
 export const TRACKING_HISTORY = 'trackingHistory';
 export const LOCALE = 'locale';

--- a/src/locales/bn-IN.json
+++ b/src/locales/bn-IN.json
@@ -46,6 +46,8 @@
   "showLabels": "লেবেল দেখান",
   "hideLabels": "লেবেল লুকান",
   "shortenButtons": "বোতাম সংক্ষিপ্ত করুন",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "ভাষা",
   "appName": "Sora JSON প্রম্পট ক্রাফটার",
   "tagline": "Sora‑র জেনারেশন সেটিংস কনফিগার করুন এবং অসাধারণ AI‑জেনারেটেড কনটেন্টের জন্য নিখুঁত JSON প্রম্পট তৈরি করুন।",

--- a/src/locales/da-DK.json
+++ b/src/locales/da-DK.json
@@ -46,6 +46,8 @@
   "showLabels": "Vis etiketter",
   "hideLabels": "Skjul etiketter",
   "shortenButtons": "Forkort knapper",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Sprog",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Konfigurer Soras genereringsindstillinger og få den perfekte JSON‑prompt til fantastisk AI‑genereret indhold.",

--- a/src/locales/de-AT.json
+++ b/src/locales/de-AT.json
@@ -46,6 +46,8 @@
   "showLabels": "Labels anzeigen",
   "hideLabels": "Labels ausblenden",
   "shortenButtons": "Schaltflächen kürzen",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Sprache",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Konfiguriere Soras Generierungseinstellungen und erhalte den perfekten JSON‑Prompt für beeindruckende KI‑Inhalte.",

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -46,6 +46,8 @@
   "showLabels": "Labels anzeigen",
   "hideLabels": "Labels ausblenden",
   "shortenButtons": "Schaltflächen verkürzen",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Sprache",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Konfiguriere Soras Generierungseinstellungen und erhalte den perfekten JSON-Prompt für beeindruckende KI-Inhalte.",

--- a/src/locales/el-GR.json
+++ b/src/locales/el-GR.json
@@ -46,6 +46,8 @@
   "showLabels": "Εμφάνιση ετικετών",
   "hideLabels": "Απόκρυψη ετικετών",
   "shortenButtons": "Σύντμηση κουμπιών",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Γλώσσα",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Διαμορφώστε τις ρυθμίσεις δημιουργίας του Sora και αποκτήστε το ιδανικό JSON prompt για εντυπωσιακό AI περιεχόμενο.",

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -46,6 +46,8 @@
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
   "shortenButtons": "Shorten Buttons",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Language",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure Sora's generation settings and get the perfect JSON prompt for stunning AI‑generated content.",

--- a/src/locales/en-PR.json
+++ b/src/locales/en-PR.json
@@ -46,6 +46,8 @@
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
   "shortenButtons": "Trim Buttons",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Tongue",
   "appName": "Sora JSON Prompt Forge",
   "tagline": "Trim Sora's sails an' snag the perfect JSON prompt fer plunder‑worthy AI booty.",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -46,6 +46,8 @@
   "showLabels": "Show Labels",
   "hideLabels": "Hide Labels",
   "shortenButtons": "Shorten Buttons",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Language",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Configure your Sora generation settings and get the perfect JSON prompt for stunning AI-generated content.",

--- a/src/locales/es-AR.json
+++ b/src/locales/es-AR.json
@@ -46,6 +46,8 @@
   "showLabels": "Mostrar etiquetas",
   "hideLabels": "Ocultar etiquetas",
   "shortenButtons": "Acortar botones",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Idioma",
   "appName": "Sora Creador de Prompts JSON",
   "tagline": "Configurá los ajustes de generación de Sora y obtené el prompt JSON perfecto para contenido IA increíble.",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -46,6 +46,8 @@
   "showLabels": "Mostrar etiquetas",
   "hideLabels": "Ocultar etiquetas",
   "shortenButtons": "Acortar botones",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Idioma",
   "appName": "Sora Creador de Prompts JSON",
   "tagline": "Configura los ajustes de generación de Sora y obtén el prompt JSON perfecto para contenido IA asombroso.",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -46,6 +46,8 @@
   "showLabels": "Mostrar etiquetas",
   "hideLabels": "Ocultar etiquetas",
   "shortenButtons": "Acortar botones",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Idioma",
   "appName": "Sora Creador de Prompts JSON",
   "tagline": "Configura los ajustes de generación de Sora y obtén el prompt JSON perfecto para contenido de IA impresionante.",

--- a/src/locales/et-EE.json
+++ b/src/locales/et-EE.json
@@ -46,6 +46,8 @@
   "showLabels": "Näita silte",
   "hideLabels": "Peida sildid",
   "shortenButtons": "Lühenda nupud",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Keel",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Seadista Sora generatsioonisätted ja hangi täiuslik JSON‑prompt vapustava tehisintellekti sisu jaoks.",

--- a/src/locales/fi-FI.json
+++ b/src/locales/fi-FI.json
@@ -46,6 +46,8 @@
   "showLabels": "Näytä tarrat",
   "hideLabels": "Piilota tarrat",
   "shortenButtons": "Lyhennä painikkeet",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Kieli",
   "appName": "Sora JSON‑kehotesepän työkalut",
   "tagline": "Säädä Soran generointiasetukset ja hanki täydellinen JSON‑kehote huikeaan tekoälysisältöön.",

--- a/src/locales/fr-BE.json
+++ b/src/locales/fr-BE.json
@@ -46,6 +46,8 @@
   "showLabels": "Afficher les étiquettes",
   "hideLabels": "Masquer les étiquettes",
   "shortenButtons": "Raccourcir les boutons",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Langue",
   "appName": "Sora Générateur de Prompts JSON",
   "tagline": "Configurez les paramètres de génération de Sora et obtenez le prompt JSON parfait pour un contenu IA épatant.",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -46,6 +46,8 @@
   "showLabels": "Afficher les étiquettes",
   "hideLabels": "Masquer les étiquettes",
   "shortenButtons": "Raccourcir les boutons",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Langue",
   "appName": "Générateur d'invites JSON Sora",
   "tagline": "Configurez les paramètres de génération de Sora et obtenez l'invite JSON parfaite pour créer un contenu IA époustouflant.",

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -46,6 +46,8 @@
   "showLabels": "Mostra etichette",
   "hideLabels": "Nascondi etichette",
   "shortenButtons": "Stringi pulsanti",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Lingua",
   "appName": "Generatore di prompt JSON di Sora",
   "tagline": "Configura le impostazioni di generazione di Sora e ottieni il prompt JSON perfetto per creare contenuti IA sorprendenti.",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -46,6 +46,8 @@
   "showLabels": "ラベルを表示",
   "hideLabels": "ラベルを非表示",
   "shortenButtons": "ボタンを短縮",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "言語",
   "appName": "Sora JSONプロンプトクラフター",
   "tagline": "Soraの生成設定を構成して、見事なAI生成コンテンツのための完璧なJSONプロンプトを手に入れましょう。",

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -46,6 +46,8 @@
   "showLabels": "라벨 표시",
   "hideLabels": "라벨 숨기기",
   "shortenButtons": "버튼 축소",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "언어",
   "appName": "Sora JSON 프롬프트 크래프터",
   "tagline": "Sora의 생성 설정을 구성하여 멋진 AI 생성 콘텐츠를 위한 완벽한 JSON 프롬프트를 얻으세요.",

--- a/src/locales/ne-NP.json
+++ b/src/locales/ne-NP.json
@@ -46,6 +46,8 @@
   "showLabels": "लेबल देखाउनुहोस्",
   "hideLabels": "लेबल लुकाउनुहोस्",
   "shortenButtons": "बटन छोट्याउनुहोस्",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "भाषा",
   "appName": "Sora JSON प्रम्प्ट क्राफ्टर",
   "tagline": "Sora को उत्पादन सेटिङहरू कन्फिगर गरेर उत्कृष्ट एआई सामग्रीका लागि उपयुक्त JSON प्रम्प्ट प्राप्त गर्नुहोस्।",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -46,6 +46,8 @@
   "showLabels": "Mostrar rótulos",
   "hideLabels": "Ocultar rótulos",
   "shortenButtons": "Reduzir botões",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Idioma",
   "appName": "Gerador de Prompt JSON do Sora",
   "tagline": "Configure as definições de geração do Sora e obtenha o prompt JSON perfeito para criar conteúdo de IA incrível.",

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -46,6 +46,8 @@
   "showLabels": "Mostrar Etiquetas",
   "hideLabels": "Ocultar Etiquetas",
   "shortenButtons": "Reduzir Botões",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Idioma",
   "appName": "Criador de Prompt JSON do Sora",
   "tagline": "Configure as definições de geração do Sora e obtenha o prompt JSON perfeito para criar conteúdo impressionante gerado por IA.",

--- a/src/locales/ro-RO.json
+++ b/src/locales/ro-RO.json
@@ -46,6 +46,8 @@
   "showLabels": "Arată etichete",
   "hideLabels": "Ascunde etichete",
   "shortenButtons": "Scurtează butoane",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Limbă",
   "appName": "Generator JSON Prompt Sora",
   "tagline": "Configurează setările de generare ale Sora și obține promptul JSON perfect pentru a crea conținut AI uimitor.",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -46,6 +46,8 @@
   "showLabels": "Показать метки",
   "hideLabels": "Скрыть метки",
   "shortenButtons": "Сократить кнопки",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Язык",
   "appName": "Конструктор JSON‑промптов Sora",
   "tagline": "Настройте параметры генерации Sora и получите идеальный JSON‑промпт для потрясающего ИИ‑контента.",

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -46,6 +46,8 @@
   "showLabels": "Visa etiketter",
   "hideLabels": "Dölj etiketter",
   "shortenButtons": "Förkorta knappar",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Språk",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Konfigurera Soras genereringsinställningar och få den perfekta JSON-prompten för fantastiskt AI-genererat innehåll.",

--- a/src/locales/th-TH.json
+++ b/src/locales/th-TH.json
@@ -46,6 +46,8 @@
   "showLabels": "แสดงป้ายกำกับ",
   "hideLabels": "ซ่อนป้ายกำกับ",
   "shortenButtons": "ลดความยาวปุ่ม",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "ภาษา",
   "appName": "เครื่องสร้างพรอมต์ JSON ของ Sora",
   "tagline": "กำหนดการตั้งค่าการสร้างของ Sora และรับพรอมต์ JSON ที่สมบูรณ์แบบเพื่อสร้างเนื้อหา AI ที่น่าทึ่ง",

--- a/src/locales/uk-UA.json
+++ b/src/locales/uk-UA.json
@@ -46,6 +46,8 @@
   "showLabels": "Показати мітки",
   "hideLabels": "Приховати мітки",
   "shortenButtons": "Скоротити кнопки",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "Мова",
   "appName": "Sora JSON Prompt Crafter",
   "tagline": "Налаштуйте параметри генерації Sora та отримайте досконалий JSON‑промпт для вражаючого AI‑контенту.",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -46,6 +46,8 @@
   "showLabels": "显示标签",
   "hideLabels": "隐藏标签",
   "shortenButtons": "缩短按钮",
+  "coreLabelsOnly": "Core Labels Only",
+  "showAllLabels": "Show All Labels",
   "language": "语言",
   "appName": "Sora JSON 提示生成器",
   "tagline": "配置 Sora 的生成设置，获取用于创建令人惊叹的 AI 内容的完美 JSON 提示。",


### PR DESCRIPTION
## Summary
- add `useCoreActionLabels` for saving core-only action label preference
- allow Settings panel to toggle core-only labels and track analytics
- respect core-only toggle across action buttons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9ecaaa33c8325aaf2733870419553