### PR TITLE
Track edit/copy counts for history entries

### DIFF
--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -61,6 +61,8 @@ export interface HistoryEntry {
   json: string;
   favorite: boolean;
   title: string;
+  editCount: number;
+  copyCount: number;
 }
 
 interface HistoryPanelProps {
@@ -70,8 +72,8 @@ interface HistoryPanelProps {
   actionHistory: { date: string; action: string }[];
   onDelete: (id: number) => void;
   onClear: () => void;
-  onCopy: (json: string) => void;
-  onEdit: (json: string) => void;
+  onCopy: (entry: HistoryEntry) => void;
+  onEdit: (entry: HistoryEntry) => void;
   onImport: (entries: { json: string; title?: string }[]) => void;
   onToggleFavorite: (id: number) => void;
   onRename: (id: number, title: string) => void;

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -15,14 +15,14 @@ import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { useSoraUserscript } from '@/hooks/use-sora-userscript';
 import { CURRENT_JSON, JSON_HISTORY } from '@/lib/storage-keys';
 
-let copyFn: ((json: string) => void) | null = null;
+let copyFn: ((entry: any) => void) | null = null;
 let updateFn: ((opts: Partial<SoraOptions>) => void) | null = null;
 const mockUseDarkMode = jest.fn(() => [false, jest.fn()] as const);
 let sendFn: (() => void) | null = null;
 let resetFn: (() => void) | null = null;
 jest.mock('../HistoryPanel', () => ({
   __esModule: true,
-  default: ({ onCopy }: { onCopy: (json: string) => void }) => {
+  default: ({ onCopy }: { onCopy: (entry: any) => void }) => {
     copyFn = onCopy;
     return null;
   },
@@ -233,7 +233,15 @@ describe('copyHistoryEntry', () => {
     render(<Dashboard />);
     await waitFor(() => expect(copyFn).not.toBeNull());
     await act(async () => {
-      copyFn?.('{"a":1}');
+      copyFn?.({
+        id: 1,
+        date: 'd',
+        json: '{"a":1}',
+        favorite: false,
+        title: '',
+        editCount: 0,
+        copyCount: 0,
+      });
       await Promise.resolve();
     });
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('{"a":1}');

--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -105,6 +105,8 @@ const sampleHistory = Array.from({ length: 20 }, (_, i) => ({
   json: `{"prompt":"p${i}"}`,
   favorite: i % 2 === 0,
   title: `title${i}`,
+  editCount: i === 0 ? 3 : 0,
+  copyCount: i === 0 ? 5 : 0,
 }));
 const sampleActions = [{ date: 'd', action: 'a' }];
 
@@ -149,6 +151,13 @@ afterEach(() => {
 });
 
 describe('HistoryPanel basic actions', () => {
+  test('displays copy and edit counters', () => {
+    renderPanel();
+    const editBtn = screen.getByRole('button', { name: /edit \(3\)/i });
+    const copyBtn = screen.getByRole('button', { name: /copy \(5\)/i });
+    expect(editBtn).toBeTruthy();
+    expect(copyBtn).toBeTruthy();
+  });
   test('exports to clipboard and file', async () => {
     renderPanel();
     const exportBtn = screen.getByRole('button', { name: /^export$/i });

--- a/src/components/history/HistoryItem.tsx
+++ b/src/components/history/HistoryItem.tsx
@@ -12,8 +12,8 @@ import {
 
 interface HistoryItemProps {
   entry: HistoryEntry;
-  onEdit: (json: string) => void;
-  onCopy: (json: string) => void;
+  onEdit: (entry: HistoryEntry) => void;
+  onCopy: (entry: HistoryEntry) => void;
   onDelete: (id: number) => void;
   onPreview: (entry: HistoryEntry) => void;
   trackingEnabled: boolean;
@@ -62,14 +62,14 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
               variant="outline"
               onClick={() => {
                 trackEvent(trackingEnabled, AnalyticsEvent.HistoryEdit);
-                onEdit(entry.json);
+                onEdit(entry);
                 setEdited(true);
                 setTimeout(() => setEdited(false), 1500);
               }}
               className={`gap-1 ${edited ? 'text-green-600 animate-pulse' : ''}`}
             >
               {edited ? <Check className="w-4 h-4" /> : <Edit className="w-4 h-4" />}{' '}
-              {edited ? t('edited') : t('edit')}
+              {edited ? t('edited') : t('edit')} ({entry.editCount})
             </Button>
           </TooltipTrigger>
           <TooltipContent>{edited ? t('edited') : t('edit')}</TooltipContent>
@@ -81,14 +81,14 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
               variant="outline"
               onClick={() => {
                 trackEvent(trackingEnabled, AnalyticsEvent.HistoryCopy);
-                onCopy(entry.json);
+                onCopy(entry);
                 setCopied(true);
                 setTimeout(() => setCopied(false), 1500);
               }}
               className={`gap-1 ${copied ? 'text-green-600 animate-pulse' : ''}`}
             >
               {copied ? <Check className="w-4 h-4" /> : <Clipboard className="w-4 h-4" />}{' '}
-              {copied ? t('copied') : t('copy')}
+              {copied ? t('copied') : t('copy')} ({entry.copyCount})
             </Button>
           </TooltipTrigger>
           <TooltipContent>{copied ? t('copied') : t('copy')}</TooltipContent>


### PR DESCRIPTION
## Summary
- extend HistoryEntry with `editCount` and `copyCount` fields
- show and update copy/edit counters when using history items
- persist counters to localStorage and add tests for history counter behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c072c1aa088325833afd3c393484bd