### PR TITLE
feat: add presets management tab

### DIFF
--- a/src/components/__tests__/SettingsPanel.presets.test.tsx
+++ b/src/components/__tests__/SettingsPanel.presets.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import SettingsPanel from '../SettingsPanel';
+import i18n from '@/i18n';
+import {
+  importCustomPresets,
+  loadCustomPresetsFromUrl,
+  exportCurrentPresets,
+  resetPresetCollections,
+} from '@/lib/presetLoader';
+import { toast } from '@/components/ui/sonner-toast';
+
+jest.mock('@/lib/presetLoader', () => ({
+  importCustomPresets: jest.fn(),
+  loadCustomPresetsFromUrl: jest.fn(),
+  exportCurrentPresets: jest.fn(() => ({})),
+  resetPresetCollections: jest.fn(),
+}));
+
+jest.mock('@/components/ui/sonner-toast', () => ({
+  __esModule: true,
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('@/hooks/use-dark-mode', () => ({
+  __esModule: true,
+  useDarkMode: jest.fn(() => [false, jest.fn()] as const),
+}));
+
+jest.mock('@/components/ui/dialog', () => ({
+  __esModule: true,
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('@/components/ui/button', () => ({
+  __esModule: true,
+  Button: ({ children, ...props }: { children: React.ReactNode } & React.ComponentProps<'button'>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+jest.mock('@/components/ui/scroll-area', () => ({
+  __esModule: true,
+  ScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('@/components/ui/alert-dialog', () => ({
+  __esModule: true,
+  AlertDialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogAction: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+  AlertDialogCancel: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+
+function renderPanel(overrides: Partial<React.ComponentProps<typeof SettingsPanel>> = {}) {
+  const props = {
+    open: true,
+    onOpenChange: jest.fn(),
+    onImport: jest.fn(),
+    onReset: jest.fn(),
+    onRegenerate: jest.fn(),
+    onRandomize: jest.fn(),
+    trackingEnabled: false,
+    onToggleTracking: jest.fn(),
+    soraToolsEnabled: true,
+    onToggleSoraTools: jest.fn(),
+    headerVisible: true,
+    onToggleHeaderVisible: jest.fn(),
+    headerButtonsEnabled: true,
+    onToggleHeaderButtons: jest.fn(),
+    logoEnabled: true,
+    onToggleLogo: jest.fn(),
+    darkModeToggleVisible: true,
+    onToggleDarkModeToggleVisible: jest.fn(),
+    floatingJsonEnabled: false,
+    onToggleFloatingJson: jest.fn(),
+    shortcutsEnabled: true,
+    onToggleShortcuts: jest.fn(),
+    actionLabelsEnabled: true,
+    onToggleActionLabels: jest.fn(),
+    coreActionLabelsOnly: false,
+    onToggleCoreActionLabels: jest.fn(),
+    defaultTab: 'presets' as const,
+    ...overrides,
+  };
+  return render(<SettingsPanel {...props} />);
+}
+
+describe('SettingsPanel presets tab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('export presets to file', () => {
+    (exportCurrentPresets as jest.Mock).mockReturnValue({ a: ['b'] });
+    Object.assign(URL, {
+      createObjectURL: jest.fn(() => 'blob:url'),
+      revokeObjectURL: jest.fn(),
+    });
+    renderPanel();
+    const exportBtn = screen.getByRole('button', { name: /export presets/i });
+    fireEvent.click(exportBtn);
+    expect(exportCurrentPresets).toHaveBeenCalled();
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith('Presets exported');
+  });
+
+  test('load presets from url and clear', async () => {
+    renderPanel();
+    const urlInput = screen.getByPlaceholderText(/preset pack url/i);
+    fireEvent.change(urlInput, { target: { value: 'http://example.com' } });
+    const loadBtn = screen.getByRole('button', { name: /load presets/i });
+    fireEvent.click(loadBtn);
+    expect(loadCustomPresetsFromUrl).toHaveBeenCalledWith('http://example.com');
+
+    const clearBtn = screen.getByRole('button', { name: /clear presets/i });
+    fireEvent.click(clearBtn);
+    expect(resetPresetCollections).toHaveBeenCalled();
+  });
+
+  test('apply edited presets', () => {
+    renderPanel();
+    const boxes = screen.getAllByRole('textbox');
+    const textarea = boxes[1];
+    fireEvent.change(textarea, { target: { value: '{"x":["y"]}' } });
+    const applyBtn = screen.getByRole('button', { name: /apply/i });
+    fireEvent.click(applyBtn);
+    expect(importCustomPresets).toHaveBeenCalledWith({ x: ['y'] });
+  });
+});

--- a/src/lib/presetLoader.ts
+++ b/src/lib/presetLoader.ts
@@ -8,6 +8,17 @@ import {
 } from '@/data/locationPresets';
 import * as dndPresets from '@/data/dndPresets';
 
+// Preserve initial preset values for reset/export operations
+const originalStylePresets = JSON.parse(JSON.stringify(stylePresets));
+const originalCameraPresets = JSON.parse(JSON.stringify(cameraPresets));
+const originalLocationPresets = {
+  environmentOptions: [...environmentOptions],
+  locationOptions: [...locationOptions],
+  seasonOptions: [...seasonOptions],
+  atmosphereMoodOptions: [...atmosphereMoodOptions],
+};
+const originalDndPresets = JSON.parse(JSON.stringify(dndPresets));
+
 export interface CustomPresetData {
   stylePresets?: Record<string, string[]>;
   cameraPresets?: Partial<typeof cameraPresets>;
@@ -145,5 +156,61 @@ export async function loadCustomPresetsFromUrl(url: string) {
     importCustomPresets(json);
   } catch (err) {
     throw new Error('Failed to load custom presets: ' + err);
+  }
+}
+
+/**
+ * Export the current in-memory preset collections.
+ */
+export function exportCurrentPresets(): CustomPresetData {
+  return {
+    stylePresets: { ...stylePresets },
+    cameraPresets: { ...(cameraPresets as Record<string, string[]>) },
+    locationPresets: {
+      environmentOptions: [...environmentOptions],
+      locationOptions: [...locationOptions],
+      seasonOptions: [...seasonOptions],
+      atmosphereMoodOptions: [...atmosphereMoodOptions],
+    },
+    dndPresets: { ...(dndPresets as Record<string, string[]>) },
+  };
+}
+
+/**
+ * Reset all preset collections to their original values.
+ */
+export function resetPresetCollections(): void {
+  for (const key of Object.keys(originalStylePresets)) {
+    stylePresets[key] = [...originalStylePresets[key]];
+  }
+  for (const key of Object.keys(originalCameraPresets)) {
+    (cameraPresets as Record<string, string[]>)[key] = [
+      ...originalCameraPresets[key],
+    ];
+  }
+  environmentOptions.splice(
+    0,
+    environmentOptions.length,
+    ...originalLocationPresets.environmentOptions,
+  );
+  locationOptions.splice(
+    0,
+    locationOptions.length,
+    ...originalLocationPresets.locationOptions,
+  );
+  seasonOptions.splice(
+    0,
+    seasonOptions.length,
+    ...originalLocationPresets.seasonOptions,
+  );
+  atmosphereMoodOptions.splice(
+    0,
+    atmosphereMoodOptions.length,
+    ...originalLocationPresets.atmosphereMoodOptions,
+  );
+  for (const key of Object.keys(originalDndPresets)) {
+    (dndPresets as Record<string, string[]>)[key] = [
+      ...originalDndPresets[key],
+    ];
   }
 }


### PR DESCRIPTION
## Summary
- add presets management UI with import/export and editing
- support exporting and resetting preset collections
- test presets tab interactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b623b740608325ac018201fc840859