### PR TITLE
fix: accept cross-origin crafter messages

### DIFF
--- a/public/sora-userscript.user.js
+++ b/public/sora-userscript.user.js
@@ -175,7 +175,8 @@
     (event) => {
       const isAllowedOrigin =
         event.origin !== SORA_ORIGIN &&
-        (!CRAFTER_ORIGIN || event.origin === CRAFTER_ORIGIN);
+        CRAFTER_ORIGIN !== null &&
+        event.origin === CRAFTER_ORIGIN;
       if (
         isAllowedOrigin &&
         event.data?.type === 'INSERT_SORA_JSON' &&


### PR DESCRIPTION
## Summary
- derive crafter origin from `document.referrer` and accept messages from that origin
- ignore same-origin `INSERT_SORA_JSON` events and validate nonce
- update userscript tests for cross-origin and nonce handling
- reject cross-origin messages when referrer is missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9c2abdbe083258bfec2b0139d4528