### PR TITLE
feat: secure Sora message channel with nonce

### DIFF
--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -12,6 +12,7 @@
   const VERSION = '__USERSCRIPT_VERSION__';
   const DEBUG = false;
   const SESSION_KEY = 'sora_json_payload';
+  const ALLOWED_ORIGIN = 'https://sora.chatgpt.com';
   console.log(`[Sora Injector] Loaded v${VERSION}`);
   if (DEBUG) {
     console.debug(`[Sora Injector] Hostname: ${window.location.hostname}`);
@@ -165,8 +166,9 @@
     'message',
     (event) => {
       if (
-        event.origin !== window.origin &&
-        event.data?.type === 'INSERT_SORA_JSON'
+        event.origin === ALLOWED_ORIGIN &&
+        event.data?.type === 'INSERT_SORA_JSON' &&
+        typeof event.data.nonce === 'string'
       ) {
         if (DEBUG) {
           console.debug(
@@ -200,7 +202,10 @@
           if (DEBUG) {
             console.debug('[Sora Injector] Textarea filled');
           }
-          event.source?.postMessage({ type: 'INSERT_SORA_JSON_ACK' }, '*');
+          event.source?.postMessage(
+            { type: 'INSERT_SORA_JSON_ACK', nonce: event.data.nonce },
+            event.origin,
+          );
           if (DEBUG) {
             console.debug('[Sora Injector] JSON ACK sent');
           }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -300,10 +300,15 @@ const Dashboard = () => {
   const sendToSora = () => {
     const win = window.open('https://sora.chatgpt.com', '_blank', 'noopener');
     if (!win) return;
-    const payload = { type: 'INSERT_SORA_JSON', json: JSON.parse(jsonString) };
+    const nonce = crypto.randomUUID();
+    const payload = {
+      type: 'INSERT_SORA_JSON',
+      json: JSON.parse(jsonString),
+      nonce,
+    } as const;
     const start = () => {
       const intervalId = setInterval(() => {
-        win.postMessage(payload, '*');
+        win.postMessage(payload, 'https://sora.chatgpt.com');
       }, 250);
       const timeoutId = setTimeout(() => {
         clearInterval(intervalId);
@@ -312,7 +317,9 @@ const Dashboard = () => {
       const ackHandler = (event: MessageEvent) => {
         if (
           event.source === win &&
-          event.data?.type === 'INSERT_SORA_JSON_ACK'
+          event.origin === 'https://sora.chatgpt.com' &&
+          event.data?.type === 'INSERT_SORA_JSON_ACK' &&
+          event.data?.nonce === nonce
         ) {
           clearInterval(intervalId);
           clearTimeout(timeoutId);

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -363,6 +363,7 @@ describe('Dashboard interactions', () => {
 
   test('dark mode toggle switches icon and sendToSora ACK stops interval', () => {
     jest.useFakeTimers();
+    jest.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue('abc');
     mockUseDarkMode.mockImplementation(() => {
       const [dark, setDark] = React.useState(false);
       return [dark, setDark] as const;
@@ -411,8 +412,9 @@ describe('Dashboard interactions', () => {
 
     act(() => {
       (handler as EventListener)?.({
+        origin: 'https://sora.chatgpt.com',
         source: win,
-        data: { type: 'INSERT_SORA_JSON_ACK' },
+        data: { type: 'INSERT_SORA_JSON_ACK', nonce: 'abc' },
       } as MessageEvent);
     });
 
@@ -424,6 +426,7 @@ describe('Dashboard interactions', () => {
     expect(removeListenerSpy).toHaveBeenCalledWith('message', handler);
 
     openSpy.mockRestore();
+    (globalThis.crypto.randomUUID as jest.Mock).mockRestore();
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
   });


### PR DESCRIPTION
## Summary
- restrict sendToSora communication to https://sora.chatgpt.com and include nonce
- validate origin/nonce in userscript and echo nonce in ack
- expand tests for origin/nonce handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b88198b99c8325a8845e40a06add3b