### PR TITLE
refactor: remove json virtualization

### DIFF
--- a/src/components/__tests__/GeneratedJson.large-json.test.tsx
+++ b/src/components/__tests__/GeneratedJson.large-json.test.tsx
@@ -1,4 +1,4 @@
-import { render, act } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import GeneratedJson from '../GeneratedJson';
 
 function createLargeJson(lines = 1000) {
@@ -7,23 +7,13 @@ function createLargeJson(lines = 1000) {
 }
 
 describe('GeneratedJson large JSON rendering', () => {
-  test('virtualizes large output', () => {
+  test('renders entire output', () => {
     const json = createLargeJson(1000);
     const { container } = render(
       <GeneratedJson json={json} trackingEnabled={false} />,
     );
-    const wrapper = container.querySelector(
-      '[data-testid="json-container"]',
-    ) as HTMLDivElement;
-    Object.defineProperty(wrapper, 'clientHeight', {
-      configurable: true,
-      value: 200,
-    });
-    act(() => {
-      window.dispatchEvent(new Event('resize'));
-    });
-    const rows = container.querySelectorAll('[data-testid="json-row"]');
-    expect(rows.length).toBeLessThan(200);
+    const content = container.textContent ?? '';
+    expect(content.includes('"k999":999')).toBe(true);
   });
 });
 

--- a/src/components/__tests__/GeneratedJson.test.tsx
+++ b/src/components/__tests__/GeneratedJson.test.tsx
@@ -8,31 +8,8 @@ jest.mock('@/lib/analytics', () => {
   return { __esModule: true, ...actual, trackEvent: jest.fn() };
 });
 
-function setup(containerHeight = 100, scrollHeight = 200) {
-  const utils = render(<GeneratedJson json='{"a":1}' trackingEnabled={true} />);
-  const container = utils.container.querySelector(
-    '[data-testid="json-container"]',
-  ) as HTMLDivElement;
-  Object.defineProperty(container, 'clientHeight', {
-    configurable: true,
-    value: containerHeight,
-  });
-  act(() => {
-    window.dispatchEvent(new Event('resize'));
-  });
-  const outer = utils.container.querySelector(
-    '[data-testid="json-outer"]',
-  ) as HTMLDivElement;
-  Object.defineProperty(outer, 'clientHeight', {
-    configurable: true,
-    value: containerHeight,
-  });
-  Object.defineProperty(outer, 'scrollHeight', {
-    configurable: true,
-    value: scrollHeight,
-  });
-  outer.scrollTop = scrollHeight - containerHeight;
-  return { ...utils, outer };
+function setup() {
+  return render(<GeneratedJson json='{"a":1}' trackingEnabled={true} />);
 }
 
 describe('GeneratedJson', () => {
@@ -47,31 +24,17 @@ describe('GeneratedJson', () => {
     jest.useRealTimers();
   });
 
-  test('highlights json diffs briefly and scrolls when at bottom', () => {
-    const { outer, rerender, container } = setup();
-
-    Object.defineProperty(outer, 'scrollHeight', {
-      configurable: true,
-      value: 202,
-    });
+  test('highlights json diffs briefly', () => {
+    const { rerender, container } = setup();
 
     act(() => {
       rerender(<GeneratedJson json='{"a":1,"b":2}' trackingEnabled={true} />);
     });
 
-    const updatedOuter = container.querySelector(
-      '[data-testid="json-outer"]',
-    ) as HTMLDivElement;
-
     expect(trackEvent).toHaveBeenCalledWith(true, AnalyticsEvent.JsonChanged);
-    expect(updatedOuter.scrollTop).toBe(
-      updatedOuter.scrollHeight - updatedOuter.clientHeight,
-    );
-    const added = updatedOuter.querySelectorAll('span.animate-highlight');
+    const added = container.querySelectorAll('span.animate-highlight');
     expect(added.length).toBeGreaterThan(0);
     expect(added[0].textContent).toBe(',"b":2');
-    const token = updatedOuter.querySelector('[style]');
-    expect(token).toBeTruthy();
 
     act(() => {
       jest.advanceTimersByTime(2000);


### PR DESCRIPTION
## Summary
- simplify GeneratedJson by removing react-window
- render JSON directly with `<pre>` and diff highlighting
- update unit tests for non-virtualized output

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1d45abce88325991a8012f6dce99f