### PR TITLE
Wrap long JSON tokens in GeneratedJson viewer

### DIFF
--- a/src/components/GeneratedJson.tsx
+++ b/src/components/GeneratedJson.tsx
@@ -114,7 +114,14 @@ const GeneratedJson: React.FC<Props> = ({ json, trackingEnabled }) => {
         PreTag="span"
         CodeTag="span"
         wrapLongLines
-        customStyle={{ margin: 0, padding: 0, background: 'none' }}
+        wrapLines
+        customStyle={{
+          margin: 0,
+          padding: 0,
+          background: 'none',
+          wordBreak: 'break-word',
+          overflowWrap: 'anywhere',
+        }}
       >
         {value}
       </SyntaxHighlighter>

--- a/src/components/__tests__/GeneratedJson.test.tsx
+++ b/src/components/__tests__/GeneratedJson.test.tsx
@@ -40,4 +40,19 @@ describe('GeneratedJson', () => {
       jest.advanceTimersByTime(2000);
     });
   });
+
+  test('wraps long tokens without horizontal scroll', () => {
+    const longToken = 'a'.repeat(5000);
+    const { getByTestId } = render(
+      <GeneratedJson
+        json={`{"token":"${longToken}"}`}
+        trackingEnabled={false}
+      />,
+    );
+
+    const container = getByTestId('json-container');
+    const pre = container.querySelector('pre') as HTMLElement;
+    expect(pre.className).toContain('break-words');
+    expect(container.scrollWidth).toBe(container.clientWidth);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure `GeneratedJson` wraps long tokens by enabling `wrapLines` and applying `word-break` styles
- test that long tokens wrap without introducing horizontal scroll

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb34eef95c8325abc2af4c4549e9b7