### PR TITLE
feat: allow custom css and js

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ go "my eyes!" when there's bright white lights.
 - Internationalization support for English, Spanish and other 2 dozens of locales
 - Works offline thanks to service worker caching of assets
 - Automatically checks for service worker updates on load and when opening the Settings panel
+- Inject custom CSS and JavaScript from the Settings panel
 
 ## Keyboard Shortcuts
 
@@ -222,6 +223,12 @@ a JSON object (or URL via `loadCustomPresetsFromUrl`). The JSON can include
 `stylePresets`, `cameraPresets`, `locationPresets` and `dndPresets` keys
 matching the built‑in structures. Imported values are merged with existing
 presets so they become available in the UI.
+
+## Custom CSS/JS
+
+Use the **Settings** panel to add custom CSS or JavaScript snippets that will
+be injected on startup. These values are stored locally and included in config
+exports and imports.
 
 ## Contributing
 

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -83,6 +83,8 @@ import {
   TOTAL_SECONDS,
   TIME_MILESTONES,
   CUSTOM_PRESETS_URL,
+  CUSTOM_CSS,
+  CUSTOM_JS,
 } from '@/lib/storage-keys';
 import { cn } from '@/lib/utils';
 
@@ -194,6 +196,22 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const [customMap, setCustomMap] = useState<CustomValuesMap>(() => getCustomValues());
   const [customKey, setCustomKey] = useState('');
   const [customValue, setCustomValue] = useState('');
+  const [cssEditorOpen, setCssEditorOpen] = useState(false);
+  const [jsEditorOpen, setJsEditorOpen] = useState(false);
+  const [customCss, setCustomCss] = useState('');
+  const [customJs, setCustomJs] = useState('');
+
+  const openCssEditor = () => {
+    const stored = safeGet(CUSTOM_CSS);
+    setCustomCss(typeof stored === 'string' ? stored : '');
+    setCssEditorOpen(true);
+  };
+
+  const openJsEditor = () => {
+    const stored = safeGet(CUSTOM_JS);
+    setCustomJs(typeof stored === 'string' ? stored : '');
+    setJsEditorOpen(true);
+  };
 
   useEffect(() => {
     if (open) {
@@ -675,13 +693,43 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                       {soraToolsEnabled
                         ? 'Hide Sora Integration'
                         : 'Show Sora Integration'}
-                  </TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className="w-full justify-start gap-2"
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start gap-2"
+                    onClick={openCssEditor}
+                  >
+                    <Pencil className="w-4 h-4" />
+                    {t('editCustomCss', { defaultValue: 'Edit custom CSS' })}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {t('editCustomCss', { defaultValue: 'Edit custom CSS' })}
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start gap-2"
+                    onClick={openJsEditor}
+                  >
+                    <Pencil className="w-4 h-4" />
+                    {t('editCustomJs', { defaultValue: 'Edit custom JS' })}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {t('editCustomJs', { defaultValue: 'Edit custom JS' })}
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start gap-2"
                         onClick={() => {
                           try {
                             setDarkMode(!darkMode);
@@ -1332,6 +1380,62 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
               </ScrollArea>
             </TabsContent>
           </Tabs>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={cssEditorOpen} onOpenChange={setCssEditorOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {t('customCss', { defaultValue: 'Custom CSS' })}
+            </DialogTitle>
+          </DialogHeader>
+          <Textarea
+            className="h-48"
+            value={customCss}
+            onChange={(e) => setCustomCss(e.target.value)}
+          />
+          <div className="flex justify-end gap-2 mt-2">
+            <Button variant="outline" onClick={() => setCssEditorOpen(false)}>
+              {t('cancel')}
+            </Button>
+            <Button
+              onClick={() => {
+                safeSet(CUSTOM_CSS, customCss);
+                setCssEditorOpen(false);
+              }}
+            >
+              {t('save', { defaultValue: 'Save' })}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={jsEditorOpen} onOpenChange={setJsEditorOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {t('customJs', { defaultValue: 'Custom JS' })}
+            </DialogTitle>
+          </DialogHeader>
+          <Textarea
+            className="h-48"
+            value={customJs}
+            onChange={(e) => setCustomJs(e.target.value)}
+          />
+          <div className="flex justify-end gap-2 mt-2">
+            <Button variant="outline" onClick={() => setJsEditorOpen(false)}>
+              {t('cancel')}
+            </Button>
+            <Button
+              onClick={() => {
+                safeSet(CUSTOM_JS, customJs);
+                setJsEditorOpen(false);
+              }}
+            >
+              {t('save', { defaultValue: 'Save' })}
+            </Button>
+          </div>
         </DialogContent>
       </Dialog>
 

--- a/src/lib/__tests__/inject-custom-code.test.ts
+++ b/src/lib/__tests__/inject-custom-code.test.ts
@@ -1,0 +1,26 @@
+import { injectCustomCode } from '../inject-custom-code';
+import { CUSTOM_CSS, CUSTOM_JS } from '../storage-keys';
+
+describe('injectCustomCode', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+    localStorage.clear();
+  });
+
+  it('injects style and script when values exist', () => {
+    localStorage.setItem(CUSTOM_CSS, 'body{color:red;}');
+    localStorage.setItem(CUSTOM_JS, 'window.testInjected=true;');
+    injectCustomCode();
+    const style = document.head.querySelector('style');
+    const script = document.body.querySelector('script');
+    expect(style?.textContent).toBe('body{color:red;}');
+    expect(script?.textContent).toBe('window.testInjected=true;');
+  });
+
+  it('does nothing when no values', () => {
+    injectCustomCode();
+    expect(document.head.querySelector('style')).toBeNull();
+    expect(document.body.querySelector('script')).toBeNull();
+  });
+});

--- a/src/lib/inject-custom-code.ts
+++ b/src/lib/inject-custom-code.ts
@@ -1,0 +1,20 @@
+import { safeGet } from './storage';
+import { CUSTOM_CSS, CUSTOM_JS } from './storage-keys';
+
+/**
+ * Injects user-provided CSS and JS into the document if present in storage.
+ */
+export function injectCustomCode() {
+  const css = (safeGet<string>(CUSTOM_CSS, '') as string) || '';
+  if (css) {
+    const style = document.createElement('style');
+    style.textContent = css;
+    document.head.appendChild(style);
+  }
+  const js = (safeGet<string>(CUSTOM_JS, '') as string) || '';
+  if (js) {
+    const script = document.createElement('script');
+    script.textContent = js;
+    document.body.appendChild(script);
+  }
+}

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -33,3 +33,5 @@ export const CUSTOM_PRESETS_URL = 'customPresetsUrl';
 export const PRESETS = 'presets';
 export const SECTION_PRESETS = 'sectionPresets';
 export const CUSTOM_VALUES = 'customValues';
+export const CUSTOM_CSS = 'customCss';
+export const CUSTOM_JS = 'customJs';

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -12,6 +12,8 @@ import {
   SECTION_PRESETS,
   CUSTOM_VALUES,
   PRESETS,
+  CUSTOM_CSS,
+  CUSTOM_JS,
 } from './storage-keys';
 import {
   exportCurrentPresets,
@@ -308,6 +310,8 @@ const PREFERENCE_KEYS = [
   ACTION_LABELS_ENABLED,
   TRACKING_ENABLED,
   LOCALE,
+  CUSTOM_CSS,
+  CUSTOM_JS,
 ];
 
 export interface AppData {
@@ -327,8 +331,13 @@ export interface AppData {
 export function exportAppData(): AppData {
   const preferences: Record<string, unknown> = {};
   for (const key of PREFERENCE_KEYS) {
-    const value = getJson<unknown>(key);
-    if (value !== null) preferences[key] = value;
+    if (key === CUSTOM_CSS || key === CUSTOM_JS) {
+      const str = safeGet<string>(key, '') as string;
+      if (str) preferences[key] = str;
+    } else {
+      const value = getJson<unknown>(key);
+      if (value !== null) preferences[key] = value;
+    }
   }
   const presets =
     getJson<CustomPresetData>(PRESETS, exportCurrentPresets()) ??
@@ -358,7 +367,11 @@ export function importAppData(data: AppData) {
   }
   if (data.preferences && typeof data.preferences === 'object') {
     for (const [key, value] of Object.entries(data.preferences)) {
-      setJson(key, value);
+      if (key === CUSTOM_CSS || key === CUSTOM_JS) {
+        safeSet(key, value as string);
+      } else {
+        setJson(key, value);
+      }
     }
   }
   if (data.sectionPresets && typeof data.sectionPresets === 'object') {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/lib/storage-keys';
 import { toast } from '@/components/ui/sonner-toast';
 import i18n from '@/i18n';
+import { injectCustomCode } from '@/lib/inject-custom-code';
 
 /**
  * Maps reload count thresholds to corresponding analytics events.
@@ -64,5 +65,8 @@ try {
   // Log error without stopping the app
   console.error('Reload counter: There was an error.');
 }
+
+// Inject any user-provided CSS/JS before rendering
+injectCustomCode();
 
 createRoot(document.getElementById('root')!).render(<App />);


### PR DESCRIPTION
## Summary
- add storage keys and startup injection for custom CSS and JS
- expose editors in Settings to manage custom code
- document custom code options

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b76a1a5744832585739c3a05176927