### PR TITLE
Handle aspect ratio labels with colons

### DIFF
--- a/src/components/__tests__/DimensionsFormatSection.test.tsx
+++ b/src/components/__tests__/DimensionsFormatSection.test.tsx
@@ -40,9 +40,12 @@ describe('DimensionsFormatSection', () => {
       />,
     );
     const comboboxes = screen.getAllByRole('combobox');
-    const ratioLabels = i18n.t('aspectRatioLabels', {
-      returnObjects: true,
-    }) as Record<string, string>;
+    const ratioLabels =
+      (i18n.getResource(
+        i18n.language,
+        'translation',
+        'aspectRatioLabels',
+      ) as Record<string, string>) || {};
     fireEvent.click(comboboxes[0]);
     fireEvent.click(
       screen.getByRole('option', { name: ratioLabels['4:3'] })

--- a/src/components/sections/DimensionsFormatSection.tsx
+++ b/src/components/sections/DimensionsFormatSection.tsx
@@ -32,7 +32,7 @@ interface DimensionsFormatSectionProps {
 export const DimensionsFormatSection: React.FC<
   DimensionsFormatSectionProps
 > = ({ options, updateOptions, isEnabled, onToggle }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const qualityOptions = [
     'maximum',
     'ultra',
@@ -52,9 +52,18 @@ export const DimensionsFormatSection: React.FC<
     'defective',
   ];
   const aspectRatios = ['16:9', '21:9', '4:3', '1:1', '9:16'];
-  const aspectRatioLabels = t('aspectRatioLabels', {
-    returnObjects: true,
-  }) as Record<string, string>;
+  const rawAspectRatioLabels =
+    (i18n.getResource(
+      i18n.language,
+      'translation',
+      'aspectRatioLabels',
+    ) as Record<string, string>) || {};
+  const aspectRatioLabels = aspectRatios.reduce(
+    (labels, ratio) => ({ ...labels, [ratio]: rawAspectRatioLabels[ratio] }),
+    {} as Record<string, string>,
+  );
+  const formatAspectRatio = (ratio: string) =>
+    aspectRatioLabels[ratio] || ratio.replace(':', '×');
 
   return (
     <CollapsibleSection
@@ -78,7 +87,7 @@ export const DimensionsFormatSection: React.FC<
             <SelectContent>
               {aspectRatios.map((ratio) => (
                 <SelectItem key={ratio} value={ratio}>
-                  {aspectRatioLabels[ratio] || ratio}
+                  {formatAspectRatio(ratio)}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/components/sections/__tests__/DimensionsFormatSection.test.tsx
+++ b/src/components/sections/__tests__/DimensionsFormatSection.test.tsx
@@ -40,9 +40,12 @@ describe('DimensionsFormatSection', () => {
       />,
     );
     const comboboxes = screen.getAllByRole('combobox');
-    const ratioLabels = i18n.t('aspectRatioLabels', {
-      returnObjects: true,
-    }) as Record<string, string>;
+    const ratioLabels =
+      (i18n.getResource(
+        i18n.language,
+        'translation',
+        'aspectRatioLabels',
+      ) as Record<string, string>) || {};
     fireEvent.click(comboboxes[0]);
     fireEvent.click(
       screen.getByRole('option', { name: ratioLabels['4:3'] }),
@@ -81,5 +84,32 @@ describe('DimensionsFormatSection', () => {
     fireEvent.click(comboboxes[3]);
     fireEvent.click(screen.getByRole('option', { name: /hdr/i }));
     expect(updateOptions).toHaveBeenCalledWith({ dynamic_range: 'HDR' });
+  });
+
+  test('displays aspect ratios with colon keys', () => {
+    render(
+      <DimensionsFormatSection
+        options={{
+          ...DEFAULT_OPTIONS,
+          use_dimensions_format: true,
+        }}
+        updateOptions={jest.fn()}
+        isEnabled={true}
+        onToggle={() => {}}
+      />,
+    );
+    const ratioLabels =
+      (i18n.getResource(
+        i18n.language,
+        'translation',
+        'aspectRatioLabels',
+      ) as Record<string, string>) || {};
+    fireEvent.click(screen.getAllByRole('combobox')[0]);
+    expect(
+      screen.getByRole('option', { name: ratioLabels['21:9'] }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('option', { name: ratioLabels['9:16'] }),
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Ensure i18next reads colon-based aspect ratio keys by fetching resources directly
- Add `formatAspectRatio` fallback to display ratios when translation is missing
- Test that ratios like `21:9` and `9:16` render correctly in the Dimensions & Format section

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa309271308325b4d981735ee90579