### PR TITLE
feat: allow custom values in dropdowns

### DIFF
--- a/src/components/MultiSelectDropdown.tsx
+++ b/src/components/MultiSelectDropdown.tsx
@@ -18,6 +18,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from '@/components/ui/tooltip';
+import { addCustomValue } from '@/lib/storage';
 
 interface MultiSelectDropdownProps {
   options: readonly string[];
@@ -27,6 +28,7 @@ interface MultiSelectDropdownProps {
   label?: string;
   getOptionLabel?: (option: string) => string;
   disabled?: boolean;
+  optionKey?: string;
 }
 
 /**
@@ -51,6 +53,7 @@ export const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
   label,
   getOptionLabel,
   disabled = false,
+  optionKey,
 }) => {
   const { t } = useTranslation();
   const placeholderText = placeholder ?? t('multiSelectPlaceholder');
@@ -177,6 +180,24 @@ export const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
               ))}
             </div>
           </ScrollArea>
+          {optionKey && (
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => {
+                const input = window.prompt('Enter custom value');
+                const custom = input?.trim();
+                if (!custom) return;
+                addCustomValue(optionKey, custom);
+                onValueChange([...value, custom]);
+                setIsOpen(false);
+                setSearchQuery('');
+              }}
+              disabled={disabled}
+            >
+              Add custom value
+            </Button>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/SearchableDropdown.tsx
+++ b/src/components/SearchableDropdown.tsx
@@ -17,6 +17,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from '@/components/ui/tooltip';
+import { addCustomValue } from '@/lib/storage';
 
 interface SearchableDropdownProps {
   options: readonly string[];
@@ -26,6 +27,7 @@ interface SearchableDropdownProps {
   label?: string;
   disabled?: boolean;
   getOptionLabel?: (option: string) => string;
+  optionKey?: string;
 }
 
 export const SearchableDropdown: React.FC<SearchableDropdownProps> = ({
@@ -36,6 +38,7 @@ export const SearchableDropdown: React.FC<SearchableDropdownProps> = ({
   label,
   disabled = false,
   getOptionLabel,
+  optionKey,
 }) => {
   const { t } = useTranslation();
   const placeholderText = placeholder ?? t('searchablePlaceholder');
@@ -142,6 +145,24 @@ export const SearchableDropdown: React.FC<SearchableDropdownProps> = ({
               ))}
             </div>
           </ScrollArea>
+          {optionKey && (
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => {
+                const input = window.prompt('Enter custom value');
+                const custom = input?.trim();
+                if (!custom) return;
+                addCustomValue(optionKey, custom);
+                onValueChange(custom);
+                setIsOpen(false);
+                setSearchQuery('');
+              }}
+              disabled={disabled}
+            >
+              Add custom value
+            </Button>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/__tests__/MultiSelectDropdown.test.tsx
+++ b/src/components/__tests__/MultiSelectDropdown.test.tsx
@@ -115,4 +115,28 @@ describe('MultiSelectDropdown', () => {
       screen.queryByPlaceholderText(i18n.t('searchOptionsPlaceholder')),
     ).toBeNull();
   });
+
+  test('adds a custom value and selects it', () => {
+    localStorage.clear();
+    const handleChange = jest.fn();
+    const promptSpy = jest
+      .spyOn(window, 'prompt')
+      .mockReturnValue('bazooka');
+    render(
+      <MultiSelectDropdown
+        options={options}
+        value={[]}
+        onValueChange={handleChange}
+        optionKey="things"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('button', { name: 'Add custom value' }));
+
+    expect(handleChange).toHaveBeenCalledWith(['bazooka']);
+    const stored = JSON.parse(localStorage.getItem('customValues') || '{}');
+    expect(stored.things).toContain('bazooka');
+    promptSpy.mockRestore();
+  });
 });

--- a/src/components/__tests__/SearchableDropdown.test.tsx
+++ b/src/components/__tests__/SearchableDropdown.test.tsx
@@ -70,4 +70,30 @@ describe('SearchableDropdown', () => {
       screen.queryByPlaceholderText(i18n.t('searchOptionsPlaceholder')),
     ).toBeNull();
   });
+
+  test('allows adding a custom value', () => {
+    localStorage.clear();
+    const handleChange = jest.fn();
+    const promptSpy = jest
+      .spyOn(window, 'prompt')
+      .mockReturnValue('orange');
+    render(
+      <SearchableDropdown
+        options={options}
+        value=""
+        onValueChange={handleChange}
+        optionKey="fruits"
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: i18n.t('searchablePlaceholder') }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add custom value' }));
+
+    expect(handleChange).toHaveBeenCalledWith('orange');
+    const stored = JSON.parse(localStorage.getItem('customValues') || '{}');
+    expect(stored.fruits).toContain('orange');
+    promptSpy.mockRestore();
+  });
 });

--- a/src/components/sections/CameraCompositionSection.tsx
+++ b/src/components/sections/CameraCompositionSection.tsx
@@ -27,6 +27,7 @@ import {
   subjectFocusOptions,
   type SubjectFocusOption,
 } from '@/data/cameraPresets';
+import { mergeCustomValues } from '@/lib/storage';
 import { Button } from '@/components/ui/button';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { PresetDropdown } from '../PresetDropdown';
@@ -125,13 +126,14 @@ export const CameraCompositionSection: React.FC<
         <div>
           <Label>{t('cameraType')}</Label>
           <SearchableDropdown
-            options={cameraTypeOptions}
+            options={mergeCustomValues('camera_type', cameraTypeOptions)}
             value={options.camera_type}
             onValueChange={(value) => updateOptions({ camera_type: value })}
             label="Camera Type"
             getOptionLabel={(opt) =>
               translateOption(opt, cameraOptionTranslations.cameraType, t)
             }
+            optionKey="camera_type"
           />
         </div>
 
@@ -146,13 +148,14 @@ export const CameraCompositionSection: React.FC<
           <div>
             <Label>{t('lensType')}</Label>
             <SearchableDropdown
-              options={lensTypeOptions}
+              options={mergeCustomValues('lens_type', lensTypeOptions)}
               value={options.lens_type}
               onValueChange={(value) => updateOptions({ lens_type: value })}
               label="Lens Type"
               getOptionLabel={(opt) =>
                 translateOption(opt, cameraOptionTranslations.lensType, t)
               }
+              optionKey="lens_type"
             />
           </div>
         </ToggleField>
@@ -168,13 +171,14 @@ export const CameraCompositionSection: React.FC<
           <div>
             <Label>{t('shotType')}</Label>
             <SearchableDropdown
-              options={shotTypeOptions}
+              options={mergeCustomValues('shot_type', shotTypeOptions)}
               value={options.shot_type}
               onValueChange={(value) => updateOptions({ shot_type: value })}
               label="Shot Type"
               getOptionLabel={(opt) =>
                 translateOption(opt, cameraOptionTranslations.shotType, t)
               }
+              optionKey="shot_type"
             />
           </div>
         </ToggleField>
@@ -190,7 +194,7 @@ export const CameraCompositionSection: React.FC<
           <div>
             <Label>{t('cameraAngle')}</Label>
             <SearchableDropdown
-              options={cameraAngleOptions}
+              options={mergeCustomValues('camera_angle', cameraAngleOptions)}
               value={options.camera_angle}
               onValueChange={(value) =>
                 updateOptions({ camera_angle: value })
@@ -199,6 +203,7 @@ export const CameraCompositionSection: React.FC<
               getOptionLabel={(opt) =>
                 translateOption(opt, cameraOptionTranslations.cameraAngle, t)
               }
+              optionKey="camera_angle"
             />
           </div>
         </ToggleField>
@@ -240,7 +245,7 @@ export const CameraCompositionSection: React.FC<
         <div>
           <Label>{t('compositionRules')}</Label>
           <MultiSelectDropdown
-            options={compositionRulesOptions}
+            options={mergeCustomValues('composition_rules', compositionRulesOptions)}
             value={options.composition_rules}
             onValueChange={handleCompositionRulesChange}
             label="Composition Rules"
@@ -248,6 +253,7 @@ export const CameraCompositionSection: React.FC<
             getOptionLabel={(opt) =>
               translateOption(opt, cameraOptionTranslations.compositionRules, t)
             }
+            optionKey="composition_rules"
           />
         </div>
 
@@ -262,7 +268,7 @@ export const CameraCompositionSection: React.FC<
           <div>
             <Label>{t('aperture')}</Label>
             <SearchableDropdown
-              options={apertureOptions}
+              options={mergeCustomValues('aperture', apertureOptions)}
               value={options.aperture}
               onValueChange={(value) =>
                 updateOptions({ aperture: value })
@@ -271,6 +277,7 @@ export const CameraCompositionSection: React.FC<
               getOptionLabel={(opt) =>
                 translateOption(opt, cameraOptionTranslations.aperture, t)
               }
+              optionKey="aperture"
             />
           </div>
         </ToggleField>
@@ -286,7 +293,7 @@ export const CameraCompositionSection: React.FC<
           <div>
             <Label>{t('depthOfField')}</Label>
             <SearchableDropdown
-              options={depthOfFieldOptions}
+              options={mergeCustomValues('depth_of_field', depthOfFieldOptions)}
               value={options.depth_of_field || 'default'}
               onValueChange={(value) =>
                 updateOptions({ depth_of_field: value })
@@ -299,6 +306,7 @@ export const CameraCompositionSection: React.FC<
                   t,
                 )
               }
+              optionKey="depth_of_field"
             />
           </div>
         </ToggleField>
@@ -314,7 +322,7 @@ export const CameraCompositionSection: React.FC<
           <div>
             <Label>{t('blurStyle')}</Label>
             <SearchableDropdown
-              options={blurStyleOptions}
+              options={mergeCustomValues('blur_style', blurStyleOptions)}
               value={options.blur_style || 'default'}
               onValueChange={(value) =>
                 updateOptions({ blur_style: value })
@@ -323,6 +331,7 @@ export const CameraCompositionSection: React.FC<
               getOptionLabel={(opt) =>
                 translateOption(opt, cameraOptionTranslations.blurStyle, t)
               }
+              optionKey="blur_style"
             />
           </div>
         </ToggleField>

--- a/src/components/sections/ColorGradingSection.tsx
+++ b/src/components/sections/ColorGradingSection.tsx
@@ -6,6 +6,7 @@ import { CollapsibleSection } from '../CollapsibleSection';
 import type { SoraOptions } from '@/lib/soraOptions';
 
 import { colorGradingOptions } from '@/data/colorGradingOptions';
+import { mergeCustomValues } from '@/lib/storage';
 import { Button } from '@/components/ui/button';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { PresetDropdown } from '../PresetDropdown';
@@ -63,11 +64,12 @@ export const ColorGradingSection: React.FC<ColorGradingSectionProps> = ({
         <div>
           <Label>{t('colorGrade')}</Label>
           <SearchableDropdown
-            options={colorGradingOptions}
+            options={mergeCustomValues('color_grade', colorGradingOptions)}
             value={options.color_grade || 'default (no specific color grading)'}
             onValueChange={(value) => updateOptions({ color_grade: value })}
             label="Color Grade Options"
             disabled={!options.use_color_grading}
+            optionKey="color_grade"
           />
         </div>
       </div>

--- a/src/components/sections/DnDSection.tsx
+++ b/src/components/sections/DnDSection.tsx
@@ -20,6 +20,7 @@ import { getOptionLabel as translateOption } from '@/lib/optionTranslator';
 import { Button } from '@/components/ui/button';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { PresetDropdown } from '../PresetDropdown';
+import { mergeCustomValues } from '@/lib/storage';
 
 interface DnDSectionProps {
   options: SoraOptions;
@@ -121,7 +122,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <div>
             <Label>{t('characterRace')}</Label>
             <SearchableDropdown
-              options={characterRaceOptions}
+              options={mergeCustomValues('dnd_character_race', characterRaceOptions)}
               value={options.dnd_character_race || 'human'}
               onValueChange={(value) =>
                 updateOptions({ dnd_character_race: value })
@@ -130,6 +131,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
               getOptionLabel={(opt) =>
                 translateOption(opt, dndOptionTranslations.characterRace, t)
               }
+              optionKey="dnd_character_race"
             />
           </div>
         </ToggleField>
@@ -145,7 +147,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <div>
             <Label>{t('characterClass')}</Label>
             <SearchableDropdown
-              options={characterClassOptions}
+              options={mergeCustomValues('dnd_character_class', characterClassOptions)}
               value={options.dnd_character_class || 'fighter'}
               onValueChange={(value) =>
                 updateOptions({ dnd_character_class: value })
@@ -154,6 +156,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
               getOptionLabel={(opt) =>
                 translateOption(opt, dndOptionTranslations.characterClass, t)
               }
+              optionKey="dnd_character_class"
             />
           </div>
         </ToggleField>
@@ -169,7 +172,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <div>
             <Label>{t('characterBackground')}</Label>
             <SearchableDropdown
-              options={characterBackgroundOptions}
+              options={mergeCustomValues('dnd_character_background', characterBackgroundOptions)}
               value={options.dnd_character_background || 'soldier'}
               onValueChange={(value) =>
                 updateOptions({ dnd_character_background: value })
@@ -182,6 +185,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
                   t,
                 )
               }
+              optionKey="dnd_character_background"
             />
           </div>
         </ToggleField>
@@ -197,7 +201,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <div>
             <Label>{t('characterAlignment')}</Label>
             <SearchableDropdown
-              options={characterAlignmentOptions}
+              options={mergeCustomValues('dnd_character_alignment', characterAlignmentOptions)}
               value={options.dnd_character_alignment || 'lawful good'}
               onValueChange={(value) =>
                 updateOptions({ dnd_character_alignment: value })
@@ -210,6 +214,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
                   t,
                 )
               }
+              optionKey="dnd_character_alignment"
             />
           </div>
         </ToggleField>
@@ -225,7 +230,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <div>
             <Label>{t('monsterType')}</Label>
             <SearchableDropdown
-              options={monsterTypeOptions}
+              options={mergeCustomValues('dnd_monster_type', monsterTypeOptions)}
               value={options.dnd_monster_type || 'dragon'}
               onValueChange={(value) =>
                 updateOptions({ dnd_monster_type: value })
@@ -234,6 +239,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
               getOptionLabel={(opt) =>
                 translateOption(opt, dndOptionTranslations.monsterType, t)
               }
+              optionKey="dnd_monster_type"
             />
           </div>
         </ToggleField>
@@ -249,7 +255,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <div>
             <Label>{t('dndEnvironment')}</Label>
             <SearchableDropdown
-              options={dndEnvironmentOptions}
+              options={mergeCustomValues('dnd_environment', dndEnvironmentOptions)}
               value={options.dnd_environment || 'dungeon'}
               onValueChange={(value) =>
                 updateOptions({ dnd_environment: value })
@@ -258,6 +264,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
               getOptionLabel={(opt) =>
                 translateOption(opt, dndOptionTranslations.environment, t)
               }
+              optionKey="dnd_environment"
             />
           </div>
         </ToggleField>
@@ -273,7 +280,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <div>
             <Label>{t('magicSchool')}</Label>
             <SearchableDropdown
-              options={magicSchoolOptions}
+              options={mergeCustomValues('dnd_magic_school', magicSchoolOptions)}
               value={options.dnd_magic_school || 'evocation'}
               onValueChange={(value) =>
                 updateOptions({ dnd_magic_school: value })
@@ -282,6 +289,7 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
               getOptionLabel={(opt) =>
                 translateOption(opt, dndOptionTranslations.magicSchool, t)
               }
+              optionKey="dnd_magic_school"
             />
           </div>
         </ToggleField>
@@ -297,13 +305,14 @@ export const DnDSection: React.FC<DnDSectionProps> = ({
           <div>
             <Label>{t('itemType')}</Label>
             <SearchableDropdown
-              options={itemTypeOptions}
+              options={mergeCustomValues('dnd_item_type', itemTypeOptions)}
               value={options.dnd_item_type || 'magic sword'}
               onValueChange={(value) => updateOptions({ dnd_item_type: value })}
               label="Item Type Options"
               getOptionLabel={(opt) =>
                 translateOption(opt, dndOptionTranslations.itemType, t)
               }
+              optionKey="dnd_item_type"
             />
           </div>
         </ToggleField>

--- a/src/components/sections/EnhancementsSection.tsx
+++ b/src/components/sections/EnhancementsSection.tsx
@@ -12,6 +12,7 @@ import {
   safetyFilterOptions,
   qualityBoosterOptions,
 } from '@/data/enhancementOptions';
+import { mergeCustomValues } from '@/lib/storage';
 import { Button } from '@/components/ui/button';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { PresetDropdown } from '../PresetDropdown';
@@ -153,12 +154,13 @@ export const EnhancementsSection: React.FC<EnhancementsSectionProps> = ({
           <div>
             <Label>{t('safetyFilter')}</Label>
             <SearchableDropdown
-              options={safetyFilterOptions}
+              options={mergeCustomValues('safety_filter', safetyFilterOptions)}
               value={
                 options.safety_filter || 'default (auto safety level)'
               }
               onValueChange={handleSafetyFilterChange}
               label="Safety Filter Options"
+              optionKey="safety_filter"
             />
           </div>
         </ToggleField>
@@ -187,7 +189,7 @@ export const EnhancementsSection: React.FC<EnhancementsSectionProps> = ({
           <div>
             <Label>{t('qualityBooster')}</Label>
             <SearchableDropdown
-              options={qualityBoosterOptions}
+              options={mergeCustomValues('quality_booster', qualityBoosterOptions)}
               value={
                 options.quality_booster || 'default (standard quality)'
               }
@@ -195,6 +197,7 @@ export const EnhancementsSection: React.FC<EnhancementsSectionProps> = ({
                 updateOptions({ quality_booster: value })
               }
               label="Quality Booster Options"
+              optionKey="quality_booster"
             />
           </div>
         </ToggleField>

--- a/src/components/sections/FaceSection.tsx
+++ b/src/components/sections/FaceSection.tsx
@@ -17,6 +17,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { PresetDropdown } from '../PresetDropdown';
+import { mergeCustomValues } from '@/lib/storage';
 interface FaceSectionProps {
   options: SoraOptions;
   updateOptions: (updates: Partial<SoraOptions>) => void;
@@ -114,7 +115,7 @@ export const FaceSection: React.FC<FaceSectionProps> = ({
           <div>
             <Label>{t('subjectGender')}</Label>
             <SearchableDropdown
-              options={subjectGenderOptions}
+              options={mergeCustomValues('subject_gender', subjectGenderOptions)}
               value={
                 options.subject_gender || 'default (auto/inferred gender)'
               }
@@ -123,6 +124,7 @@ export const FaceSection: React.FC<FaceSectionProps> = ({
               getOptionLabel={(opt) =>
                 translateOption(opt, faceOptionTranslations.subjectGender, t)
               }
+              optionKey="subject_gender"
             />
           </div>
         </ToggleField>
@@ -138,7 +140,7 @@ export const FaceSection: React.FC<FaceSectionProps> = ({
           <div>
             <Label>{t('makeupStyle')}</Label>
             <SearchableDropdown
-              options={makeupStyleOptions}
+              options={mergeCustomValues('makeup_style', makeupStyleOptions)}
               value={
                 options.makeup_style || 'default (no specific makeup)'
               }
@@ -147,6 +149,7 @@ export const FaceSection: React.FC<FaceSectionProps> = ({
               getOptionLabel={(opt) =>
                 translateOption(opt, faceOptionTranslations.makeupStyle, t)
               }
+              optionKey="makeup_style"
             />
           </div>
         </ToggleField>
@@ -162,7 +165,7 @@ export const FaceSection: React.FC<FaceSectionProps> = ({
           <div>
             <Label>{t('characterMood')}</Label>
             <SearchableDropdown
-              options={characterMoodOptions}
+              options={mergeCustomValues('character_mood', characterMoodOptions)}
               value={
                 options.character_mood || 'default (neutral mood)'
               }
@@ -173,6 +176,7 @@ export const FaceSection: React.FC<FaceSectionProps> = ({
               getOptionLabel={(opt) =>
                 translateOption(opt, faceOptionTranslations.characterMood, t)
               }
+              optionKey="character_mood"
             />
           </div>
         </ToggleField>

--- a/src/components/sections/LightingSection.tsx
+++ b/src/components/sections/LightingSection.tsx
@@ -6,6 +6,7 @@ import { CollapsibleSection } from '../CollapsibleSection';
 import type { SoraOptions } from '@/lib/soraOptions';
 
 import { lightingOptions } from '@/data/lightingOptions';
+import { mergeCustomValues } from '@/lib/storage';
 import { Button } from '@/components/ui/button';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { PresetDropdown } from '../PresetDropdown';
@@ -62,12 +63,13 @@ export const LightingSection: React.FC<LightingSectionProps> = ({
         <div>
           <Label>{t('lighting')}</Label>
           <SearchableDropdown
-            options={lightingOptions}
+            options={mergeCustomValues('lighting', lightingOptions)}
             value={options.lighting || ''}
             onValueChange={(value) => updateOptions({ lighting: value })}
             label="Lighting Options"
             placeholder="Select lighting..."
             disabled={!options.use_lighting}
+            optionKey="lighting"
           />
         </div>
       </div>

--- a/src/components/sections/MaterialSection.tsx
+++ b/src/components/sections/MaterialSection.tsx
@@ -7,6 +7,7 @@ import { ToggleField } from '../ToggleField';
 import type { SoraOptions } from '@/lib/soraOptions';
 
 import { materialOptions } from '@/data/materialOptions';
+import { mergeCustomValues } from '@/lib/storage';
 import { Button } from '@/components/ui/button';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { PresetDropdown } from '../PresetDropdown';
@@ -67,10 +68,11 @@ export const MaterialSection: React.FC<MaterialSectionProps> = ({
         <div>
           <Label>{t('madeOutOf')}</Label>
           <SearchableDropdown
-            options={materialOptions}
+            options={mergeCustomValues('material', materialOptions)}
             value={options.made_out_of}
             onValueChange={(value) => updateOptions({ made_out_of: value })}
             label="Material Options"
+            optionKey="material"
           />
         </div>
 
@@ -85,12 +87,13 @@ export const MaterialSection: React.FC<MaterialSectionProps> = ({
           <div>
             <Label>{t('secondaryMaterial')}</Label>
             <SearchableDropdown
-              options={materialOptions}
+              options={mergeCustomValues('material', materialOptions)}
               value={options.secondary_material || 'default'}
               onValueChange={(value) =>
                 updateOptions({ secondary_material: value })
               }
               label="Secondary Material Options"
+              optionKey="material"
             />
           </div>
         </ToggleField>

--- a/src/components/sections/SettingsLocationSection.tsx
+++ b/src/components/sections/SettingsLocationSection.tsx
@@ -12,6 +12,7 @@ import {
   seasonOptions,
   atmosphereMoodOptions,
 } from '@/data/locationPresets';
+import { mergeCustomValues } from '@/lib/storage';
 import { Button } from '@/components/ui/button';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { PresetDropdown } from '../PresetDropdown';
@@ -121,10 +122,11 @@ export const SettingsLocationSection: React.FC<
           <div>
             <Label>{t('environment')}</Label>
             <SearchableDropdown
-              options={environmentOptions}
+              options={mergeCustomValues('environment', environmentOptions)}
               value={options.environment}
               onValueChange={(value) => updateOptions({ environment: value })}
               label={t('environmentOptions')}
+              optionKey="environment"
             />
           </div>
         </ToggleField>
@@ -140,10 +142,11 @@ export const SettingsLocationSection: React.FC<
           <div>
             <Label>{t('location')}</Label>
             <SearchableDropdown
-              options={locationOptions}
+              options={mergeCustomValues('location', locationOptions)}
               value={options.location || 'Berlin, Germany'}
               onValueChange={(value) => updateOptions({ location: value })}
               label={t('locationOptions')}
+              optionKey="location"
             />
           </div>
         </ToggleField>
@@ -159,10 +162,11 @@ export const SettingsLocationSection: React.FC<
           <div>
             <Label>{t('season')}</Label>
             <SearchableDropdown
-              options={seasonOptions}
+              options={mergeCustomValues('season', seasonOptions)}
               value={options.season || 'default (any season)'}
               onValueChange={(value) => updateOptions({ season: value })}
               label={t('seasonOptions')}
+              optionKey="season"
             />
           </div>
         </ToggleField>
@@ -196,7 +200,7 @@ export const SettingsLocationSection: React.FC<
           <div>
             <Label>{t('atmosphereMood')}</Label>
             <SearchableDropdown
-              options={atmosphereMoodOptions}
+              options={mergeCustomValues('atmosphere_mood', atmosphereMoodOptions)}
               value={
                 options.atmosphere_mood || 'default (neutral mood)'
               }
@@ -204,6 +208,7 @@ export const SettingsLocationSection: React.FC<
                 updateOptions({ atmosphere_mood: value })
               }
               label={t('atmosphereMoodOptions')}
+              optionKey="atmosphere_mood"
             />
           </div>
         </ToggleField>

--- a/src/components/sections/StyleSection.tsx
+++ b/src/components/sections/StyleSection.tsx
@@ -15,6 +15,7 @@ import { stylePresets } from '@/data/stylePresets';
 import { Button } from '@/components/ui/button';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { PresetDropdown } from '../PresetDropdown';
+import { mergeCustomValues } from '@/lib/storage';
 
 interface StyleSectionProps {
   options: SoraOptions;
@@ -123,17 +124,19 @@ export const StyleSection: React.FC<StyleSectionProps> = ({
         <div>
           <Label htmlFor="style_preset">{t('style')}</Label>
           <SearchableDropdown
-            options={
+            options={mergeCustomValues(
+              `style_${options.style_preset.category}`,
               stylePresets[
                 options.style_preset.category as keyof typeof stylePresets
-              ] ?? []
-            }
+              ] ?? [],
+            )}
             value={options.style_preset.style}
             onValueChange={(value) =>
               updateNestedOptions('style_preset.style', value)
             }
             label="Style Options"
             placeholder="Select style..."
+            optionKey={`style_${options.style_preset.category}`}
           />
         </div>
       </div>

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -31,3 +31,4 @@ export const TOTAL_SECONDS = 'totalSeconds';
 export const TIME_MILESTONES = 'timeMilestones';
 export const CUSTOM_PRESETS_URL = 'customPresetsUrl';
 export const SECTION_PRESETS = 'sectionPresets';
+export const CUSTOM_VALUES = 'customValues';

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -10,6 +10,7 @@ import {
   SORA_TOOLS_ENABLED,
   TRACKING_ENABLED,
   SECTION_PRESETS,
+  CUSTOM_VALUES,
 } from './storage-keys';
 /**
  * Safely retrieves a value from `localStorage`.
@@ -172,6 +173,50 @@ export function removeSectionPreset(
   };
   setJson(SECTION_PRESETS, updated);
   return updated;
+}
+
+export type CustomValuesMap = Record<string, string[]>;
+
+/**
+ * Retrieves all custom option values grouped by their option key.
+ */
+export function getCustomValues(): CustomValuesMap {
+  return getJson<CustomValuesMap>(CUSTOM_VALUES, {}) ?? {};
+}
+
+/**
+ * Adds a custom value for the specified option key and persists it.
+ *
+ * @param optionKey - Identifier for the option type.
+ * @param value - Custom value to store.
+ * @returns Updated map of custom values.
+ */
+export function addCustomValue(
+  optionKey: string,
+  value: string,
+): CustomValuesMap {
+  const map = getCustomValues();
+  const values = new Set(map[optionKey] ?? []);
+  values.add(value);
+  const updated = { ...map, [optionKey]: Array.from(values) };
+  setJson(CUSTOM_VALUES, updated);
+  return updated;
+}
+
+/**
+ * Merges stored custom values for the given option key with a base list.
+ *
+ * @param optionKey - Identifier for the option type.
+ * @param base - Base list of option strings.
+ * @returns Combined array including any saved custom values.
+ */
+export function mergeCustomValues(
+  optionKey: string,
+  base: readonly string[],
+): string[] {
+  const map = getCustomValues();
+  const custom = map[optionKey] ?? [];
+  return [...base, ...custom];
 }
 
 const PREFERENCE_KEYS = [


### PR DESCRIPTION
## Summary
- allow users to add custom entries in SearchableDropdown and MultiSelectDropdown
- persist custom options per field and merge when sections render
- test custom value flows for single and multi-select dropdowns

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b62896187883258b6c31b450e25869