### PR TITLE
feat(history): add entry titles

### DIFF
--- a/src/__tests__/app.integration.test.tsx
+++ b/src/__tests__/app.integration.test.tsx
@@ -94,6 +94,8 @@ describe('App integration flow', () => {
     fireEvent.click(historyButton);
 
     const dialog = await screen.findByRole('dialog');
-    expect(within(dialog).getByText('Integration test prompt')).toBeTruthy();
+    expect(
+      within(dialog).getAllByText('Integration test prompt').length,
+    ).toBeGreaterThan(0);
   }, 15000);
 });

--- a/src/components/__tests__/BulkFileImportModal.test.tsx
+++ b/src/components/__tests__/BulkFileImportModal.test.tsx
@@ -56,7 +56,9 @@ describe('BulkFileImportModal', () => {
     const button = screen.getByRole('button', { name: /import/i });
     fireEvent.click(button);
     await waitFor(() =>
-      expect(onImport).toHaveBeenCalledWith(['{"prompt":"test"}']),
+      expect(onImport).toHaveBeenCalledWith([
+        { json: '{"prompt":"test"}', title: undefined },
+      ]),
     );
     expect(trackEvent).toHaveBeenCalledWith(true, AnalyticsEvent.HistoryImport, {
       type: 'bulk_file',

--- a/src/components/__tests__/ClipboardImportModal.test.tsx
+++ b/src/components/__tests__/ClipboardImportModal.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import ClipboardImportModal from '../ClipboardImportModal';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
-import i18n from '@/i18n';
 import { useTracking } from '@/hooks/use-tracking';
 import { toast } from '@/components/ui/sonner-toast';
 import i18n from '@/i18n';
@@ -46,7 +45,9 @@ describe('ClipboardImportModal', () => {
     const button = screen.getByRole('button', { name: /import/i });
     fireEvent.click(button);
 
-    expect(onImport).toHaveBeenCalledWith(['{"prompt":"test"}']);
+    expect(onImport).toHaveBeenCalledWith([
+      { json: '{"prompt":"test"}', title: undefined },
+    ]);
     expect(trackEvent).toHaveBeenCalledWith(true, AnalyticsEvent.HistoryImport, {
       type: 'clipboard',
     });
@@ -73,8 +74,8 @@ describe('ClipboardImportModal', () => {
     fireEvent.click(button);
 
     expect(onImport).toHaveBeenCalledWith([
-      '{"prompt":"one"}',
-      '{"prompt":"two"}',
+      { json: '{"prompt":"one"}', title: undefined },
+      { json: '{"prompt":"two"}', title: undefined },
     ]);
     expect(trackEvent).toHaveBeenCalledWith(true, AnalyticsEvent.HistoryImport, {
       type: 'clipboard',
@@ -95,7 +96,7 @@ describe('ClipboardImportModal', () => {
     );
     const textarea = screen.getByPlaceholderText(/paste json/i);
     const objectArrayText = JSON.stringify([
-      { json: '{"prompt":"one"}' },
+      { json: '{"prompt":"one"}', title: 't1' },
       { json: '{"prompt":"two"}' },
     ]);
     fireEvent.change(textarea, {
@@ -105,8 +106,8 @@ describe('ClipboardImportModal', () => {
     fireEvent.click(button);
 
     expect(onImport).toHaveBeenCalledWith([
-      '{"prompt":"one"}',
-      '{"prompt":"two"}',
+      { json: '{"prompt":"one"}', title: 't1' },
+      { json: '{"prompt":"two"}', title: undefined },
     ]);
     expect(trackEvent).toHaveBeenCalledWith(true, AnalyticsEvent.HistoryImport, {
       type: 'clipboard',

--- a/src/components/__tests__/DashboardHistory.test.tsx
+++ b/src/components/__tests__/DashboardHistory.test.tsx
@@ -13,11 +13,15 @@ import { useActionHistory } from '@/hooks/use-action-history';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
 import { JSON_HISTORY } from '@/lib/storage-keys';
 
-let importFn: ((jsons: string[]) => void) | null = null;
+let importFn: ((entries: { json: string; title?: string }[]) => void) | null = null;
 
 jest.mock('../HistoryPanel', () => ({
   __esModule: true,
-  default: ({ onImport }: { onImport: (jsons: string[]) => void }) => {
+  default: ({
+    onImport,
+  }: {
+    onImport: (entries: { json: string; title?: string }[]) => void;
+  }) => {
     importFn = onImport;
     return null;
   },
@@ -79,6 +83,7 @@ function createEntries(n: number) {
     date: 'd',
     json: '{}',
     favorite: false,
+    title: `t${i}`,
   }));
 }
 
@@ -119,7 +124,7 @@ describe('Dashboard history limit', () => {
     });
 
     act(() => {
-      importFn?.(Array(20).fill('{}'));
+      importFn?.(Array(20).fill({ json: '{}' }));
     });
 
     await waitFor(() => {

--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -82,6 +82,7 @@ const sampleHistory = Array.from({ length: 20 }, (_, i) => ({
   date: 'd',
   json: `{"prompt":"p${i}"}`,
   favorite: i % 2 === 0,
+  title: `title${i}`,
 }));
 const sampleActions = [{ date: 'd', action: 'a' }];
 
@@ -99,6 +100,7 @@ function renderPanel(
     onEdit: jest.fn(),
     onImport: jest.fn(),
     onToggleFavorite: jest.fn(),
+    onRename: jest.fn(),
   };
   return render(
     <TooltipProvider>
@@ -247,6 +249,23 @@ describe('HistoryPanel basic actions', () => {
 
     expect(screen.queryByText('p2')).toBeNull();
     expect(screen.getByText('p1')).toBeTruthy();
+
+    fireEvent.change(input, { target: { value: 'title2' } });
+    expect(screen.queryByText('p1')).toBeNull();
+    expect(screen.getByText('title2')).toBeTruthy();
+  });
+
+  test('renames history entry', () => {
+    const onRename = jest.fn();
+    renderPanel({ onRename });
+    const renameBtn = screen.getAllByRole('button', { name: /rename/i })[0];
+    fireEvent.click(renameBtn);
+    const dialog = screen.getByRole('dialog');
+    const input = within(dialog).getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'new title' } });
+    const saveBtn = within(dialog).getByRole('button', { name: /save/i });
+    fireEvent.click(saveBtn);
+    expect(onRename).toHaveBeenCalledWith(1, 'new title');
   });
 
   test('toggles favorites and filters favorites', () => {

--- a/src/components/history/HistoryItem.tsx
+++ b/src/components/history/HistoryItem.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { Clipboard, Trash2, Edit, Eye, Check, Star } from 'lucide-react';
+import { Clipboard, Trash2, Edit, Eye, Check, Star, Pencil } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
 import type { HistoryEntry } from '../HistoryPanel';
@@ -18,6 +18,7 @@ interface HistoryItemProps {
   onPreview: (entry: HistoryEntry) => void;
   trackingEnabled: boolean;
   onToggleFavorite: (id: number) => void;
+  onRename: (entry: HistoryEntry) => void;
 }
 
 const HistoryItem: React.FC<HistoryItemProps> = ({
@@ -28,6 +29,7 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
   onPreview,
   trackingEnabled,
   onToggleFavorite,
+  onRename,
 }) => {
   const { t } = useTranslation();
   const [edited, setEdited] = useState(false);
@@ -39,18 +41,19 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
       <div className="text-xs text-muted-foreground flex justify-between">
         <span>{entry.date}</span>
       </div>
-      {(() => {
-        try {
-          const obj = JSON.parse(entry.json);
-          return (
-            <div className="space-y-1 text-xs text-muted-foreground">
-              <div className="font-medium break-words">{obj.prompt}</div>
-            </div>
-          );
-        } catch {
-          return null;
-        }
-      })()}
+      <div className="space-y-1 text-xs text-muted-foreground">
+        <div className="font-medium break-words text-foreground">
+          {entry.title}
+        </div>
+        {(() => {
+          try {
+            const obj = JSON.parse(entry.json);
+            return <div className="break-words">{obj.prompt}</div>;
+          } catch {
+            return null;
+          }
+        })()}
+      </div>
       <div className="flex flex-wrap gap-2">
         <Tooltip>
           <TooltipTrigger asChild>
@@ -89,6 +92,19 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent>{copied ? t('copied') : t('copy')}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onRename(entry)}
+              className="gap-1"
+            >
+              <Pencil className="w-4 h-4" /> {t('rename', { defaultValue: 'Rename' })}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('rename', { defaultValue: 'Rename' })}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- allow naming history entries and filter by title
- preserve titles through import/export with default title migration
- test history naming and search

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b605c3ccd8832597f7fa90fa2ce595