### PR TITLE
feat: constrain settings and history dialogs

### DIFF
--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -269,7 +269,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-2xl">
+        <DialogContent className="w-[90vw] max-w-2xl h-[80vh] overflow-hidden">
           <DialogHeader>
             <DialogTitle>{t('history')}</DialogTitle>
             <DialogDescription>{t('historyDescription')}</DialogDescription>
@@ -438,7 +438,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
                   itemCount={filteredHistory.length}
                   itemSize={130}
                   width="100%"
-                  className="pb-2"
+                  className="pb-2 overflow-auto"
                   outerElementType={HistoryListOuter}
                 >
                   {({ index, style }) => (

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -535,7 +535,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-sm">
+        <DialogContent className="w-[90vw] max-w-lg h-[80vh] overflow-hidden">
           <DialogHeader>
             <DialogTitle>{t('manage')}</DialogTitle>
           </DialogHeader>

--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -43,6 +43,28 @@ jest.mock('@/lib/storage', () => ({
   setJson: jest.fn(),
 }));
 
+jest.mock('@/components/ui/dialog', () => ({
+  __esModule: true,
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) => (
+    open ? <div role="dialog">{children}</div> : null
+  ),
+  DialogContent: ({
+    className,
+    children,
+  }: {
+    className?: string;
+    children: React.ReactNode;
+  }) => (
+    <div data-testid="dialog-content" className={className}>
+      {children}
+    </div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
 jest.mock('../ClipboardImportModal', () => ({
   __esModule: true,
   default: () => null,
@@ -260,7 +282,7 @@ describe('HistoryPanel basic actions', () => {
     renderPanel({ onRename });
     const renameBtn = screen.getAllByRole('button', { name: /rename/i })[0];
     fireEvent.click(renameBtn);
-    const dialog = screen.getByRole('dialog');
+    const dialog = screen.getAllByRole('dialog')[1];
     const input = within(dialog).getByRole('textbox');
     fireEvent.change(input, { target: { value: 'new title' } });
     const saveBtn = within(dialog).getByRole('button', { name: /save/i });
@@ -334,5 +356,15 @@ describe('HistoryPanel action history', () => {
 
     expect(safeSet).toHaveBeenCalledWith(TRACKING_HISTORY, [], true);
     expect(events).toHaveLength(1);
+  });
+
+  test('dialog content has responsive size classes', () => {
+    renderPanel();
+    const content = screen.getByTestId('dialog-content');
+    const cls = content.className;
+    expect(cls).toContain('w-[90vw]');
+    expect(cls).toContain('max-w-2xl');
+    expect(cls).toContain('h-[80vh]');
+    expect(cls).toContain('overflow-hidden');
   });
 });

--- a/src/components/__tests__/SettingsPanel.test.tsx
+++ b/src/components/__tests__/SettingsPanel.test.tsx
@@ -41,7 +41,17 @@ jest.mock('@/components/ui/dialog', () => ({
   Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) => (
     open ? <div>{children}</div> : null
   ),
-  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({
+    className,
+    children,
+  }: {
+    className?: string;
+    children: React.ReactNode;
+  }) => (
+    <div data-testid="dialog-content" className={className}>
+      {children}
+    </div>
+  ),
   DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
@@ -166,5 +176,15 @@ describe('SettingsPanel', () => {
     await waitFor(() => expect(importAppData).toHaveBeenCalledWith({ b: 2 }));
     expect(toast.success).toHaveBeenCalledWith(i18n.t('dataImported'));
     expect(trackEvent).toHaveBeenCalledWith(true, AnalyticsEvent.DataImport);
+  });
+
+  test('dialog content has responsive size classes', () => {
+    renderPanel();
+    const content = screen.getByTestId('dialog-content');
+    const cls = content.className;
+    expect(cls).toContain('w-[90vw]');
+    expect(cls).toContain('max-w-lg');
+    expect(cls).toContain('h-[80vh]');
+    expect(cls).toContain('overflow-hidden');
   });
 });


### PR DESCRIPTION
## Summary
- limit Settings and History dialog content to viewport with 90vw width and 80vh height
- ensure History list scrolls within dialog
- add tests covering responsive dialog classes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be9ad2d78c8325a7fe04266ce2a073