### PR TITLE
Use line-based diff for GeneratedJson highlighting

### DIFF
--- a/src/components/__tests__/GeneratedJson.test.tsx
+++ b/src/components/__tests__/GeneratedJson.test.tsx
@@ -34,7 +34,7 @@ describe('GeneratedJson', () => {
     expect(trackEvent).toHaveBeenCalledWith(true, AnalyticsEvent.JsonChanged);
     const added = container.querySelectorAll('span.animate-highlight');
     expect(added.length).toBeGreaterThan(0);
-    expect(added[0].textContent).toBe(',"b":2');
+    expect(added[0].textContent).toBe('{"a":1,"b":2}');
 
     act(() => {
       jest.advanceTimersByTime(2000);


### PR DESCRIPTION
## Summary
- switch GeneratedJson to use `diffLines` for line-based diffs
- render diff results per line and adjust scroll logic
- update GeneratedJson test expectations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1dcc5cb348325808e3e15ad1a7511