### PR TITLE
Include presets and custom values in storage backup

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -286,6 +286,8 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
       try {
         const text = await file.text();
         importAppData(JSON.parse(text));
+        setPresetEditor(JSON.stringify(exportCurrentPresets(), null, 2));
+        setCustomMap(getCustomValues());
         toast.success(t('dataImported', { defaultValue: 'Data imported' }));
         trackEvent(trackingEnabled, AnalyticsEvent.DataImport);
       } catch {

--- a/src/lib/__tests__/storage-backup.test.ts
+++ b/src/lib/__tests__/storage-backup.test.ts
@@ -1,9 +1,26 @@
-import { exportAppData, importAppData } from '../storage';
-import { CURRENT_JSON, JSON_HISTORY, DARK_MODE } from '../storage-keys';
+import {
+  exportAppData,
+  importAppData,
+  addCustomValue,
+  getCustomValues,
+} from '../storage';
+import {
+  CURRENT_JSON,
+  JSON_HISTORY,
+  DARK_MODE,
+  PRESETS,
+  CUSTOM_VALUES,
+} from '../storage-keys';
+import {
+  importCustomPresets,
+  exportCurrentPresets,
+  resetPresetCollections,
+} from '../presetLoader';
 
 describe('exportAppData/importAppData', () => {
   beforeEach(() => {
     localStorage.clear();
+    resetPresetCollections();
   });
 
   test('round trips application data', () => {
@@ -12,16 +29,30 @@ describe('exportAppData/importAppData', () => {
     localStorage.setItem(JSON_HISTORY, JSON.stringify(history));
     localStorage.setItem(DARK_MODE, JSON.stringify(true));
 
+    importCustomPresets({ stylePresets: { foo: ['bar'] } });
+    addCustomValue('color', 'red');
+
     const exported = exportAppData();
     expect(exported.currentJson).toBe('test');
     expect(exported.jsonHistory).toHaveLength(1);
     expect(exported.preferences[DARK_MODE]).toBe(true);
+    expect(exported.presets.stylePresets?.foo).toEqual(['bar']);
+    expect(exported.customValues).toEqual({ color: ['red'] });
 
     localStorage.clear();
+    resetPresetCollections();
     importAppData(exported);
 
     expect(localStorage.getItem(CURRENT_JSON)).toBe('test');
     expect(JSON.parse(localStorage.getItem(JSON_HISTORY) || '[]')).toHaveLength(1);
     expect(JSON.parse(localStorage.getItem(DARK_MODE) || 'false')).toBe(true);
+    expect(
+      JSON.parse(localStorage.getItem(PRESETS) || '{}').stylePresets.foo,
+    ).toEqual(['bar']);
+    expect(JSON.parse(localStorage.getItem(CUSTOM_VALUES) || '{}')).toEqual({
+      color: ['red'],
+    });
+    expect(exportCurrentPresets().stylePresets?.foo).toEqual(['bar']);
+    expect(getCustomValues()).toEqual({ color: ['red'] });
   });
 });

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -30,5 +30,6 @@ export const APP_RELOAD_MILESTONES = 'appReloadMilestones';
 export const TOTAL_SECONDS = 'totalSeconds';
 export const TIME_MILESTONES = 'timeMilestones';
 export const CUSTOM_PRESETS_URL = 'customPresetsUrl';
+export const PRESETS = 'presets';
 export const SECTION_PRESETS = 'sectionPresets';
 export const CUSTOM_VALUES = 'customValues';

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -11,7 +11,13 @@ import {
   TRACKING_ENABLED,
   SECTION_PRESETS,
   CUSTOM_VALUES,
+  PRESETS,
 } from './storage-keys';
+import {
+  exportCurrentPresets,
+  importCustomPresets,
+  type CustomPresetData,
+} from './presetLoader';
 /**
  * Safely retrieves a value from `localStorage`.
  *
@@ -309,6 +315,8 @@ export interface AppData {
   jsonHistory: unknown[];
   preferences: Record<string, unknown>;
   sectionPresets: SectionPresets;
+  presets: CustomPresetData;
+  customValues: CustomValuesMap;
 }
 
 /**
@@ -322,11 +330,16 @@ export function exportAppData(): AppData {
     const value = getJson<unknown>(key);
     if (value !== null) preferences[key] = value;
   }
+  const presets =
+    getJson<CustomPresetData>(PRESETS, exportCurrentPresets()) ??
+    exportCurrentPresets();
   return {
     currentJson: safeGet<string>(CURRENT_JSON, null) as string | null,
     jsonHistory: getJson<unknown[]>(JSON_HISTORY, []) ?? [],
     preferences,
     sectionPresets: getSectionPresets(),
+    presets,
+    customValues: getCustomValues(),
   };
 }
 
@@ -350,5 +363,12 @@ export function importAppData(data: AppData) {
   }
   if (data.sectionPresets && typeof data.sectionPresets === 'object') {
     setJson(SECTION_PRESETS, data.sectionPresets);
+  }
+  if (data.presets && typeof data.presets === 'object') {
+    setJson(PRESETS, data.presets);
+    importCustomPresets(data.presets);
+  }
+  if (data.customValues && typeof data.customValues === 'object') {
+    setCustomValues(data.customValues);
   }
 }


### PR DESCRIPTION
## Summary
- extend `AppData` to track presets and custom values
- handle new fields in export/import helpers and settings UI
- test round-trip persistence for presets and custom values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b72fad8c088325818c33b5dc8f1222