### PR TITLE
feat(cli): add url option

### DIFF
--- a/cli/__tests__/index.test.ts
+++ b/cli/__tests__/index.test.ts
@@ -4,55 +4,71 @@ import { tmpdir } from 'node:os';
 import * as fs from 'node:fs';
 import { runCli } from '../index.ts';
 
-test('generates JSON from flags', () => {
-  const out = runCli(['--prompt', 'hello', '--width', '123']);
+test('generates JSON from flags', async () => {
+  const out = await runCli(['--prompt', 'hello', '--width', '123']);
   const obj = JSON.parse(out);
   expect(obj.prompt).toBe('hello');
   expect(obj.width).toBe(123);
 });
 
-test('generates JSON from file', () => {
+test('generates JSON from file', async () => {
   const file = join(tmpdir(), 'options.json');
   fs.writeFileSync(file, JSON.stringify({ prompt: 'from file', width: 456 }));
-  const out = runCli(['--file', file]);
+  const out = await runCli(['--file', file]);
   const obj = JSON.parse(out);
   expect(obj.prompt).toBe('from file');
   expect(obj.width).toBe(456);
 });
 
-test('shows help with --help', () => {
-  const out = runCli(['--help']);
+test('shows help with --help', async () => {
+  const out = await runCli(['--help']);
   expect(out).toMatch(/Usage: sora-crafter/);
 });
 
-test('prints version with --version', () => {
+test('prints version with --version', async () => {
   const version = JSON.parse(
     fs.readFileSync(join(__dirname, '../../package.json'), 'utf8'),
   ).version;
-  expect(runCli(['--version']).trim()).toBe(version);
+  expect((await runCli(['--version'])).trim()).toBe(version);
 });
 
-test('throws on unknown flag', () => {
-  expect(() => runCli(['--unknown'])).toThrow(/Unknown flag/);
+test('throws on unknown flag', async () => {
+  await expect(runCli(['--unknown'])).rejects.toThrow(/Unknown flag/);
 });
 
-test('reads options from stdin when no flags are given', () => {
-  const out = runCli([], JSON.stringify({ prompt: 'stdin', width: 321 }));
+test('reads options from stdin when no flags are given', async () => {
+  const out = await runCli([], JSON.stringify({ prompt: 'stdin', width: 321 }));
   const obj = JSON.parse(out);
   expect(obj.prompt).toBe('stdin');
   expect(obj.width).toBe(321);
 });
 
-test('writes output to file when --output is provided', () => {
+test('writes output to file when --output is provided', async () => {
   const file = join(tmpdir(), 'cli-output.json');
-  const out = runCli(['--prompt', 'file test', '--output', file]);
+  const out = await runCli(['--prompt', 'file test', '--output', file]);
   expect(out).toBe('');
   const obj = JSON.parse(fs.readFileSync(file, 'utf8'));
   expect(obj.prompt).toBe('file test');
 });
 
-test('minifies JSON when --minify is set', () => {
-  const out = runCli(['--prompt', 'mini', '--minify']);
+test('minifies JSON when --minify is set', async () => {
+  const out = await runCli(['--prompt', 'mini', '--minify']);
   const parsed = JSON.parse(out);
   expect(out).toBe(JSON.stringify(parsed));
+});
+
+test('loads options from url', async () => {
+  const mockResponse = { prompt: 'from url', width: 789 };
+  const mockFetch = jest
+    .spyOn(globalThis, 'fetch')
+    .mockResolvedValue({
+      text: async () => JSON.stringify(mockResponse),
+    } as unknown as Response);
+
+  const out = await runCli(['--url', 'https://example.com/data.json']);
+  const obj = JSON.parse(out);
+  expect(mockFetch).toHaveBeenCalledWith('https://example.com/data.json');
+  expect(obj.prompt).toBe('from url');
+  expect(obj.width).toBe(789);
+  mockFetch.mockRestore();
 });


### PR DESCRIPTION
## Summary
- add `--url` flag parsing to CLI
- load options from remote URL when provided
- test URL loading with mocked fetch

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca8837e3c83258d55293a08be4eef