### PR TITLE
feat: add reset buttons for sections

### DIFF
--- a/src/components/sections/CameraCompositionSection.tsx
+++ b/src/components/sections/CameraCompositionSection.tsx
@@ -27,6 +27,8 @@ import {
   subjectFocusOptions,
   type SubjectFocusOption,
 } from '@/data/cameraPresets';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 
 interface CameraCompositionSectionProps {
   options: SoraOptions;
@@ -57,6 +59,27 @@ export const CameraCompositionSection: React.FC<
     updateOptions({ composition_rules: selectedRules });
   };
 
+  const handleReset = () => {
+    updateOptions({
+      camera_type: DEFAULT_OPTIONS.camera_type,
+      use_lens_type: DEFAULT_OPTIONS.use_lens_type,
+      lens_type: DEFAULT_OPTIONS.lens_type,
+      use_shot_type: DEFAULT_OPTIONS.use_shot_type,
+      shot_type: DEFAULT_OPTIONS.shot_type,
+      use_camera_angle: DEFAULT_OPTIONS.use_camera_angle,
+      camera_angle: DEFAULT_OPTIONS.camera_angle,
+      use_subject_focus: DEFAULT_OPTIONS.use_subject_focus,
+      subject_focus: DEFAULT_OPTIONS.subject_focus,
+      composition_rules: DEFAULT_OPTIONS.composition_rules,
+      use_aperture: DEFAULT_OPTIONS.use_aperture,
+      aperture: DEFAULT_OPTIONS.aperture,
+      use_dof: DEFAULT_OPTIONS.use_dof,
+      depth_of_field: DEFAULT_OPTIONS.depth_of_field,
+      use_blur_style: DEFAULT_OPTIONS.use_blur_style,
+      blur_style: DEFAULT_OPTIONS.blur_style,
+    });
+  };
+
   return (
     <CollapsibleSection
       title="Camera & Composition"
@@ -65,6 +88,11 @@ export const CameraCompositionSection: React.FC<
       onToggle={onToggle}
     >
       <div className="grid grid-cols-1 gap-4">
+        <div className="flex justify-end">
+          <Button variant="outline" size="sm" onClick={handleReset}>
+            {t('reset')}
+          </Button>
+        </div>
         <div>
           <Label>{t('cameraType')}</Label>
           <SearchableDropdown

--- a/src/components/sections/ColorGradingSection.tsx
+++ b/src/components/sections/ColorGradingSection.tsx
@@ -6,6 +6,8 @@ import { CollapsibleSection } from '../CollapsibleSection';
 import type { SoraOptions } from '@/lib/soraOptions';
 
 import { colorGradingOptions } from '@/data/colorGradingOptions';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 interface ColorGradingSectionProps {
   options: SoraOptions;
   updateOptions: (updates: Partial<SoraOptions>) => void;
@@ -23,6 +25,13 @@ export const ColorGradingSection: React.FC<ColorGradingSectionProps> = ({
   updateOptions,
 }) => {
   const { t } = useTranslation();
+
+  const handleReset = () => {
+    updateOptions({
+      use_color_grading: DEFAULT_OPTIONS.use_color_grading,
+      color_grade: DEFAULT_OPTIONS.color_grade,
+    });
+  };
   return (
     <CollapsibleSection
       title="Color Grading"
@@ -31,6 +40,11 @@ export const ColorGradingSection: React.FC<ColorGradingSectionProps> = ({
       onToggle={(enabled) => updateOptions({ use_color_grading: enabled })}
     >
       <div className="space-y-4">
+        <div className="flex justify-end">
+          <Button variant="outline" size="sm" onClick={handleReset}>
+            {t('reset')}
+          </Button>
+        </div>
         <div>
           <Label>{t('colorGrade')}</Label>
           <SearchableDropdown

--- a/src/components/sections/CoreSettingsSection.tsx
+++ b/src/components/sections/CoreSettingsSection.tsx
@@ -5,6 +5,8 @@ import { Input } from '@/components/ui/input';
 import { Slider } from '@/components/ui/slider';
 import { CollapsibleSection } from '../CollapsibleSection';
 import type { SoraOptions } from '@/lib/soraOptions';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 
 interface CoreSettingsSectionProps {
   options: SoraOptions;
@@ -31,6 +33,16 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
   onToggle,
 }) => {
   const { t } = useTranslation();
+
+  const handleReset = () => {
+    updateOptions({
+      seed: DEFAULT_OPTIONS.seed,
+      steps: DEFAULT_OPTIONS.steps,
+      guidance_scale: DEFAULT_OPTIONS.guidance_scale,
+      temperature: DEFAULT_OPTIONS.temperature,
+      cfg_rescale: DEFAULT_OPTIONS.cfg_rescale,
+    });
+  };
   return (
     <CollapsibleSection
       title={t('coreSettings')}
@@ -39,6 +51,11 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
       onToggle={onToggle}
     >
       <div className="grid grid-cols-1 gap-4">
+        <div className="flex justify-end">
+          <Button variant="outline" size="sm" onClick={handleReset}>
+            {t('reset')}
+          </Button>
+        </div>
         <div>
           <Label htmlFor="seed">{t('seed')}</Label>
           <Input

--- a/src/components/sections/DimensionsFormatSection.tsx
+++ b/src/components/sections/DimensionsFormatSection.tsx
@@ -12,6 +12,8 @@ import {
 import { CollapsibleSection } from '../CollapsibleSection';
 import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 
 interface DimensionsFormatSectionProps {
   options: SoraOptions;
@@ -73,6 +75,27 @@ export const DimensionsFormatSection: React.FC<
       onToggle={onToggle}
     >
       <div className="grid grid-cols-1 gap-4">
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              updateOptions({
+                aspect_ratio: DEFAULT_OPTIONS.aspect_ratio,
+                quality: DEFAULT_OPTIONS.quality,
+                use_dimensions: DEFAULT_OPTIONS.use_dimensions,
+                width: DEFAULT_OPTIONS.width,
+                height: DEFAULT_OPTIONS.height,
+                use_output_format: DEFAULT_OPTIONS.use_output_format,
+                output_format: DEFAULT_OPTIONS.output_format,
+                use_dynamic_range: DEFAULT_OPTIONS.use_dynamic_range,
+                dynamic_range: DEFAULT_OPTIONS.dynamic_range,
+              })
+            }
+          >
+            {t('reset')}
+          </Button>
+        </div>
         <div>
           <Label htmlFor="aspect_ratio">{t('aspectRatio')}</Label>
           <Select

--- a/src/components/sections/DnDSection.tsx
+++ b/src/components/sections/DnDSection.tsx
@@ -17,6 +17,8 @@ import {
 } from '@/data/dndPresets';
 import { dndOptionTranslations } from '@/data/optionTranslations';
 import { getOptionLabel as translateOption } from '@/lib/optionTranslator';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 
 interface DnDSectionProps {
   options: SoraOptions;
@@ -50,6 +52,38 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
       onToggle={onToggle}
     >
       <div className="grid grid-cols-1 gap-4">
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              updateOptions({
+                use_dnd_character_race:
+                  DEFAULT_OPTIONS.use_dnd_character_race,
+                dnd_character_race: DEFAULT_OPTIONS.dnd_character_race,
+                use_dnd_character_class:
+                  DEFAULT_OPTIONS.use_dnd_character_class,
+                dnd_character_class: DEFAULT_OPTIONS.dnd_character_class,
+                use_dnd_character_background:
+                  DEFAULT_OPTIONS.use_dnd_character_background,
+                dnd_character_background: DEFAULT_OPTIONS.dnd_character_background,
+                use_dnd_character_alignment:
+                  DEFAULT_OPTIONS.use_dnd_character_alignment,
+                dnd_character_alignment: DEFAULT_OPTIONS.dnd_character_alignment,
+                use_dnd_monster_type: DEFAULT_OPTIONS.use_dnd_monster_type,
+                dnd_monster_type: DEFAULT_OPTIONS.dnd_monster_type,
+                use_dnd_environment: DEFAULT_OPTIONS.use_dnd_environment,
+                dnd_environment: DEFAULT_OPTIONS.dnd_environment,
+                use_dnd_magic_school: DEFAULT_OPTIONS.use_dnd_magic_school,
+                dnd_magic_school: DEFAULT_OPTIONS.dnd_magic_school,
+                use_dnd_item_type: DEFAULT_OPTIONS.use_dnd_item_type,
+                dnd_item_type: DEFAULT_OPTIONS.dnd_item_type,
+              })
+            }
+          >
+            {t('reset')}
+          </Button>
+        </div>
         <ToggleField
           id="use_dnd_character_race"
           label={t('useCharacterRace')}

--- a/src/components/sections/EnhancementsSection.tsx
+++ b/src/components/sections/EnhancementsSection.tsx
@@ -12,6 +12,8 @@ import {
   safetyFilterOptions,
   qualityBoosterOptions,
 } from '@/data/enhancementOptions';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 interface EnhancementsSectionProps {
   options: SoraOptions;
   updateOptions: (updates: Partial<SoraOptions>) => void;
@@ -63,6 +65,29 @@ export const EnhancementsSection: React.FC<EnhancementsSectionProps> = ({
       onToggle={onToggle}
     >
       <div className="space-y-4">
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              updateOptions({
+                prevent_deformities: DEFAULT_OPTIONS.prevent_deformities,
+                use_upscale_factor: DEFAULT_OPTIONS.use_upscale_factor,
+                upscale: DEFAULT_OPTIONS.upscale,
+                use_safety_filter: DEFAULT_OPTIONS.use_safety_filter,
+                safety_filter: DEFAULT_OPTIONS.safety_filter,
+                keep_typography_details: DEFAULT_OPTIONS.keep_typography_details,
+                use_quality_booster: DEFAULT_OPTIONS.use_quality_booster,
+                quality_booster: DEFAULT_OPTIONS.quality_booster,
+                enhance_object_reflections:
+                  DEFAULT_OPTIONS.enhance_object_reflections,
+                keep_key_details: DEFAULT_OPTIONS.keep_key_details,
+              })
+            }
+          >
+            {t('reset')}
+          </Button>
+        </div>
         <div className="flex items-center space-x-2">
           <Checkbox
             id="prevent_deformities"

--- a/src/components/sections/FaceSection.tsx
+++ b/src/components/sections/FaceSection.tsx
@@ -14,6 +14,8 @@ import {
   makeupStyleOptions,
   characterMoodOptions,
 } from '@/data/faceOptions';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 interface FaceSectionProps {
   options: SoraOptions;
   updateOptions: (updates: Partial<SoraOptions>) => void;
@@ -39,6 +41,27 @@ export const FaceSection: React.FC<FaceSectionProps> = ({
       onToggle={(enabled) => updateOptions({ use_face_enhancements: enabled })}
     >
       <div className="space-y-4">
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              updateOptions({
+                use_face_enhancements: DEFAULT_OPTIONS.use_face_enhancements,
+                add_same_face: DEFAULT_OPTIONS.add_same_face,
+                dont_change_face: DEFAULT_OPTIONS.dont_change_face,
+                use_subject_gender: DEFAULT_OPTIONS.use_subject_gender,
+                subject_gender: DEFAULT_OPTIONS.subject_gender,
+                use_makeup_style: DEFAULT_OPTIONS.use_makeup_style,
+                makeup_style: DEFAULT_OPTIONS.makeup_style,
+                use_character_mood: DEFAULT_OPTIONS.use_character_mood,
+                character_mood: DEFAULT_OPTIONS.character_mood,
+              })
+            }
+          >
+            {t('reset')}
+          </Button>
+        </div>
         <div className="flex items-center space-x-2">
           <Checkbox
             id="add_same_face"

--- a/src/components/sections/LightingSection.tsx
+++ b/src/components/sections/LightingSection.tsx
@@ -6,6 +6,8 @@ import { CollapsibleSection } from '../CollapsibleSection';
 import type { SoraOptions } from '@/lib/soraOptions';
 
 import { lightingOptions } from '@/data/lightingOptions';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 interface LightingSectionProps {
   options: SoraOptions;
   updateOptions: (updates: Partial<SoraOptions>) => void;
@@ -31,6 +33,20 @@ export const LightingSection: React.FC<LightingSectionProps> = ({
       onToggle={(enabled) => updateOptions({ use_lighting: enabled })}
     >
       <div className="space-y-4">
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              updateOptions({
+                use_lighting: DEFAULT_OPTIONS.use_lighting,
+                lighting: DEFAULT_OPTIONS.lighting,
+              })
+            }
+          >
+            {t('reset')}
+          </Button>
+        </div>
         <div>
           <Label>{t('lighting')}</Label>
           <SearchableDropdown

--- a/src/components/sections/MaterialSection.tsx
+++ b/src/components/sections/MaterialSection.tsx
@@ -7,6 +7,8 @@ import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
 
 import { materialOptions } from '@/data/materialOptions';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 interface MaterialSectionProps {
   options: SoraOptions;
   updateOptions: (updates: Partial<SoraOptions>) => void;
@@ -32,6 +34,22 @@ export const MaterialSection: React.FC<MaterialSectionProps> = ({
       onToggle={(enabled) => updateOptions({ use_material: enabled })}
     >
       <div className="space-y-4">
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              updateOptions({
+                use_material: DEFAULT_OPTIONS.use_material,
+                made_out_of: DEFAULT_OPTIONS.made_out_of,
+                use_secondary_material: DEFAULT_OPTIONS.use_secondary_material,
+                secondary_material: DEFAULT_OPTIONS.secondary_material,
+              })
+            }
+          >
+            {t('reset')}
+          </Button>
+        </div>
         <div>
           <Label>{t('madeOutOf')}</Label>
           <SearchableDropdown

--- a/src/components/sections/PromptSection.tsx
+++ b/src/components/sections/PromptSection.tsx
@@ -6,6 +6,8 @@ import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
 import { useResizeTracker } from '@/hooks/use-resize-tracker';
 import { AnalyticsEvent } from '@/lib/analytics';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 
 interface PromptSectionProps {
   options: SoraOptions;
@@ -35,8 +37,21 @@ export const PromptSection: React.FC<PromptSectionProps> = ({
     trackingEnabled,
     AnalyticsEvent.NegativePromptResize,
   );
+
+  const handleReset = () => {
+    updateOptions({
+      prompt: DEFAULT_OPTIONS.prompt,
+      negative_prompt: DEFAULT_OPTIONS.negative_prompt,
+      use_negative_prompt: DEFAULT_OPTIONS.use_negative_prompt,
+    });
+  };
   return (
     <div className="space-y-4">
+      <div className="flex justify-end">
+        <Button variant="outline" size="sm" onClick={handleReset}>
+          {t('reset')}
+        </Button>
+      </div>
       <div>
         <Label htmlFor="prompt" className="text-base font-semibold mb-2 block">
           {t('prompt')}

--- a/src/components/sections/SettingsLocationSection.tsx
+++ b/src/components/sections/SettingsLocationSection.tsx
@@ -12,6 +12,8 @@ import {
   seasonOptions,
   atmosphereMoodOptions,
 } from '@/data/locationPresets';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 
 interface SettingsLocationSectionProps {
   options: SoraOptions;
@@ -37,6 +39,31 @@ export const SettingsLocationSection: React.FC<
       onToggle={(enabled) => updateOptions({ use_settings_location: enabled })}
     >
       <div className="grid grid-cols-1 gap-4">
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              updateOptions({
+                use_settings_location: DEFAULT_OPTIONS.use_settings_location,
+                use_year: DEFAULT_OPTIONS.use_year,
+                year: DEFAULT_OPTIONS.year,
+                use_environment: DEFAULT_OPTIONS.use_environment,
+                environment: DEFAULT_OPTIONS.environment,
+                use_location: DEFAULT_OPTIONS.use_location,
+                location: DEFAULT_OPTIONS.location,
+                use_season: DEFAULT_OPTIONS.use_season,
+                season: DEFAULT_OPTIONS.season,
+                use_time_of_year: DEFAULT_OPTIONS.use_time_of_year,
+                time_of_year: DEFAULT_OPTIONS.time_of_year,
+                use_atmosphere_mood: DEFAULT_OPTIONS.use_atmosphere_mood,
+                atmosphere_mood: DEFAULT_OPTIONS.atmosphere_mood,
+              })
+            }
+          >
+            {t('reset')}
+          </Button>
+        </div>
         <ToggleField
           id="use_year"
           label={t('useYear')}

--- a/src/components/sections/StyleSection.tsx
+++ b/src/components/sections/StyleSection.tsx
@@ -12,6 +12,8 @@ import { SearchableDropdown } from '../SearchableDropdown';
 import { CollapsibleSection } from '../CollapsibleSection';
 import type { SoraOptions } from '@/lib/soraOptions';
 import { stylePresets } from '@/data/stylePresets';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 
 interface StyleSectionProps {
   options: SoraOptions;
@@ -54,6 +56,27 @@ export const StyleSection: React.FC<StyleSectionProps> = ({
       onToggle={(enabled) => updateOptions({ use_style_preset: enabled })}
     >
       <div className="grid grid-cols-1 gap-4">
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              updateOptions({
+                use_style_preset: DEFAULT_OPTIONS.use_style_preset,
+              });
+              updateNestedOptions(
+                'style_preset.category',
+                DEFAULT_OPTIONS.style_preset.category,
+              );
+              updateNestedOptions(
+                'style_preset.style',
+                DEFAULT_OPTIONS.style_preset.style,
+              );
+            }}
+          >
+            {t('reset')}
+          </Button>
+        </div>
         <div>
           <Label htmlFor="style_category">{t('styleCategory')}</Label>
           <Select

--- a/src/components/sections/VideoMotionSection.tsx
+++ b/src/components/sections/VideoMotionSection.tsx
@@ -14,6 +14,8 @@ import { Slider } from '@/components/ui/slider';
 import { CollapsibleSection } from '../CollapsibleSection';
 import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 
 interface VideoMotionSectionProps {
   options: SoraOptions;
@@ -47,6 +49,29 @@ export const VideoMotionSection: React.FC<VideoMotionSectionProps> = ({
       onToggle={onToggle}
     >
       <div className="grid grid-cols-1 gap-4">
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              updateOptions({
+                use_duration: DEFAULT_OPTIONS.use_duration,
+                duration_seconds: DEFAULT_OPTIONS.duration_seconds,
+                extended_fps: DEFAULT_OPTIONS.extended_fps,
+                fps: DEFAULT_OPTIONS.fps,
+                extended_motion_strength:
+                  DEFAULT_OPTIONS.extended_motion_strength,
+                use_motion_strength: DEFAULT_OPTIONS.use_motion_strength,
+                motion_strength: DEFAULT_OPTIONS.motion_strength,
+                camera_motion: DEFAULT_OPTIONS.camera_motion,
+                motion_direction: DEFAULT_OPTIONS.motion_direction,
+                frame_interpolation: DEFAULT_OPTIONS.frame_interpolation,
+              })
+            }
+          >
+            {t('reset')}
+          </Button>
+        </div>
         <ToggleField
           id="use_duration"
           label={t('useDuration')}

--- a/src/components/sections/__tests__/PromptSection.test.tsx
+++ b/src/components/sections/__tests__/PromptSection.test.tsx
@@ -63,4 +63,28 @@ describe('PromptSection', () => {
       ),
     ).toBe(false);
   });
+
+  test('reset button restores default prompt values', () => {
+    const updateOptions = jest.fn();
+    const options = {
+      ...DEFAULT_OPTIONS,
+      prompt: 'custom prompt',
+      negative_prompt: 'custom negative',
+      use_negative_prompt: false,
+    };
+    render(
+      <PromptSection
+        options={options}
+        updateOptions={updateOptions}
+        trackingEnabled={false}
+      />,
+    );
+    const resetButton = screen.getByRole('button', { name: /reset/i });
+    fireEvent.click(resetButton);
+    expect(updateOptions).toHaveBeenCalledWith({
+      prompt: DEFAULT_OPTIONS.prompt,
+      negative_prompt: DEFAULT_OPTIONS.negative_prompt,
+      use_negative_prompt: DEFAULT_OPTIONS.use_negative_prompt,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add Reset button and default options import to all section components
- reset button restores section fields via DEFAULT_OPTIONS
- test prompt section resetting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1b02d8a7c83258593ab9fbb6163f8