### PR TITLE
Add global keyboard shortcut hook for copy/undo/redo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,14 @@ go "my eyes!" when there's bright white lights.
 - Works offline thanks to service worker caching of assets
 - Automatically checks for service worker updates on load and when opening the Settings panel
 
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+| --- | --- |
+| Cmd/Ctrl + C | Copy generated JSON |
+| Cmd/Ctrl + Z | Undo last change |
+| Cmd/Ctrl + Shift + Z or Cmd/Ctrl + Y | Redo last change |
+
 Example JSON output:
 
 ```json

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,8 @@ go "my eyes!" when there's bright white lights.
 | Cmd/Ctrl + Z | Undo last change |
 | Cmd/Ctrl + Shift + Z or Cmd/Ctrl + Y | Redo last change |
 
+Keyboard shortcuts are enabled by default. You can toggle them in the Settings panel if they interfere with other tools.
+
 Example JSON output:
 
 ```json

--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -201,41 +201,9 @@ const { toast: notify } = useToast();
     }
   }, [onRedo, trackingEnabled, t]);
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement | null;
-      if (
-        target &&
-        (target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.isContentEditable)
-      ) {
-        return;
-      }
-
-      if (e.ctrlKey) {
-        const key = e.key.toLowerCase();
-        if (key === 'z') {
-          if (e.shiftKey) {
-            handleRedoAction();
-          } else {
-            handleUndoAction();
-          }
-          e.preventDefault();
-        } else if (key === 'y') {
-          handleRedoAction();
-          e.preventDefault();
-        }
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleUndoAction, handleRedoAction]);
-
-  useEffect(() => {
-    checkForUpdate();
-  }, [checkForUpdate]);
+    useEffect(() => {
+      checkForUpdate();
+    }, [checkForUpdate]);
 
   useEffect(() => {
     if (updateAvailable) {

--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -72,6 +72,8 @@ interface ActionBarProps {
   onToggleDarkModeToggleVisible: () => void;
   floatingJsonEnabled: boolean;
   onToggleFloatingJson: () => void;
+  shortcutsEnabled: boolean;
+  onToggleShortcuts: () => void;
   actionLabelsEnabled: boolean;
   onToggleActionLabels: () => void;
   coreActionLabelsOnly: boolean;
@@ -120,6 +122,8 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   onToggleDarkModeToggleVisible,
   floatingJsonEnabled,
   onToggleFloatingJson,
+  shortcutsEnabled,
+  onToggleShortcuts,
   actionLabelsEnabled,
   onToggleActionLabels,
   coreActionLabelsOnly,
@@ -675,6 +679,8 @@ const { toast: notify } = useToast();
         onToggleDarkModeToggleVisible={onToggleDarkModeToggleVisible}
         floatingJsonEnabled={floatingJsonEnabled}
         onToggleFloatingJson={onToggleFloatingJson}
+        shortcutsEnabled={shortcutsEnabled}
+        onToggleShortcuts={onToggleShortcuts}
         actionLabelsEnabled={actionLabelsEnabled}
         onToggleActionLabels={onToggleActionLabels}
         coreActionLabelsOnly={coreActionLabelsOnly}

--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -1,15 +1,8 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocale } from '@/hooks/use-locale';
 import { Button } from '@/components/ui/button';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
-import { safeGet, safeSet } from '@/lib/storage';
-import {
-  UNDO_COUNT,
-  UNDO_MILESTONES,
-  REDO_COUNT,
-  REDO_MILESTONES,
-} from '@/lib/storage-keys';
 import { cn } from '@/lib/utils';
 import {
   DropdownMenu,
@@ -25,7 +18,6 @@ import {
 
 import SettingsPanel from './SettingsPanel';
 import { useUpdateCheck } from '@/hooks/use-update-check';
-import { toast } from '@/components/ui/sonner-toast';
 import { useToast } from '@/components/ui/use-toast';
 import { ToastAction } from '@/components/ui/toast';
 import {
@@ -50,19 +42,6 @@ import {
   MoveDown,
 } from 'lucide-react';
 
-const UNDO_MILESTONE_EVENTS: [number, AnalyticsEvent][] = [
-  [100, AnalyticsEvent.Undo100],
-  [500, AnalyticsEvent.Undo500],
-  [1000, AnalyticsEvent.Undo1000],
-  [10000, AnalyticsEvent.Undo10000],
-];
-
-const REDO_MILESTONE_EVENTS: [number, AnalyticsEvent][] = [
-  [100, AnalyticsEvent.Redo100],
-  [500, AnalyticsEvent.Redo500],
-  [1000, AnalyticsEvent.Redo1000],
-  [10000, AnalyticsEvent.Redo10000],
-];
 
 interface ActionBarProps {
   onUndo: () => void;
@@ -157,53 +136,9 @@ export const ActionBar: React.FC<ActionBarProps> = ({
   const { checkForUpdate, updateAvailable } = useUpdateCheck();
 const { toast: notify } = useToast();
 
-  const handleUndoAction = useCallback(() => {
-    onUndo();
-    trackEvent(trackingEnabled, AnalyticsEvent.UndoButton);
-    try {
-      const count = (safeGet<number>(UNDO_COUNT, 0, true) as number) ?? 0;
-      const newCount = count + 1;
-      safeSet(UNDO_COUNT, newCount, true);
-      const milestones =
-        (safeGet<number[]>(UNDO_MILESTONES, [], true) as number[]) ?? [];
-      for (const [threshold, event] of UNDO_MILESTONE_EVENTS) {
-        if (newCount >= threshold && !milestones.includes(threshold)) {
-          trackEvent(trackingEnabled, event);
-          toast.success(t('milestoneReached', { threshold }));
-          milestones.push(threshold);
-        }
-      }
-      safeSet(UNDO_MILESTONES, milestones, true);
-    } catch {
-      console.error('Undo counter: There was an error.');
-    }
-  }, [onUndo, trackingEnabled, t]);
-
-  const handleRedoAction = useCallback(() => {
-    onRedo();
-    trackEvent(trackingEnabled, AnalyticsEvent.RedoButton);
-    try {
-      const count = (safeGet<number>(REDO_COUNT, 0, true) as number) ?? 0;
-      const newCount = count + 1;
-      safeSet(REDO_COUNT, newCount, true);
-      const milestones =
-        (safeGet<number[]>(REDO_MILESTONES, [], true) as number[]) ?? [];
-      for (const [threshold, event] of REDO_MILESTONE_EVENTS) {
-        if (newCount >= threshold && !milestones.includes(threshold)) {
-          trackEvent(trackingEnabled, event);
-          toast.success(t('milestoneReached', { threshold }));
-          milestones.push(threshold);
-        }
-      }
-      safeSet(REDO_MILESTONES, milestones, true);
-    } catch {
-      console.error('Redo counter: There was an error.');
-    }
-  }, [onRedo, trackingEnabled, t]);
-
-    useEffect(() => {
-      checkForUpdate();
-    }, [checkForUpdate]);
+  useEffect(() => {
+    checkForUpdate();
+  }, [checkForUpdate]);
 
   useEffect(() => {
     if (updateAvailable) {
@@ -282,7 +217,7 @@ const { toast: notify } = useToast();
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
-            onClick={handleUndoAction}
+            onClick={onUndo}
             variant="outline"
             size="sm"
             disabled={!canUndo}
@@ -297,7 +232,7 @@ const { toast: notify } = useToast();
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
-            onClick={handleRedoAction}
+            onClick={onRedo}
             variant="outline"
             size="sm"
             disabled={!canRedo}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -36,6 +36,7 @@ import { useFloatingJson } from '@/hooks/use-floating-json';
 import { useSoraUserscript } from '@/hooks/use-sora-userscript';
 import { useActionHistory } from '@/hooks/use-action-history';
 import { useUndoRedo } from '@/hooks/use-undo-redo';
+import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
 import { trackShare } from '@/lib/share-counter';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
@@ -521,15 +522,21 @@ const Dashboard = () => {
   /**
    * Scroll the page to the generated JSON section.
    */
-  const scrollToJson = () => {
-    document
-      .getElementById('generated-json')
-      ?.scrollIntoView({ behavior: 'smooth' });
-  };
+    const scrollToJson = () => {
+      document
+        .getElementById('generated-json')
+        ?.scrollIntoView({ behavior: 'smooth' });
+    };
 
-  return (
-    <div className="min-h-screen flex flex-col bg-background">
-      {!isOnline && !offlineDismissed && (
+    useKeyboardShortcuts({
+      onCopy: copyToClipboard,
+      onUndo: undo,
+      onRedo: redo,
+    });
+
+    return (
+      <div className="min-h-screen flex flex-col bg-background">
+        {!isOnline && !offlineDismissed && (
         <div className="bg-yellow-500 text-black p-2 text-center">
           <div className="flex items-center justify-between max-w-2xl mx-auto">
             <span>{t('offlineNotice', { defaultValue: 'You are offline' })}</span>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -37,6 +37,7 @@ import { useSoraUserscript } from '@/hooks/use-sora-userscript';
 import { useActionHistory } from '@/hooks/use-action-history';
 import { useUndoRedo } from '@/hooks/use-undo-redo';
 import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts';
+import { useKeyboardShortcutsEnabled } from '@/hooks/use-keyboard-shortcuts-enabled';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
 import { trackShare } from '@/lib/share-counter';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
@@ -171,6 +172,9 @@ const Dashboard = () => {
   const actionHistory = useActionHistory();
   const githubStats = useGithubStats();
   const { copy } = useClipboard();
+
+  const [shortcutsEnabled, setShortcutsEnabled] =
+    useKeyboardShortcutsEnabled();
 
   useEffect(() => {
     const timer = setTimeout(
@@ -590,11 +594,14 @@ const Dashboard = () => {
         ?.scrollIntoView({ behavior: 'smooth' });
     };
 
-    useKeyboardShortcuts({
-      onCopy: copyToClipboard,
-      onUndo: handleUndoAction,
-      onRedo: handleRedoAction,
-    });
+    useKeyboardShortcuts(
+      {
+        onCopy: copyToClipboard,
+        onUndo: handleUndoAction,
+        onRedo: handleRedoAction,
+      },
+      shortcutsEnabled,
+    );
 
     return (
       <div className="min-h-screen flex flex-col bg-background">
@@ -921,6 +928,10 @@ const Dashboard = () => {
         floatingJsonEnabled={floatingJsonEnabled}
         onToggleFloatingJson={() =>
           setFloatingJsonEnabled(!floatingJsonEnabled)
+        }
+        shortcutsEnabled={shortcutsEnabled}
+        onToggleShortcuts={() =>
+          setShortcutsEnabled(!shortcutsEnabled)
         }
         actionLabelsEnabled={actionLabelsEnabled}
         onToggleActionLabels={() =>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import {
   Sun,
   Moon,
@@ -62,6 +62,10 @@ import {
   JSON_HISTORY,
   JSON_COPY_COUNT,
   JSON_COPY_MILESTONES,
+  UNDO_COUNT,
+  UNDO_MILESTONES,
+  REDO_COUNT,
+  REDO_MILESTONES,
 } from '@/lib/storage-keys';
 import { useOnlineStatus } from '@/hooks/use-online-status';
 
@@ -76,6 +80,20 @@ const COPY_MILESTONES: [number, AnalyticsEvent][] = [
   [2000, AnalyticsEvent.CopyJson2000],
   [5000, AnalyticsEvent.CopyJson5000],
   [10000, AnalyticsEvent.CopyJson10000],
+];
+
+const UNDO_MILESTONE_EVENTS: [number, AnalyticsEvent][] = [
+  [100, AnalyticsEvent.Undo100],
+  [500, AnalyticsEvent.Undo500],
+  [1000, AnalyticsEvent.Undo1000],
+  [10000, AnalyticsEvent.Undo10000],
+];
+
+const REDO_MILESTONE_EVENTS: [number, AnalyticsEvent][] = [
+  [100, AnalyticsEvent.Redo100],
+  [500, AnalyticsEvent.Redo500],
+  [1000, AnalyticsEvent.Redo1000],
+  [10000, AnalyticsEvent.Redo10000],
 ];
 
 /**
@@ -356,6 +374,50 @@ const Dashboard = () => {
     trackEvent(trackingEnabled, AnalyticsEvent.RandomizeButton);
   };
 
+  const handleUndoAction = useCallback(() => {
+    undo();
+    trackEvent(trackingEnabled, AnalyticsEvent.UndoButton);
+    try {
+      const count = (safeGet<number>(UNDO_COUNT, 0, true) as number) ?? 0;
+      const newCount = count + 1;
+      safeSet(UNDO_COUNT, newCount, true);
+      const milestones =
+        (safeGet<number[]>(UNDO_MILESTONES, [], true) as number[]) ?? [];
+      for (const [threshold, event] of UNDO_MILESTONE_EVENTS) {
+        if (newCount >= threshold && !milestones.includes(threshold)) {
+          trackEvent(trackingEnabled, event);
+          toast.success(t('milestoneReached', { threshold }));
+          milestones.push(threshold);
+        }
+      }
+      safeSet(UNDO_MILESTONES, milestones, true);
+    } catch {
+      console.error('Undo counter: There was an error.');
+    }
+  }, [undo, trackingEnabled, t]);
+
+  const handleRedoAction = useCallback(() => {
+    redo();
+    trackEvent(trackingEnabled, AnalyticsEvent.RedoButton);
+    try {
+      const count = (safeGet<number>(REDO_COUNT, 0, true) as number) ?? 0;
+      const newCount = count + 1;
+      safeSet(REDO_COUNT, newCount, true);
+      const milestones =
+        (safeGet<number[]>(REDO_MILESTONES, [], true) as number[]) ?? [];
+      for (const [threshold, event] of REDO_MILESTONE_EVENTS) {
+        if (newCount >= threshold && !milestones.includes(threshold)) {
+          trackEvent(trackingEnabled, event);
+          toast.success(t('milestoneReached', { threshold }));
+          milestones.push(threshold);
+        }
+      }
+      safeSet(REDO_MILESTONES, milestones, true);
+    } catch {
+      console.error('Redo counter: There was an error.');
+    }
+  }, [redo, trackingEnabled, t]);
+
   /**
    * Shallow merge updates into the options state and track changed keys.
    *
@@ -530,8 +592,8 @@ const Dashboard = () => {
 
     useKeyboardShortcuts({
       onCopy: copyToClipboard,
-      onUndo: undo,
-      onRedo: redo,
+      onUndo: handleUndoAction,
+      onRedo: handleRedoAction,
     });
 
     return (
@@ -826,8 +888,8 @@ const Dashboard = () => {
       )}
 
       <ActionBar
-        onUndo={undo}
-        onRedo={redo}
+        onUndo={handleUndoAction}
+        onRedo={handleRedoAction}
         canUndo={canUndo}
         canRedo={canRedo}
         onCopy={copyToClipboard}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -28,6 +28,8 @@ import {
   RotateCcw,
   RefreshCw,
   Shuffle,
+  Keyboard,
+  KeyboardOff,
   Eye,
   EyeOff,
   Trash2,
@@ -79,6 +81,8 @@ interface SettingsPanelProps {
   onToggleDarkModeToggleVisible: () => void;
   floatingJsonEnabled: boolean;
   onToggleFloatingJson: () => void;
+  shortcutsEnabled: boolean;
+  onToggleShortcuts: () => void;
   actionLabelsEnabled: boolean;
   onToggleActionLabels: () => void;
   coreActionLabelsOnly: boolean;
@@ -137,6 +141,8 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   onToggleDarkModeToggleVisible,
   floatingJsonEnabled,
   onToggleFloatingJson,
+  shortcutsEnabled,
+  onToggleShortcuts,
   actionLabelsEnabled,
   onToggleActionLabels,
   coreActionLabelsOnly,
@@ -780,17 +786,71 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                         )}
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent>
-                      {floatingJsonEnabled
-                        ? t('disableFloatingJson')
-                        : t('enableFloatingJson')}
-                    </TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className="w-full justify-start gap-2"
+                  <TooltipContent>
+                    {floatingJsonEnabled
+                      ? t('disableFloatingJson')
+                      : t('enableFloatingJson')}
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      className="w-full justify-start gap-2"
+                      onClick={() => {
+                        try {
+                          onToggleShortcuts();
+                          toast.success(
+                            !shortcutsEnabled
+                              ? t('enableShortcuts', {
+                                  defaultValue: 'Enable shortcuts',
+                                })
+                              : t('disableShortcuts', {
+                                  defaultValue: 'Disable shortcuts',
+                                }),
+                          );
+                          trackEvent(
+                            trackingEnabled,
+                            AnalyticsEvent.ToggleKeyboardShortcuts,
+                            { enabled: !shortcutsEnabled },
+                          );
+                        } catch {
+                          toast.error('Failed to toggle shortcuts');
+                        }
+                      }}
+                    >
+                      {shortcutsEnabled ? (
+                        <>
+                          <KeyboardOff className="w-4 h-4" />
+                          {t('disableShortcuts', {
+                            defaultValue: 'Disable shortcuts',
+                          })}
+                        </>
+                      ) : (
+                        <>
+                          <Keyboard className="w-4 h-4" />
+                          {t('enableShortcuts', {
+                            defaultValue: 'Enable shortcuts',
+                          })}
+                        </>
+                      )}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {shortcutsEnabled
+                      ? t('disableShortcuts', {
+                          defaultValue: 'Disable shortcuts',
+                        })
+                      : t('enableShortcuts', {
+                          defaultValue: 'Enable shortcuts',
+                        })}
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      className="w-full justify-start gap-2"
                         onClick={exportDataFile}
                       >
                         <Download className="w-4 h-4" />

--- a/src/components/__tests__/ActionBar.test.tsx
+++ b/src/components/__tests__/ActionBar.test.tsx
@@ -197,30 +197,6 @@ describe('ActionBar', () => {
     expect(props.onRedo).toHaveBeenCalled();
   });
 
-  test('keyboard shortcuts trigger undo/redo', () => {
-    const props = createProps();
-    renderActionBar(props);
-    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
-    expect(props.onUndo).toHaveBeenCalledTimes(1);
-    fireEvent.keyDown(window, { key: 'z', ctrlKey: true, shiftKey: true });
-    expect(props.onRedo).toHaveBeenCalledTimes(1);
-    fireEvent.keyDown(window, { key: 'y', ctrlKey: true });
-    expect(props.onRedo).toHaveBeenCalledTimes(2);
-  });
-
-  test('shortcuts ignored when typing in inputs', () => {
-    const props = createProps();
-    renderActionBar(props);
-    const input = document.createElement('input');
-    document.body.appendChild(input);
-    input.focus();
-    fireEvent.keyDown(input, { key: 'z', ctrlKey: true });
-    fireEvent.keyDown(input, { key: 'y', ctrlKey: true });
-    expect(props.onUndo).not.toHaveBeenCalled();
-    expect(props.onRedo).not.toHaveBeenCalled();
-    input.remove();
-  });
-
   test('undo/redo disabled states', () => {
     const props = createProps({ canUndo: false, canRedo: false });
     renderActionBar(props);

--- a/src/components/__tests__/ActionBar.test.tsx
+++ b/src/components/__tests__/ActionBar.test.tsx
@@ -2,12 +2,6 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import { ActionBar } from '../ActionBar';
 import { toast } from '@/components/ui/sonner-toast';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
-import {
-  UNDO_COUNT,
-  UNDO_MILESTONES,
-  REDO_COUNT,
-  REDO_MILESTONES,
-} from '@/lib/storage-keys';
 import i18n from '@/i18n';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
@@ -303,61 +297,4 @@ describe('ActionBar', () => {
     expect(screen.getByRole('button', { name: /copy/i })).toBeTruthy();
   });
 
-  test('undo counter persists and milestone triggers once', () => {
-    localStorage.setItem(UNDO_COUNT, '99');
-    localStorage.setItem(UNDO_MILESTONES, '[]');
-    (trackEvent as jest.Mock).mockClear();
-    const props = createProps();
-    const { unmount } = renderActionBar(props);
-    const undoBtn = screen.getByRole('button', { name: /undo/i });
-    fireEvent.click(undoBtn);
-    expect(JSON.parse(localStorage.getItem(UNDO_COUNT) || '0')).toBe(100);
-    let calls = (trackEvent as jest.Mock).mock.calls.filter(
-      (c) => c[1] === AnalyticsEvent.Undo100,
-    );
-    expect(calls.length).toBe(1);
-    expect(JSON.parse(localStorage.getItem(UNDO_MILESTONES) || '[]')).toEqual([
-      100,
-    ]);
-    unmount();
-    renderActionBar(props);
-    fireEvent.click(screen.getByRole('button', { name: /undo/i }));
-    expect(JSON.parse(localStorage.getItem(UNDO_COUNT) || '0')).toBe(101);
-    calls = (trackEvent as jest.Mock).mock.calls.filter(
-      (c) => c[1] === AnalyticsEvent.Undo100,
-    );
-    expect(calls.length).toBe(1);
-    expect(JSON.parse(localStorage.getItem(UNDO_MILESTONES) || '[]')).toEqual([
-      100,
-    ]);
-  });
-
-  test('redo counter persists and milestone triggers once', () => {
-    localStorage.setItem(REDO_COUNT, '99');
-    localStorage.setItem(REDO_MILESTONES, '[]');
-    (trackEvent as jest.Mock).mockClear();
-    const props = createProps();
-    const { unmount } = renderActionBar(props);
-    const redoBtn = screen.getByRole('button', { name: /redo/i });
-    fireEvent.click(redoBtn);
-    expect(JSON.parse(localStorage.getItem(REDO_COUNT) || '0')).toBe(100);
-    let calls = (trackEvent as jest.Mock).mock.calls.filter(
-      (c) => c[1] === AnalyticsEvent.Redo100,
-    );
-    expect(calls.length).toBe(1);
-    expect(JSON.parse(localStorage.getItem(REDO_MILESTONES) || '[]')).toEqual([
-      100,
-    ]);
-    unmount();
-    renderActionBar(props);
-    fireEvent.click(screen.getByRole('button', { name: /redo/i }));
-    expect(JSON.parse(localStorage.getItem(REDO_COUNT) || '0')).toBe(101);
-    calls = (trackEvent as jest.Mock).mock.calls.filter(
-      (c) => c[1] === AnalyticsEvent.Redo100,
-    );
-    expect(calls.length).toBe(1);
-    expect(JSON.parse(localStorage.getItem(REDO_MILESTONES) || '[]')).toEqual([
-      100,
-    ]);
-  });
 });

--- a/src/components/__tests__/ActionBar.test.tsx
+++ b/src/components/__tests__/ActionBar.test.tsx
@@ -147,6 +147,8 @@ function createProps(
     onToggleDarkModeToggleVisible: jest.fn(),
     floatingJsonEnabled: false,
     onToggleFloatingJson: jest.fn(),
+    shortcutsEnabled: true,
+    onToggleShortcuts: jest.fn(),
     actionLabelsEnabled: true,
     onToggleActionLabels: jest.fn(),
     coreActionLabelsOnly: false,

--- a/src/components/__tests__/Dashboard.undo-redo-shortcuts.test.tsx
+++ b/src/components/__tests__/Dashboard.undo-redo-shortcuts.test.tsx
@@ -1,0 +1,125 @@
+import { render, fireEvent } from '@testing-library/react';
+import Dashboard from '../Dashboard';
+import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
+import {
+  UNDO_COUNT,
+  UNDO_MILESTONES,
+  REDO_COUNT,
+  REDO_MILESTONES,
+} from '@/lib/storage-keys';
+
+jest.mock('../HistoryPanel', () => ({ __esModule: true, default: () => null }));
+jest.mock('../ControlPanel', () => ({
+  __esModule: true,
+  ControlPanel: () => null,
+}));
+jest.mock('../ShareModal', () => ({
+  __esModule: true,
+  ShareModal: () => null,
+}));
+jest.mock('../ImportModal', () => ({ __esModule: true, default: () => null }));
+jest.mock('../Footer', () => ({ __esModule: true, default: () => null }));
+jest.mock('../DisclaimerModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../ProgressBar', () => ({
+  __esModule: true,
+  ProgressBar: () => null,
+  default: () => null,
+}));
+jest.mock('@/hooks/use-single-column', () => ({
+  __esModule: true,
+  useIsSingleColumn: jest.fn(() => false),
+}));
+jest.mock('@/hooks/use-dark-mode', () => ({
+  __esModule: true,
+  useDarkMode: jest.fn(() => [false, jest.fn()] as const),
+}));
+jest.mock('@/hooks/use-dark-mode-toggle-visibility', () => ({
+  __esModule: true,
+  useDarkModeToggleVisibility: jest.fn(() => [true, jest.fn()] as const),
+}));
+jest.mock('@/hooks/use-tracking', () => ({
+  __esModule: true,
+  useTracking: jest.fn(() => [true, jest.fn()] as const),
+}));
+jest.mock('@/hooks/use-action-history', () => ({
+  __esModule: true,
+  useActionHistory: jest.fn(() => []),
+}));
+jest.mock('@/hooks/use-sora-userscript', () => ({
+  __esModule: true,
+  useSoraUserscript: jest.fn(() => [true, '1.0'] as const),
+}));
+jest.mock('@/hooks/use-github-stats', () => ({
+  __esModule: true,
+  useGithubStats: jest.fn(() => ({})),
+}));
+jest.mock('@/hooks/use-clipboard', () => ({
+  __esModule: true,
+  useClipboard: () => ({ copy: jest.fn(() => Promise.resolve(true)) }),
+}));
+jest.mock('@/lib/analytics', () => {
+  const actual = jest.requireActual('@/lib/analytics');
+  return { __esModule: true, ...actual, trackEvent: jest.fn() };
+});
+jest.mock('@/components/ui/sonner-toast', () => ({
+  __esModule: true,
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+describe('Dashboard keyboard undo/redo counters', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    (trackEvent as jest.Mock).mockClear();
+    window.matchMedia = jest.fn().mockReturnValue({
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }) as unknown as typeof window.matchMedia;
+  });
+
+  test('keyboard shortcuts increment counters and emit milestones once', () => {
+    localStorage.setItem(UNDO_COUNT, '99');
+    localStorage.setItem(UNDO_MILESTONES, '[]');
+    localStorage.setItem(REDO_COUNT, '99');
+    localStorage.setItem(REDO_MILESTONES, '[]');
+    render(<Dashboard />);
+
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+    let calls = (trackEvent as jest.Mock).mock.calls.filter(
+      (c) => c[1] === AnalyticsEvent.Undo100,
+    );
+    expect(JSON.parse(localStorage.getItem(UNDO_COUNT) || '0')).toBe(100);
+    expect(calls.length).toBe(1);
+    expect(JSON.parse(localStorage.getItem(UNDO_MILESTONES) || '[]')).toEqual([100]);
+
+    (trackEvent as jest.Mock).mockClear();
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+    calls = (trackEvent as jest.Mock).mock.calls.filter(
+      (c) => c[1] === AnalyticsEvent.Undo100,
+    );
+    expect(JSON.parse(localStorage.getItem(UNDO_COUNT) || '0')).toBe(101);
+    expect(calls.length).toBe(0);
+    expect(JSON.parse(localStorage.getItem(UNDO_MILESTONES) || '[]')).toEqual([100]);
+
+    (trackEvent as jest.Mock).mockClear();
+    fireEvent.keyDown(window, { key: 'y', ctrlKey: true });
+    calls = (trackEvent as jest.Mock).mock.calls.filter(
+      (c) => c[1] === AnalyticsEvent.Redo100,
+    );
+    expect(JSON.parse(localStorage.getItem(REDO_COUNT) || '0')).toBe(100);
+    expect(calls.length).toBe(1);
+    expect(JSON.parse(localStorage.getItem(REDO_MILESTONES) || '[]')).toEqual([100]);
+
+    (trackEvent as jest.Mock).mockClear();
+    fireEvent.keyDown(window, { key: 'y', ctrlKey: true });
+    calls = (trackEvent as jest.Mock).mock.calls.filter(
+      (c) => c[1] === AnalyticsEvent.Redo100,
+    );
+    expect(JSON.parse(localStorage.getItem(REDO_COUNT) || '0')).toBe(101);
+    expect(calls.length).toBe(0);
+    expect(JSON.parse(localStorage.getItem(REDO_MILESTONES) || '[]')).toEqual([100]);
+  });
+});
+

--- a/src/components/__tests__/Dashboard.undo-redo-shortcuts.test.tsx
+++ b/src/components/__tests__/Dashboard.undo-redo-shortcuts.test.tsx
@@ -6,6 +6,7 @@ import {
   UNDO_MILESTONES,
   REDO_COUNT,
   REDO_MILESTONES,
+  KEYBOARD_SHORTCUTS_ENABLED,
 } from '@/lib/storage-keys';
 
 jest.mock('../HistoryPanel', () => ({ __esModule: true, default: () => null }));
@@ -120,6 +121,14 @@ describe('Dashboard keyboard undo/redo counters', () => {
     expect(JSON.parse(localStorage.getItem(REDO_COUNT) || '0')).toBe(101);
     expect(calls.length).toBe(0);
     expect(JSON.parse(localStorage.getItem(REDO_MILESTONES) || '[]')).toEqual([100]);
+  });
+
+  test('shortcuts can be disabled', () => {
+    localStorage.setItem(KEYBOARD_SHORTCUTS_ENABLED, 'false');
+    render(<Dashboard />);
+
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+    expect(localStorage.getItem(UNDO_COUNT)).toBe(null);
   });
 });
 

--- a/src/components/__tests__/SettingsPanel.test.tsx
+++ b/src/components/__tests__/SettingsPanel.test.tsx
@@ -94,6 +94,8 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof SettingsPane
     onToggleDarkModeToggleVisible: jest.fn(),
     floatingJsonEnabled: false,
     onToggleFloatingJson: jest.fn(),
+    shortcutsEnabled: true,
+    onToggleShortcuts: jest.fn(),
     actionLabelsEnabled: true,
     onToggleActionLabels: jest.fn(),
     coreActionLabelsOnly: false,

--- a/src/hooks/__tests__/use-keyboard-shortcuts.test.ts
+++ b/src/hooks/__tests__/use-keyboard-shortcuts.test.ts
@@ -1,0 +1,36 @@
+import { renderHook, fireEvent } from '@testing-library/react';
+import { useKeyboardShortcuts } from '../use-keyboard-shortcuts';
+
+describe('useKeyboardShortcuts', () => {
+  test('triggers handlers on shortcuts', () => {
+    const onCopy = jest.fn();
+    const onUndo = jest.fn();
+    const onRedo = jest.fn();
+    renderHook(() => useKeyboardShortcuts({ onCopy, onUndo, onRedo }));
+
+    fireEvent.keyDown(window, { key: 'c', ctrlKey: true });
+    expect(onCopy).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true, shiftKey: true });
+    expect(onRedo).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(window, { key: 'y', ctrlKey: true });
+    expect(onRedo).toHaveBeenCalledTimes(2);
+  });
+
+  test('shortcuts ignored when typing', () => {
+    const onCopy = jest.fn();
+    const onUndo = jest.fn();
+    const onRedo = jest.fn();
+    renderHook(() => useKeyboardShortcuts({ onCopy, onUndo, onRedo }));
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    fireEvent.keyDown(input, { key: 'c', ctrlKey: true });
+    fireEvent.keyDown(input, { key: 'z', ctrlKey: true });
+    expect(onCopy).not.toHaveBeenCalled();
+    expect(onUndo).not.toHaveBeenCalled();
+    input.remove();
+  });
+});

--- a/src/hooks/__tests__/use-keyboard-shortcuts.test.ts
+++ b/src/hooks/__tests__/use-keyboard-shortcuts.test.ts
@@ -32,5 +32,13 @@ describe('useKeyboardShortcuts', () => {
     expect(onCopy).not.toHaveBeenCalled();
     expect(onUndo).not.toHaveBeenCalled();
     input.remove();
+});
+
+  test('does not register when disabled', () => {
+    const onCopy = jest.fn();
+    renderHook(() => useKeyboardShortcuts({ onCopy }, false));
+
+    fireEvent.keyDown(window, { key: 'c', ctrlKey: true });
+    expect(onCopy).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/use-keyboard-shortcuts-enabled.ts
+++ b/src/hooks/use-keyboard-shortcuts-enabled.ts
@@ -1,0 +1,10 @@
+import { useLocalStorageState } from './use-local-storage-state';
+import { KEYBOARD_SHORTCUTS_ENABLED } from '@/lib/storage-keys';
+
+/**
+ * Manages the global keyboard shortcuts enabled state.
+ * Defaults to `true` and persists the preference in localStorage.
+ */
+export function useKeyboardShortcutsEnabled() {
+  return useLocalStorageState(KEYBOARD_SHORTCUTS_ENABLED, true);
+}

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -11,8 +11,13 @@ interface ShortcutHandlers {
  *
  * @param handlers Callback functions for the respective keyboard shortcuts.
  */
-export function useKeyboardShortcuts({ onCopy, onUndo, onRedo }: ShortcutHandlers) {
+export function useKeyboardShortcuts(
+  { onCopy, onUndo, onRedo }: ShortcutHandlers,
+  enabled = true,
+) {
   useEffect(() => {
+    if (!enabled) return;
+
     const handleKeyDown = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
       if (
@@ -58,7 +63,7 @@ export function useKeyboardShortcuts({ onCopy, onUndo, onRedo }: ShortcutHandler
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onCopy, onUndo, onRedo]);
+  }, [onCopy, onUndo, onRedo, enabled]);
 }
 
 export default useKeyboardShortcuts;

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+
+interface ShortcutHandlers {
+  onCopy?: () => void;
+  onUndo?: () => void;
+  onRedo?: () => void;
+}
+
+/**
+ * Registers global keyboard shortcuts for copy, undo and redo actions.
+ *
+ * @param handlers Callback functions for the respective keyboard shortcuts.
+ */
+export function useKeyboardShortcuts({ onCopy, onUndo, onRedo }: ShortcutHandlers) {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+
+      if (e.metaKey || e.ctrlKey) {
+        const key = e.key.toLowerCase();
+        switch (key) {
+          case 'c':
+            if (onCopy) {
+              onCopy();
+              e.preventDefault();
+            }
+            break;
+          case 'z':
+            if (e.shiftKey) {
+              if (onRedo) {
+                onRedo();
+                e.preventDefault();
+              }
+            } else if (onUndo) {
+              onUndo();
+              e.preventDefault();
+            }
+            break;
+          case 'y':
+            if (onRedo) {
+              onRedo();
+              e.preventDefault();
+            }
+            break;
+          default:
+            break;
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onCopy, onUndo, onRedo]);
+}
+
+export default useKeyboardShortcuts;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -56,6 +56,7 @@ export enum AnalyticsEvent {
   ToggleActionLabels = 'toggle_action_labels',
   ToggleCoreActionLabels = 'toggle_core_action_labels',
   ToggleFloatingJson = 'toggle_floating_json',
+  ToggleKeyboardShortcuts = 'toggle_keyboard_shortcuts',
   ToggleDarkModeButton = 'toggle_dark_mode_button',
   PurgeCache = 'purge_cache',
   DisableTrackingConfirm = 'disable_tracking_confirm',

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -5,6 +5,7 @@ export const HEADER_VISIBLE = 'headerVisible';
 export const HEADER_BUTTONS_ENABLED = 'headerButtonsEnabled';
 export const LOGO_ENABLED = 'logoEnabled';
 export const FLOATING_JSON_ENABLED = 'floatingJsonEnabled';
+export const KEYBOARD_SHORTCUTS_ENABLED = 'keyboardShortcutsEnabled';
 export const ACTION_LABELS_ENABLED = 'actionLabelsEnabled';
 export const CORE_ACTION_LABELS_ONLY = 'coreActionLabelsOnly';
 export const TRACKING_ENABLED = 'trackingEnabled';


### PR DESCRIPTION
## Summary
- add `useKeyboardShortcuts` hook to register copy/undo/redo keys
- wire keyboard shortcuts into Dashboard
- document available shortcuts
- test hook behavior for key presses

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1d6ab61748325b2ea483bd0b38e9a