### PR TITLE
refactor: remove any in locales test

### DIFF
--- a/src/__tests__/locales.test.ts
+++ b/src/__tests__/locales.test.ts
@@ -4,9 +4,14 @@ import path from 'path';
 describe('locale key parity', () => {
   const localesDir = path.join(__dirname, '..', 'locales');
   const files = fs.readdirSync(localesDir).filter((f) => f.endsWith('.json'));
-  const enUS = JSON.parse(fs.readFileSync(path.join(localesDir, 'en-US.json'), 'utf-8'));
+  const enUS = JSON.parse(
+    fs.readFileSync(path.join(localesDir, 'en-US.json'), 'utf-8'),
+  );
 
-  const flatten = (obj: any, prefix = ''): Record<string, true> => {
+  const flatten = (
+    obj: Record<string, unknown>,
+    prefix = '',
+  ): Record<string, true> => {
     const out: Record<string, true> = {};
     for (const [key, value] of Object.entries(obj)) {
       const newKey = prefix ? `${prefix}.${key}` : key;
@@ -23,7 +28,9 @@ describe('locale key parity', () => {
 
   for (const file of files.filter((f) => f !== 'en-US.json')) {
     test(`${file} matches en-US keys`, () => {
-      const data = JSON.parse(fs.readFileSync(path.join(localesDir, file), 'utf-8'));
+      const data = JSON.parse(
+        fs.readFileSync(path.join(localesDir, file), 'utf-8'),
+      );
       const keys = flatten(data);
       for (const key of Object.keys(baseKeys)) {
         expect(keys[key]).toBe(true);


### PR DESCRIPTION
## Summary
- replace `any` in locales flatten helper with `Record<string, unknown>`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc78a09770832584d78a48b9b9fad1