### PR TITLE
style: center offline banner

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,6 +9,7 @@ import {
   Bug,
   Download,
   RefreshCw,
+  X,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -635,19 +636,20 @@ const Dashboard = () => {
     return (
       <div className="min-h-screen flex flex-col bg-background">
         {!isOnline && !offlineDismissed && (
-        <div className="bg-yellow-500 text-black p-2 text-center">
-          <div className="flex items-center justify-between max-w-2xl mx-auto">
+          <div
+            className="fixed top-4 left-1/2 -translate-x-1/2 w-full max-w-md p-3 rounded bg-yellow-500 text-black shadow flex items-center justify-between gap-2"
+          >
             <span>{t('offlineNotice', { defaultValue: 'You are offline' })}</span>
             <Button
-              variant="ghost"
-              size="sm"
+              variant="outline"
+              size="icon"
               onClick={() => setOfflineDismissed(true)}
+              aria-label={t('dismiss', { defaultValue: 'Dismiss' })}
             >
-              {t('dismiss', { defaultValue: 'Dismiss' })}
+              <X className="h-4 w-4" />
             </Button>
           </div>
-        </div>
-      )}
+        )}
       <div className="container mx-auto p-6 flex flex-col flex-1">
         {headerVisible && (
           <div className="mb-8 flex items-start justify-between">

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -476,7 +476,19 @@ describe('offline banner', () => {
   test('toggles visibility based on navigator.onLine', async () => {
     setOnline(false);
     render(<Dashboard />);
-    expect(screen.getByText(i18n.t('offlineNotice'))).toBeTruthy();
+    const notice = screen.getByText(i18n.t('offlineNotice'));
+    const banner = notice.parentElement as HTMLElement;
+    expect(banner.className).toContain('fixed');
+    expect(banner.className).toContain('top-4');
+    expect(banner.className).toContain('left-1/2');
+    expect(banner.className).toContain('-translate-x-1/2');
+    expect(banner.className).toContain('max-w-md');
+    expect(banner.className).toContain('bg-yellow-500');
+    expect(banner.className).toContain('text-black');
+    const dismissButton = screen.getByLabelText(
+      i18n.t('dismiss', { defaultValue: 'Dismiss' }),
+    );
+    expect(dismissButton.className).toContain('border');
 
     act(() => {
       setOnline(true);


### PR DESCRIPTION
## Summary
- center offline banner with outline dismiss icon
- update dashboard tests for offline banner structure

## Testing
- `npm test` *(fails: App integration flow › updates JSON and history after user actions - exceeded timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c008d6c44c8325807b56b38145483c