### PR TITLE
feat: add dark mode toggle control

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -21,6 +21,8 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import {
+  Sun,
+  Moon,
   Import as ImportIcon,
   Download,
   RotateCcw,
@@ -35,6 +37,7 @@ import { toast } from '@/components/ui/sonner-toast';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
 import { purgeCache } from '@/lib/purgeCache';
 import { useUpdateCheck } from '@/hooks/use-update-check';
+import { useDarkMode } from '@/hooks/use-dark-mode';
 import { exportAppData, importAppData, safeGet } from '@/lib/storage';
 import { formatDateTime } from '@/lib/date';
 import {
@@ -139,6 +142,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const [confirmDisableTracking, setConfirmDisableTracking] = useState(false);
   const [confirmEnableTracking, setConfirmEnableTracking] = useState(false);
   const { checkForUpdate } = useUpdateCheck();
+  const [darkMode, setDarkMode] = useDarkMode();
 
   useEffect(() => {
     if (open) {
@@ -431,6 +435,58 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                         ? 'Hide Sora Integration'
                         : 'Show Sora Integration'}
                   </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={() => {
+                          try {
+                            setDarkMode(!darkMode);
+                            toast.success(
+                              !darkMode
+                                ? t('darkModeEnabled', {
+                                    defaultValue: 'Dark mode enabled',
+                                  })
+                                : t('darkModeDisabled', {
+                                    defaultValue: 'Dark mode disabled',
+                                  }),
+                            );
+                            trackEvent(
+                              trackingEnabled,
+                              AnalyticsEvent.DarkModeToggle,
+                              { enabled: !darkMode },
+                            );
+                          } catch {
+                            toast.error('Failed to toggle dark mode');
+                          }
+                        }}
+                      >
+                        {darkMode ? (
+                          <>
+                            <Sun className="w-4 h-4" /> {t('disableDarkMode', {
+                              defaultValue: 'Disable dark mode',
+                            })}
+                          </>
+                        ) : (
+                          <>
+                            <Moon className="w-4 h-4" /> {t('enableDarkMode', {
+                              defaultValue: 'Enable dark mode',
+                            })}
+                          </>
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {darkMode
+                        ? t('disableDarkMode', {
+                            defaultValue: 'Disable dark mode',
+                          })
+                        : t('enableDarkMode', {
+                            defaultValue: 'Enable dark mode',
+                          })}
+                    </TooltipContent>
                   </Tooltip>
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/src/components/__tests__/SettingsPanel.test.tsx
+++ b/src/components/__tests__/SettingsPanel.test.tsx
@@ -25,6 +25,10 @@ jest.mock('@/lib/date', () => ({
   __esModule: true,
   formatDateTime: jest.fn(() => '20240101-000000'),
 }));
+jest.mock('@/hooks/use-dark-mode', () => ({
+  __esModule: true,
+  useDarkMode: jest.fn(() => [false, jest.fn()] as const),
+}));
 
 jest.mock('@/components/ui/dialog', () => ({
   __esModule: true,


### PR DESCRIPTION
## Summary
- add dark mode toggle button in settings panel with analytics tracking and toast feedback
- mock dark mode hook in SettingsPanel tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa1f55134c8325a035c78c4442b278