### PR TITLE
feat: sync config via url

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -27,6 +27,7 @@ import {
   Moon,
   Import as ImportIcon,
   Download,
+  Upload,
   Plus,
   Pencil,
   RotateCcw,
@@ -55,6 +56,8 @@ import {
   updateCustomValue,
   exportCustomValues,
   importCustomValues,
+  syncConfigToUrl,
+  loadConfigFromUrl,
   type CustomValuesMap,
 } from '@/lib/storage';
 import {
@@ -237,6 +240,28 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     toast.success(
       t('customValuesExported', { defaultValue: 'Custom values exported' }),
     );
+  };
+
+  const syncToUrl = async () => {
+    const url = window.prompt('Enter URL');
+    if (!url) return;
+    try {
+      await syncConfigToUrl(url.trim());
+      toast.success(t('dataExported', { defaultValue: 'Data exported' }));
+    } catch {
+      toast.error(t('requestBlocked'));
+    }
+  };
+
+  const loadFromUrl = async () => {
+    const url = window.prompt('Enter URL');
+    if (!url) return;
+    try {
+      await loadConfigFromUrl(url.trim());
+      toast.success(t('dataImported', { defaultValue: 'Data imported' }));
+    } catch {
+      toast.error(t('requestBlocked'));
+    }
   };
 
   const importCustomValuesFile = () => {
@@ -520,6 +545,30 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>{t('import')}</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={syncToUrl}
+                      >
+                        <Upload className="w-4 h-4" /> {t('syncToUrl')}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('syncToUrl')}</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start gap-2"
+                        onClick={loadFromUrl}
+                      >
+                        <Download className="w-4 h-4" /> {t('loadFromUrl')}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('loadFromUrl')}</TooltipContent>
                   </Tooltip>
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/src/lib/__tests__/storage-sync.test.ts
+++ b/src/lib/__tests__/storage-sync.test.ts
@@ -1,0 +1,68 @@
+import * as storage from '../storage';
+import { CURRENT_JSON } from '../storage-keys';
+
+describe('remote storage helpers', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { fetch: jest.Mock }).fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('syncConfigToUrl posts AppData', async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200, statusText: 'OK' });
+
+    await storage.syncConfigToUrl('https://example.com');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = (fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('https://example.com');
+    expect(opts?.method).toBe('POST');
+    expect(opts?.headers).toEqual({ 'Content-Type': 'application/json' });
+    expect(() => JSON.parse(opts?.body as string)).not.toThrow();
+  });
+
+  test('syncConfigToUrl rejects on error', async () => {
+    (fetch as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(
+      storage.syncConfigToUrl('https://example.com'),
+    ).rejects.toThrow('Failed to sync config');
+  });
+
+  test('loadConfigFromUrl fetches and imports AppData', async () => {
+    const data = {
+      currentJson: 'hi',
+      jsonHistory: [],
+      preferences: {},
+      sectionPresets: {},
+      presets: {},
+      customValues: {},
+    } as storage.AppData;
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: jest.fn().mockResolvedValue(data),
+    });
+
+    await storage.loadConfigFromUrl('https://example.com');
+
+    expect(fetch).toHaveBeenCalledWith('https://example.com');
+    expect(localStorage.getItem(CURRENT_JSON)).toBe('hi');
+  });
+
+  test('loadConfigFromUrl rejects on non-ok', async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500, statusText: 'err' });
+    await expect(
+      storage.loadConfigFromUrl('https://example.com'),
+    ).rejects.toThrow('Failed to load config');
+  });
+
+  test('loadConfigFromUrl rejects on fetch error', async () => {
+    (fetch as jest.Mock).mockRejectedValue(new Error('fail'));
+    await expect(
+      storage.loadConfigFromUrl('https://example.com'),
+    ).rejects.toThrow('Failed to load config');
+  });
+});

--- a/src/locales/bn-IN.json
+++ b/src/locales/bn-IN.json
@@ -16,6 +16,8 @@
   "reset": "রিসেট",
   "regenerate": "পুনরায় তৈরি করুন",
   "randomize": "এলোমেলো করুন",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/da-DK.json
+++ b/src/locales/da-DK.json
@@ -16,6 +16,8 @@
   "reset": "Nulstil",
   "regenerate": "Generer igen",
   "randomize": "Tilfældiggør",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/de-AT.json
+++ b/src/locales/de-AT.json
@@ -16,6 +16,8 @@
   "reset": "Zurücksetzen",
   "regenerate": "Neu generieren",
   "randomize": "Zufällig",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -16,6 +16,8 @@
   "reset": "Zurücksetzen",
   "regenerate": "Neu generieren",
   "randomize": "Zufällig",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/el-GR.json
+++ b/src/locales/el-GR.json
@@ -16,6 +16,8 @@
   "reset": "Επαναφορά",
   "regenerate": "Επαναδημιουργία",
   "randomize": "Τυχαιοποίηση",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -16,6 +16,8 @@
   "reset": "Reset",
   "regenerate": "Regenerate",
   "randomize": "Randomise",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/en-PR.json
+++ b/src/locales/en-PR.json
@@ -16,6 +16,8 @@
   "reset": "Scuttle",
   "regenerate": "Raise Again",
   "randomize": "Yo‑ho Shuffle",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -16,6 +16,8 @@
   "reset": "Reset",
   "regenerate": "Regenerate",
   "randomize": "Randomize",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/es-AR.json
+++ b/src/locales/es-AR.json
@@ -16,6 +16,8 @@
   "reset": "Restablecer",
   "regenerate": "Regenerar",
   "randomize": "Aleatorizar",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -16,6 +16,8 @@
   "reset": "Restablecer",
   "regenerate": "Regenerar",
   "randomize": "Aleatorizar",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -16,6 +16,8 @@
   "reset": "Restablecer",
   "regenerate": "Regenerar",
   "randomize": "Aleatorizar",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/et-EE.json
+++ b/src/locales/et-EE.json
@@ -16,6 +16,8 @@
   "reset": "Lähtesta",
   "regenerate": "Genereeri uuesti",
   "randomize": "Juhuslikusta",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/fi-FI.json
+++ b/src/locales/fi-FI.json
@@ -16,6 +16,8 @@
   "reset": "Palauta oletuksiin",
   "regenerate": "Luo uudelleen",
   "randomize": "Satunnaista",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/fr-BE.json
+++ b/src/locales/fr-BE.json
@@ -16,6 +16,8 @@
   "reset": "Réinitialiser",
   "regenerate": "Régénérer",
   "randomize": "Aléatoiriser",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -16,6 +16,8 @@
   "reset": "Réinitialiser",
   "regenerate": "Régénérer",
   "randomize": "Randomiser",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -16,6 +16,8 @@
   "reset": "Ripristina",
   "regenerate": "Rigenera",
   "randomize": "Casualizza",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -16,6 +16,8 @@
   "reset": "リセット",
   "regenerate": "再生成",
   "randomize": "ランダム化",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -16,6 +16,8 @@
   "reset": "초기화",
   "regenerate": "재생성",
   "randomize": "무작위화",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/ne-NP.json
+++ b/src/locales/ne-NP.json
@@ -16,6 +16,8 @@
   "reset": "रीसेट",
   "regenerate": "पुनः उत्पन्न गर्नुहोस्",
   "randomize": "अनियमित बनाउनुहोस्",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -16,6 +16,8 @@
   "reset": "Restaurar",
   "regenerate": "Regenerar",
   "randomize": "Aleatorizar",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -16,6 +16,8 @@
   "reset": "Repor",
   "regenerate": "Regenerar",
   "randomize": "Aleatorizar",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/ro-RO.json
+++ b/src/locales/ro-RO.json
@@ -16,6 +16,8 @@
   "reset": "Resetează",
   "regenerate": "Regenerare",
   "randomize": "Randomizează",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -16,6 +16,8 @@
   "reset": "Сброс",
   "regenerate": "Сгенерировать заново",
   "randomize": "Случайно",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -16,6 +16,8 @@
   "reset": "Återställ",
   "regenerate": "Regenerera",
   "randomize": "Slumpa",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/th-TH.json
+++ b/src/locales/th-TH.json
@@ -16,6 +16,8 @@
   "reset": "รีเซ็ต",
   "regenerate": "สร้างใหม่",
   "randomize": "สุ่ม",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/uk-UA.json
+++ b/src/locales/uk-UA.json
@@ -16,6 +16,8 @@
   "reset": "Скинути",
   "regenerate": "Згенерувати знову",
   "randomize": "Випадково",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -16,6 +16,8 @@
   "reset": "重置",
   "regenerate": "重新生成",
   "randomize": "随机化",
+  "syncToUrl": "Sync to URL",
+  "loadFromUrl": "Load from URL",
   "purgeCache": "Purge Cache",
   "purgeCacheTitle": "Purge cache?",
   "purgeCacheConfirm": "Purge",


### PR DESCRIPTION
## Summary
- add helpers to sync config to URL or load from URL
- expose sync/load buttons in manage tab
- cover remote sync helpers with unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b75c2eddd8832596a44d1a5434e49f