### PR TITLE
feat: add offline banner

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -62,6 +62,7 @@ import {
   JSON_COPY_COUNT,
   JSON_COPY_MILESTONES,
 } from '@/lib/storage-keys';
+import { useOnlineStatus } from '@/hooks/use-online-status';
 
 const COPY_MILESTONES: [number, AnalyticsEvent][] = [
   [10, AnalyticsEvent.CopyJson10],
@@ -84,6 +85,8 @@ const COPY_MILESTONES: [number, AnalyticsEvent][] = [
 const Dashboard = () => {
   const { t } = useTranslation();
   useLocale();
+  const isOnline = useOnlineStatus();
+  const [offlineDismissed, setOfflineDismissed] = useState(false);
   /**
    * Initialize Sora options from the URL or local storage.
    * Falls back to default options if no saved state is found or parsing fails.
@@ -510,6 +513,20 @@ const Dashboard = () => {
 
   return (
     <div className="min-h-screen flex flex-col bg-background">
+      {!isOnline && !offlineDismissed && (
+        <div className="bg-yellow-500 text-black p-2 text-center">
+          <div className="flex items-center justify-between max-w-2xl mx-auto">
+            <span>{t('offlineNotice', { defaultValue: 'You are offline' })}</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setOfflineDismissed(true)}
+            >
+              {t('dismiss', { defaultValue: 'Dismiss' })}
+            </Button>
+          </div>
+        </div>
+      )}
       <div className="container mx-auto p-6 flex flex-col flex-1">
         {headerVisible && (
           <div className="mb-8 flex items-start justify-between">

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -452,3 +452,44 @@ describe('userscript version', () => {
     expect(trackEvent).toHaveBeenCalledWith(true, AnalyticsEvent.UpdateUserscript);
   });
 });
+
+describe('offline banner', () => {
+  const setOnline = (value: boolean) => {
+    Object.defineProperty(window.navigator, 'onLine', {
+      configurable: true,
+      value,
+    });
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    window.matchMedia = jest.fn().mockReturnValue({
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }) as unknown as typeof window.matchMedia;
+  });
+
+  test('toggles visibility based on navigator.onLine', async () => {
+    setOnline(false);
+    render(<Dashboard />);
+    expect(screen.getByText(/offline/i)).toBeTruthy();
+
+    act(() => {
+      setOnline(true);
+      window.dispatchEvent(new Event('online'));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/offline/i)).toBeNull();
+    });
+
+    act(() => {
+      setOnline(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/offline/i)).toBeTruthy();
+    });
+  });
+});

--- a/src/hooks/use-online-status.ts
+++ b/src/hooks/use-online-status.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+/**
+ * Tracks the browser's online status.
+ *
+ * Listens to the global `online` and `offline` events and returns the current
+ * `navigator.onLine` value, defaulting to `true` when the navigator is
+ * undefined.
+ *
+ * @returns {boolean} `true` if the browser reports being online, otherwise `false`.
+ */
+export function useOnlineStatus() {
+  const [isOnline, setIsOnline] = React.useState(
+    typeof navigator !== 'undefined' ? navigator.onLine : true,
+  );
+
+  React.useEffect(() => {
+    const updateStatus = () => setIsOnline(navigator.onLine);
+    window.addEventListener('online', updateStatus);
+    window.addEventListener('offline', updateStatus);
+    return () => {
+      window.removeEventListener('online', updateStatus);
+      window.removeEventListener('offline', updateStatus);
+    };
+  }, []);
+
+  return isOnline;
+}


### PR DESCRIPTION
## Summary
- add `useOnlineStatus` hook to track browser connectivity
- show dismissible offline banner on dashboard
- test offline banner toggling with mocked `navigator.onLine`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ace38188c08325a391e246e6f5cd4e