### PR TITLE
feat: add history favorites filter

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -131,7 +131,10 @@ const Dashboard = () => {
   const [showDisclaimer, setShowDisclaimer] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [history, setHistory] = useState<HistoryEntry[]>(() =>
-    safeGet<HistoryEntry[]>(JSON_HISTORY, [], true),
+    (safeGet<HistoryEntry[]>(JSON_HISTORY, [], true) ?? []).map((e) => ({
+      favorite: false,
+      ...e,
+    })),
   );
   const isSingleColumn = useIsSingleColumn();
   const [darkMode, setDarkMode] = useDarkMode();
@@ -198,6 +201,7 @@ const Dashboard = () => {
         id: Date.now(),
         date: new Date().toLocaleString(),
         json: jsonString,
+        favorite: false,
       };
       setHistory((prev) => [entry, ...prev].slice(0, 100));
       const opts = options as unknown as Record<string, unknown>;
@@ -497,9 +501,21 @@ const Dashboard = () => {
       id: Date.now() + Math.random(),
       date: new Date().toLocaleString(),
       json: j,
+      favorite: false,
     }));
     setHistory((prev) => [...entries, ...prev].slice(0, 100));
     trackEvent(trackingEnabled, AnalyticsEvent.HistoryImport, { type: 'bulk' });
+  };
+
+  /**
+   * Toggle favorite state for a history entry by id.
+   *
+   * @param {number} id - Entry identifier.
+   */
+  const toggleFavorite = (id: number) => {
+    setHistory((prev) =>
+      prev.map((e) => (e.id === id ? { ...e, favorite: !e.favorite } : e)),
+    );
   };
 
   /**
@@ -865,6 +881,7 @@ const Dashboard = () => {
         onCopy={copyHistoryEntry}
         onEdit={editHistoryEntry}
         onImport={importHistoryEntries}
+        onToggleFavorite={toggleFavorite}
       />
       <ImportModal
         isOpen={showImportModal}

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -27,6 +27,7 @@ import {
   Import as ImportIcon,
   Download,
   Check,
+  Star,
 } from 'lucide-react';
 import {
   Tooltip,
@@ -56,6 +57,7 @@ export interface HistoryEntry {
   id: number;
   date: string;
   json: string;
+  favorite: boolean;
 }
 
 interface HistoryPanelProps {
@@ -68,6 +70,7 @@ interface HistoryPanelProps {
   onCopy: (json: string) => void;
   onEdit: (json: string) => void;
   onImport: (jsons: string[]) => void;
+  onToggleFavorite: (id: number) => void;
 }
 
 /**
@@ -97,6 +100,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
   onCopy,
   onEdit,
   onImport,
+  onToggleFavorite,
 }) => {
   const { t } = useTranslation();
   const [preview, setPreview] = useState<HistoryEntry | null>(null);
@@ -111,11 +115,14 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
     number | null
   >(null);
   const [searchTerm, setSearchTerm] = useState('');
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
   const noHistory = history.length === 0;
   const noActions = actionHistory.length === 0;
-  const filteredHistory = history.filter((entry) =>
-    entry.json.toLowerCase().includes(searchTerm.toLowerCase()),
-  );
+  const filteredHistory = history
+    .filter((entry) =>
+      entry.json.toLowerCase().includes(searchTerm.toLowerCase()),
+    )
+    .filter((entry) => (!favoritesOnly ? true : entry.favorite));
 
   useEffect(() => {
     if (open) {
@@ -385,7 +392,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
               <TooltipContent>{t('clearHistory')}</TooltipContent>
             </Tooltip>
             </div>
-            <div className="mb-2">
+            <div className="mb-2 flex items-center gap-2">
               <Input
                 placeholder={t('searchHistoryPlaceholder', {
                   defaultValue: 'Search history...'
@@ -393,6 +400,29 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
               />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant={favoritesOnly ? 'default' : 'outline'}
+                    onClick={() => setFavoritesOnly((prev) => !prev)}
+                    aria-label={t('favoritesFilter', {
+                      defaultValue: 'Favorites filter'
+                    })}
+                  >
+                    <Star
+                      className={`w-4 h-4 ${favoritesOnly ? 'fill-current' : ''}`}
+                    />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {favoritesOnly
+                    ? t('showAll', { defaultValue: 'Show all' })
+                    : t('showFavoritesOnly', {
+                        defaultValue: 'Show favorites only'
+                      })}
+                </TooltipContent>
+              </Tooltip>
             </div>
             <div className="h-[60vh]">
               {filteredHistory.length > 0 ? (
@@ -416,6 +446,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
                         }}
                         onPreview={setPreview}
                         trackingEnabled={trackingEnabled}
+                        onToggleFavorite={onToggleFavorite}
                       />
                     </div>
                   )}

--- a/src/components/__tests__/DashboardHistory.test.tsx
+++ b/src/components/__tests__/DashboardHistory.test.tsx
@@ -78,6 +78,7 @@ function createEntries(n: number) {
     id: i,
     date: 'd',
     json: '{}',
+    favorite: false,
   }));
 }
 

--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -81,6 +81,7 @@ const sampleHistory = Array.from({ length: 20 }, (_, i) => ({
   id: i + 1,
   date: 'd',
   json: `{"prompt":"p${i}"}`,
+  favorite: i % 2 === 0,
 }));
 const sampleActions = [{ date: 'd', action: 'a' }];
 
@@ -97,6 +98,7 @@ function renderPanel(
     onCopy: jest.fn(),
     onEdit: jest.fn(),
     onImport: jest.fn(),
+    onToggleFavorite: jest.fn(),
   };
   return render(
     <TooltipProvider>
@@ -244,6 +246,22 @@ describe('HistoryPanel basic actions', () => {
     fireEvent.change(input, { target: { value: 'p1' } });
 
     expect(screen.queryByText('p2')).toBeNull();
+    expect(screen.getByText('p1')).toBeTruthy();
+  });
+
+  test('toggles favorites and filters favorites', () => {
+    const onToggleFavorite = jest.fn();
+    renderPanel({ onToggleFavorite });
+
+    const starBtn = screen.getAllByRole('button', { name: /unfavorite/i })[0];
+    fireEvent.click(starBtn);
+    expect(onToggleFavorite).toHaveBeenCalledWith(1);
+
+    const filterBtn = screen.getByLabelText(/favorites filter/i);
+    fireEvent.click(filterBtn);
+    expect(screen.queryByText('p1')).toBeNull();
+    expect(screen.getByText('p0')).toBeTruthy();
+    fireEvent.click(filterBtn);
     expect(screen.getByText('p1')).toBeTruthy();
   });
 });

--- a/src/components/history/HistoryItem.tsx
+++ b/src/components/history/HistoryItem.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { Clipboard, Trash2, Edit, Eye, Check } from 'lucide-react';
+import { Clipboard, Trash2, Edit, Eye, Check, Star } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
 import type { HistoryEntry } from '../HistoryPanel';
@@ -17,6 +17,7 @@ interface HistoryItemProps {
   onDelete: (id: number) => void;
   onPreview: (entry: HistoryEntry) => void;
   trackingEnabled: boolean;
+  onToggleFavorite: (id: number) => void;
 }
 
 const HistoryItem: React.FC<HistoryItemProps> = ({
@@ -26,6 +27,7 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
   onDelete,
   onPreview,
   trackingEnabled,
+  onToggleFavorite,
 }) => {
   const { t } = useTranslation();
   const [edited, setEdited] = useState(false);
@@ -103,6 +105,30 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent>{t('preview')}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="sm"
+              variant={entry.favorite ? 'default' : 'outline'}
+              onClick={() => onToggleFavorite(entry.id)}
+              className="gap-1"
+              aria-label={entry.favorite
+                ? t('unfavorite', { defaultValue: 'Unfavorite' })
+                : t('favorite', { defaultValue: 'Favorite' })}
+            >
+              <Star
+                className={`w-4 h-4 ${
+                  entry.favorite ? 'fill-current text-yellow-500' : ''
+                }`}
+              />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {entry.favorite
+              ? t('unfavorite', { defaultValue: 'Unfavorite' })
+              : t('favorite', { defaultValue: 'Favorite' })}
+          </TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- allow marking history entries as favorites and persisting the state
- add star toggle and favorites-only filter in history panel
- cover favorites interactions with tests

## Testing
- `CI=true npm test >/tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68ae01b9f12c83259f313582d7107166