### PR TITLE
Center Loading progress bar

### DIFF
--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -13,7 +13,7 @@ const Loading: React.FC = () => {
 
   return (
     <div
-      className="flex h-screen w-screen flex-col items-center justify-center transition-opacity duration-50"
+      className="flex h-screen w-screen flex-col items-center justify-center text-center transition-opacity duration-50"
       role="status"
     >
       <div className="flex items-center justify-center gap-3">
@@ -21,7 +21,7 @@ const Loading: React.FC = () => {
         <span className="text-lg font-medium">{t('loading')}</span>
       </div>
       <div
-        className="mt-4 h-1 w-48 overflow-hidden rounded bg-muted"
+        className="mx-auto mt-4 h-1 w-48 overflow-hidden rounded bg-muted"
         role="progressbar"
         aria-label="loading progress"
         aria-valuemin={0}

--- a/src/components/__tests__/Loading.test.tsx
+++ b/src/components/__tests__/Loading.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import Loading from '../Loading';
+
+describe('Loading', () => {
+  test('centers progress bar and applies text-center to wrapper', () => {
+    const { getByRole } = render(<Loading />);
+    const wrapper = getByRole('status');
+    const progress = getByRole('progressbar');
+
+    expect(wrapper.classList.contains('text-center')).toBe(true);
+    expect(progress.classList.contains('mx-auto')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Center loading progress bar by wrapping with `mx-auto` and using `text-center`
- Test Loading component styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf28cf04c483259bd4475d45e303a6