### PR TITLE
feat(history): add history sorting options

### DIFF
--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -314,6 +314,64 @@ describe('HistoryPanel basic actions', () => {
     fireEvent.click(filterBtn);
     expect(screen.getByText('p1')).toBeTruthy();
   });
+
+  test('sorts history based on sort mode', () => {
+    const history = [
+      {
+        id: 1,
+        date: '2024-01-01',
+        json: '{"prompt":"b"}',
+        favorite: false,
+        title: 'Bravo',
+        editCount: 2,
+        copyCount: 1,
+      },
+      {
+        id: 2,
+        date: '2024-01-03',
+        json: '{"prompt":"a"}',
+        favorite: false,
+        title: 'Alpha',
+        editCount: 1,
+        copyCount: 3,
+      },
+      {
+        id: 3,
+        date: '2024-01-02',
+        json: '{"prompt":"c"}',
+        favorite: false,
+        title: 'Charlie',
+        editCount: 5,
+        copyCount: 2,
+      },
+    ];
+    renderPanel({ history });
+    const getTitles = () =>
+      screen
+        .getAllByText(/Alpha|Bravo|Charlie/)
+        .filter((el) => ['Alpha', 'Bravo', 'Charlie'].includes(el.textContent || ''))
+        .map((el) => el.textContent);
+
+    // default sort by date
+    expect(getTitles()).toEqual(['Alpha', 'Charlie', 'Bravo']);
+
+    const select = screen.getByRole('combobox', { name: /sort by/i });
+
+    fireEvent.mouseDown(select);
+    fireEvent.click(select);
+    fireEvent.click(screen.getByRole('option', { name: /name/i }));
+    expect(getTitles()).toEqual(['Alpha', 'Bravo', 'Charlie']);
+
+    fireEvent.mouseDown(select);
+    fireEvent.click(select);
+    fireEvent.click(screen.getByRole('option', { name: /edited/i }));
+    expect(getTitles()).toEqual(['Charlie', 'Bravo', 'Alpha']);
+
+    fireEvent.mouseDown(select);
+    fireEvent.click(select);
+    fireEvent.click(screen.getByRole('option', { name: /copied/i }));
+    expect(getTitles()).toEqual(['Alpha', 'Charlie', 'Bravo']);
+  });
 });
 
 describe('HistoryPanel action history', () => {

--- a/src/locales/bn-IN.json
+++ b/src/locales/bn-IN.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/da-DK.json
+++ b/src/locales/da-DK.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/de-AT.json
+++ b/src/locales/de-AT.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/el-GR.json
+++ b/src/locales/el-GR.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/en-PR.json
+++ b/src/locales/en-PR.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/es-AR.json
+++ b/src/locales/es-AR.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/et-EE.json
+++ b/src/locales/et-EE.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/fi-FI.json
+++ b/src/locales/fi-FI.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/fr-BE.json
+++ b/src/locales/fr-BE.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/ne-NP.json
+++ b/src/locales/ne-NP.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/ro-RO.json
+++ b/src/locales/ro-RO.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/th-TH.json
+++ b/src/locales/th-TH.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/uk-UA.json
+++ b/src/locales/uk-UA.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1125,5 +1125,10 @@
   "showAll": "Show all",
   "showFavoritesOnly": "Show favorites only",
   "rename": "Rename",
-  "title": "Title"
+  "title": "Title",
+  "sortBy": "Sort by",
+  "sortByName": "Name",
+  "sortByDate": "Date",
+  "sortByEdited": "Most Edited",
+  "sortByCopied": "Most Copied"
 }


### PR DESCRIPTION
## Summary
- add `sortMode` state to HistoryPanel with name, date, edited, and copied options
- introduce Shadcn Select for choosing sort order
- add sort option translations across locales and test coverage

## Testing
- `npm run lint` *(fails: Unexpected any in Dashboard tests)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e8826a108325920f7e262d56425f