### PR TITLE
feat: add floating JSON view

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -87,6 +87,8 @@ interface ActionBarProps {
   onToggleHeaderButtons: () => void;
   logoEnabled: boolean;
   onToggleLogo: () => void;
+  floatingJsonEnabled: boolean;
+  onToggleFloatingJson: () => void;
   actionLabelsEnabled: boolean;
   onToggleActionLabels: () => void;
   coreActionLabelsOnly: boolean;
@@ -129,6 +131,8 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   onToggleHeaderButtons,
   logoEnabled,
   onToggleLogo,
+  floatingJsonEnabled,
+  onToggleFloatingJson,
   actionLabelsEnabled,
   onToggleActionLabels,
   coreActionLabelsOnly,
@@ -718,6 +722,8 @@ const { toast: notify } = useToast();
         onToggleHeaderButtons={onToggleHeaderButtons}
         logoEnabled={logoEnabled}
         onToggleLogo={onToggleLogo}
+        floatingJsonEnabled={floatingJsonEnabled}
+        onToggleFloatingJson={onToggleFloatingJson}
         actionLabelsEnabled={actionLabelsEnabled}
         onToggleActionLabels={onToggleActionLabels}
         coreActionLabelsOnly={coreActionLabelsOnly}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -30,6 +30,7 @@ import { useHeaderButtons } from '@/hooks/use-header-buttons';
 import { useLogo } from '@/hooks/use-logo';
 import { useActionLabels } from '@/hooks/use-action-labels';
 import { useCoreActionLabels } from '@/hooks/use-core-action-labels';
+import { useFloatingJson } from '@/hooks/use-floating-json';
 import { useSoraUserscript } from '@/hooks/use-sora-userscript';
 import { useActionHistory } from '@/hooks/use-action-history';
 import { useUndoRedo } from '@/hooks/use-undo-redo';
@@ -133,6 +134,7 @@ const Dashboard = () => {
   const [soraToolsEnabled, setSoraToolsEnabled] = useSoraTools();
   const [headerButtonsEnabled, setHeaderButtonsEnabled] = useHeaderButtons();
   const [logoEnabled, setLogoEnabled] = useLogo();
+  const [floatingJsonEnabled, setFloatingJsonEnabled] = useFloatingJson();
   const [actionLabelsEnabled, setActionLabelsEnabled] = useActionLabels();
   const [coreActionLabelsOnly, setCoreActionLabelsOnly] = useCoreActionLabels();
   const [userscriptInstalled, userscriptVersion] = useSoraUserscript();
@@ -747,25 +749,32 @@ const Dashboard = () => {
             </CardContent>
           </Card>
 
-          <Card
-            id="generated-json"
-            className="flex flex-col lg:sticky lg:top-4 lg:max-h-[calc(100vh-1rem)]"
-          >
-            <CardHeader className="border-b">
-              <CardTitle className="flex items-center gap-2">
-                <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-                {t('generatedJsonPrompt')}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="flex-1 p-0 overflow-hidden">
-              <GeneratedJson
-                json={jsonString}
-                trackingEnabled={trackingEnabled}
-              />
-            </CardContent>
-          </Card>
+          {(!isSingleColumn || !floatingJsonEnabled) && (
+            <Card
+              id="generated-json"
+              className="flex flex-col lg:sticky lg:top-4 lg:max-h-[calc(100vh-1rem)]"
+            >
+              <CardHeader className="border-b">
+                <CardTitle className="flex items-center gap-2">
+                  <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+                  {t('generatedJsonPrompt')}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="flex-1 p-0 overflow-hidden">
+                <GeneratedJson
+                  json={jsonString}
+                  trackingEnabled={trackingEnabled}
+                />
+              </CardContent>
+            </Card>
+          )}
         </div>
       </div>
+      {isSingleColumn && floatingJsonEnabled && (
+        <div className="fixed bottom-0 left-0 right-0 z-40 h-[40vh] max-h-[50vh] border-t bg-background">
+          <GeneratedJson json={jsonString} trackingEnabled={trackingEnabled} />
+        </div>
+      )}
 
       <ActionBar
         onUndo={undo}
@@ -792,6 +801,10 @@ const Dashboard = () => {
         }
         logoEnabled={logoEnabled}
         onToggleLogo={() => setLogoEnabled(!logoEnabled)}
+        floatingJsonEnabled={floatingJsonEnabled}
+        onToggleFloatingJson={() =>
+          setFloatingJsonEnabled(!floatingJsonEnabled)
+        }
         actionLabelsEnabled={actionLabelsEnabled}
         onToggleActionLabels={() =>
           setActionLabelsEnabled(!actionLabelsEnabled)
@@ -801,7 +814,7 @@ const Dashboard = () => {
           setCoreActionLabelsOnly(!coreActionLabelsOnly)
         }
         copied={copied}
-        showJumpToJson={isSingleColumn}
+        showJumpToJson={isSingleColumn && !floatingJsonEnabled}
         onJumpToJson={scrollToJson}
       />
       <ShareModal

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -70,6 +70,8 @@ interface SettingsPanelProps {
   onToggleHeaderButtons: () => void;
   logoEnabled: boolean;
   onToggleLogo: () => void;
+  floatingJsonEnabled: boolean;
+  onToggleFloatingJson: () => void;
   actionLabelsEnabled: boolean;
   onToggleActionLabels: () => void;
   coreActionLabelsOnly: boolean;
@@ -98,6 +100,8 @@ interface SettingsPanelProps {
  * @param onToggleHeaderButtons - Toggles header button visibility.
  * @param logoEnabled - Whether the logo is displayed.
  * @param onToggleLogo - Toggles logo visibility.
+ * @param floatingJsonEnabled - Whether floating JSON view is enabled.
+ * @param onToggleFloatingJson - Toggles floating JSON view.
  * @param actionLabelsEnabled - Whether action buttons display text labels.
  * @param onToggleActionLabels - Toggles action button labels.
  */
@@ -116,6 +120,8 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   onToggleHeaderButtons,
   logoEnabled,
   onToggleLogo,
+  floatingJsonEnabled,
+  onToggleFloatingJson,
   actionLabelsEnabled,
   onToggleActionLabels,
   coreActionLabelsOnly,
@@ -574,10 +580,52 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                         )}
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent>
+                  <TooltipContent>
                       {coreActionLabelsOnly
                         ? t('showAllLabels')
                         : t('coreLabelsOnly')}
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={() => {
+                          try {
+                            onToggleFloatingJson();
+                            toast.success(
+                              !floatingJsonEnabled
+                                ? t('enableFloatingJson')
+                                : t('disableFloatingJson'),
+                            );
+                            trackEvent(
+                              trackingEnabled,
+                              AnalyticsEvent.ToggleFloatingJson,
+                              { enabled: !floatingJsonEnabled },
+                            );
+                          } catch {
+                            toast.error('Failed to toggle floating JSON');
+                          }
+                        }}
+                      >
+                        {floatingJsonEnabled ? (
+                          <>
+                            <EyeOff className="w-4 h-4" />
+                            {t('disableFloatingJson')}
+                          </>
+                        ) : (
+                          <>
+                            <Eye className="w-4 h-4" />
+                            {t('enableFloatingJson')}
+                          </>
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {floatingJsonEnabled
+                        ? t('disableFloatingJson')
+                        : t('enableFloatingJson')}
                     </TooltipContent>
                   </Tooltip>
                   <Tooltip>

--- a/src/components/__tests__/ActionBar.test.tsx
+++ b/src/components/__tests__/ActionBar.test.tsx
@@ -34,6 +34,7 @@ jest.mock('../SettingsPanel', () => ({
     open: boolean;
     onToggleTracking: () => void;
     trackingEnabled: boolean;
+    [key: string]: unknown;
   }) =>
     open ? (
       <div>
@@ -146,6 +147,8 @@ function createProps(
     onToggleHeaderButtons: jest.fn(),
     logoEnabled: true,
     onToggleLogo: jest.fn(),
+    floatingJsonEnabled: false,
+    onToggleFloatingJson: jest.fn(),
     actionLabelsEnabled: true,
     onToggleActionLabels: jest.fn(),
     coreActionLabelsOnly: false,

--- a/src/components/__tests__/SettingsPanel.test.tsx
+++ b/src/components/__tests__/SettingsPanel.test.tsx
@@ -84,6 +84,8 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof SettingsPane
     onToggleHeaderButtons: jest.fn(),
     logoEnabled: true,
     onToggleLogo: jest.fn(),
+    floatingJsonEnabled: false,
+    onToggleFloatingJson: jest.fn(),
     actionLabelsEnabled: true,
     onToggleActionLabels: jest.fn(),
     coreActionLabelsOnly: false,

--- a/src/hooks/__tests__/use-floating-json.test.ts
+++ b/src/hooks/__tests__/use-floating-json.test.ts
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react';
+import { useFloatingJson } from '../use-floating-json';
+
+describe('useFloatingJson', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  test('initializes state from localStorage', () => {
+    const getSpy = jest.spyOn(Storage.prototype, 'getItem');
+    localStorage.setItem('floatingJsonEnabled', 'true');
+    const { result } = renderHook(() => useFloatingJson());
+    expect(result.current[0]).toBe(true);
+    expect(getSpy).toHaveBeenCalledWith('floatingJsonEnabled');
+  });
+
+  test('persists state changes to localStorage', () => {
+    const setSpy = jest.spyOn(Storage.prototype, 'setItem');
+    const { result } = renderHook(() => useFloatingJson());
+
+    act(() => {
+      result.current[1](true);
+    });
+
+    expect(localStorage.getItem('floatingJsonEnabled')).toBe('true');
+    expect(setSpy).toHaveBeenCalledWith('floatingJsonEnabled', 'true');
+  });
+});

--- a/src/hooks/use-floating-json.ts
+++ b/src/hooks/use-floating-json.ts
@@ -1,0 +1,12 @@
+import { useLocalStorageState } from './use-local-storage-state';
+import { FLOATING_JSON_ENABLED } from '@/lib/storage-keys';
+
+/**
+ * Persists user's preference for displaying the generated JSON as a floating
+ * panel on small screens.
+ *
+ * @returns A tuple containing the current enabled state and a setter.
+ */
+export function useFloatingJson() {
+  return useLocalStorageState(FLOATING_JSON_ENABLED, false);
+}

--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -4,6 +4,7 @@ import {
   SORA_TOOLS_ENABLED,
   HEADER_BUTTONS_ENABLED,
   LOGO_ENABLED,
+  FLOATING_JSON_ENABLED,
   ACTION_LABELS_ENABLED,
   CORE_ACTION_LABELS_ONLY,
   TRACKING_ENABLED,
@@ -26,6 +27,7 @@ describe('constants', () => {
     expect(SORA_TOOLS_ENABLED).toBe('soraToolsEnabled');
     expect(HEADER_BUTTONS_ENABLED).toBe('headerButtonsEnabled');
     expect(LOGO_ENABLED).toBe('logoEnabled');
+    expect(FLOATING_JSON_ENABLED).toBe('floatingJsonEnabled');
     expect(ACTION_LABELS_ENABLED).toBe('actionLabelsEnabled');
     expect(CORE_ACTION_LABELS_ONLY).toBe('coreActionLabelsOnly');
     expect(TRACKING_ENABLED).toBe('trackingEnabled');

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -21,6 +21,7 @@ export enum AnalyticsEvent {
   ToggleLogo = 'toggle_logo',
   ToggleActionLabels = 'toggle_action_labels',
   ToggleCoreActionLabels = 'toggle_core_action_labels',
+  ToggleFloatingJson = 'toggle_floating_json',
   PurgeCache = 'purge_cache',
   DisableTrackingConfirm = 'disable_tracking_confirm',
   ToggleTracking = 'toggle_tracking',

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -2,6 +2,7 @@ export const DARK_MODE = 'darkMode';
 export const SORA_TOOLS_ENABLED = 'soraToolsEnabled';
 export const HEADER_BUTTONS_ENABLED = 'headerButtonsEnabled';
 export const LOGO_ENABLED = 'logoEnabled';
+export const FLOATING_JSON_ENABLED = 'floatingJsonEnabled';
 export const ACTION_LABELS_ENABLED = 'actionLabelsEnabled';
 export const CORE_ACTION_LABELS_ONLY = 'coreActionLabelsOnly';
 export const TRACKING_ENABLED = 'trackingEnabled';

--- a/src/locales/bn-IN.json
+++ b/src/locales/bn-IN.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "হেডার বোতাম লুকান",
   "showLogo": "লোগো দেখান",
   "hideLogo": "লোগো লুকান",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "ইতিহাস",
   "jumpToJson": "JSON‑এ যান",
   "actions": "কর্মসমূহ",

--- a/src/locales/da-DK.json
+++ b/src/locales/da-DK.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Skjul header‑knapper",
   "showLogo": "Vis logo",
   "hideLogo": "Skjul logo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Historik",
   "jumpToJson": "Gå til JSON",
   "actions": "Handlinger",

--- a/src/locales/de-AT.json
+++ b/src/locales/de-AT.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Header‑Schaltflächen ausblenden",
   "showLogo": "Logo anzeigen",
   "hideLogo": "Logo ausblenden",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Verlauf",
   "jumpToJson": "Zu JSON springen",
   "actions": "Aktionen",

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Header-Schaltflächen ausblenden",
   "showLogo": "Logo anzeigen",
   "hideLogo": "Logo ausblenden",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Verlauf",
   "jumpToJson": "Zu JSON springen",
   "actions": "Aktionen",

--- a/src/locales/el-GR.json
+++ b/src/locales/el-GR.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Απόκρυψη κουμπιών κεφαλίδας",
   "showLogo": "Εμφάνιση λογοτύπου",
   "hideLogo": "Απόκρυψη λογοτύπου",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Ιστορικό",
   "jumpToJson": "Μετάβαση στο JSON",
   "actions": "Ενέργειες",

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Hide Header Buttons",
   "showLogo": "Show Logo",
   "hideLogo": "Hide Logo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "History",
   "jumpToJson": "Jump to JSON",
   "actions": "Actions",

--- a/src/locales/en-PR.json
+++ b/src/locales/en-PR.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Hide the Mast Buttons",
   "showLogo": "Show the Jolly Roger",
   "hideLogo": "Stow the Jolly Roger",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Logbook",
   "jumpToJson": "Leap to JSON",
   "actions": "Deeds",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Hide Header Buttons",
   "showLogo": "Show Logo",
   "hideLogo": "Hide Logo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "History",
   "jumpToJson": "Jump to JSON",
   "actions": "Actions",

--- a/src/locales/es-AR.json
+++ b/src/locales/es-AR.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Ocultar botones de encabezado",
   "showLogo": "Mostrar logo",
   "hideLogo": "Ocultar logo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Historial",
   "jumpToJson": "Ir al JSON",
   "actions": "Acciones",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Ocultar botones de cabecera",
   "showLogo": "Mostrar logotipo",
   "hideLogo": "Ocultar logotipo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Historial",
   "jumpToJson": "Ir al JSON",
   "actions": "Acciones",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Ocultar botones de encabezado",
   "showLogo": "Mostrar logo",
   "hideLogo": "Ocultar logo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Historial",
   "jumpToJson": "Ir al JSON",
   "actions": "Acciones",

--- a/src/locales/et-EE.json
+++ b/src/locales/et-EE.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Peida päise nupud",
   "showLogo": "Näita logo",
   "hideLogo": "Peida logo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Ajalugu",
   "jumpToJson": "Hüppa JSON-i",
   "actions": "Tegevused",

--- a/src/locales/fi-FI.json
+++ b/src/locales/fi-FI.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Piilota yläpalkin painikkeet",
   "showLogo": "Näytä logo",
   "hideLogo": "Piilota logo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Historia",
   "jumpToJson": "Siirry JSON‑tiedostoon",
   "actions": "Toiminnot",

--- a/src/locales/fr-BE.json
+++ b/src/locales/fr-BE.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Masquer les boutons d’en-tête",
   "showLogo": "Afficher le logo",
   "hideLogo": "Masquer le logo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Historique",
   "jumpToJson": "Aller au JSON",
   "actions": "Actions",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Masquer les boutons d'en-tête",
   "showLogo": "Afficher le logo",
   "hideLogo": "Masquer le logo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Historique",
   "jumpToJson": "Aller au JSON",
   "actions": "Actions",

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Nascondi pulsanti header",
   "showLogo": "Mostra logo",
   "hideLogo": "Nascondi logo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Cronologia",
   "jumpToJson": "Vai a JSON",
   "actions": "Azioni",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "ヘッダーボタンを非表示",
   "showLogo": "ロゴを表示",
   "hideLogo": "ロゴを非表示",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "履歴",
   "jumpToJson": "JSONへジャンプ",
   "actions": "アクション",

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "헤더 버튼 숨기기",
   "showLogo": "로고 표시",
   "hideLogo": "로고 숨기기",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "기록",
   "jumpToJson": "JSON으로 이동",
   "actions": "동작",

--- a/src/locales/ne-NP.json
+++ b/src/locales/ne-NP.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "हेडर बटन लुकाउनुहोस्",
   "showLogo": "लोगो देखाउनुहोस्",
   "hideLogo": "लोगो लुकाउनुहोस्",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "इतिहास",
   "jumpToJson": "JSON मा जानुहोस्",
   "actions": "कार्यहरू",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Ocultar botões de cabeçalho",
   "showLogo": "Mostrar logotipo",
   "hideLogo": "Ocultar logotipo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Histórico",
   "jumpToJson": "Ir para JSON",
   "actions": "Ações",

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Ocultar Botões de Cabeçalho",
   "showLogo": "Mostrar Logótipo",
   "hideLogo": "Ocultar Logótipo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Histórico",
   "jumpToJson": "Ir para JSON",
   "actions": "Ações",

--- a/src/locales/ro-RO.json
+++ b/src/locales/ro-RO.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Ascunde butoane header",
   "showLogo": "Arată logo",
   "hideLogo": "Ascunde logo",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Istoric",
   "jumpToJson": "Salt la JSON",
   "actions": "Acțiuni",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Скрыть кнопки заголовка",
   "showLogo": "Показать логотип",
   "hideLogo": "Скрыть логотип",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "История",
   "jumpToJson": "Перейти к JSON",
   "actions": "Действия",

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Dölj huvudknappar",
   "showLogo": "Visa logotyp",
   "hideLogo": "Dölj logotyp",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Historik",
   "jumpToJson": "Hoppa till JSON",
   "actions": "Åtgärder",

--- a/src/locales/th-TH.json
+++ b/src/locales/th-TH.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "ซ่อนปุ่มส่วนหัว",
   "showLogo": "แสดงโลโก้",
   "hideLogo": "ซ่อนโลโก้",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "ประวัติ",
   "jumpToJson": "ไปที่ JSON",
   "actions": "การดำเนินการ",

--- a/src/locales/uk-UA.json
+++ b/src/locales/uk-UA.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "Приховати кнопки заголовка",
   "showLogo": "Показати логотип",
   "hideLogo": "Приховати логотип",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "Історія",
   "jumpToJson": "Перейти до JSON",
   "actions": "Дії",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -27,6 +27,8 @@
   "hideHeaderButtons": "隐藏标题按钮",
   "showLogo": "显示徽标",
   "hideLogo": "隐藏徽标",
+  "enableFloatingJson": "Enable Floating JSON",
+  "disableFloatingJson": "Disable Floating JSON",
   "history": "历史记录",
   "jumpToJson": "跳转到 JSON",
   "actions": "操作",


### PR DESCRIPTION
## Summary
- add `useFloatingJson` hook with storage + analytics
- allow toggling floating JSON in settings
- render JSON panel as floating view on small screens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9f152e8b4832599ce8b258cd392b1