### PR TITLE
fix(history): use timestamps for reliable sorting

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -165,12 +165,16 @@ const Dashboard = () => {
   const [showHistory, setShowHistory] = useState(false);
   const [history, setHistory] = useState<HistoryEntry[]>(() =>
     (safeGet<HistoryEntry[]>(JSON_HISTORY, [], true) ?? []).map((e) => ({
-      favorite: false,
-      title: e.title ?? getTitleFromJson(e.json),
-      editCount: e.editCount ?? 0,
-      copyCount: e.copyCount ?? 0,
-      ...e,
-    })),
+        favorite: false,
+        title: e.title ?? getTitleFromJson(e.json),
+        editCount: e.editCount ?? 0,
+        copyCount: e.copyCount ?? 0,
+        ...e,
+        date:
+          typeof e.date === 'number'
+            ? e.date
+            : new Date(e.date).getTime() || Date.now(),
+      })),
   );
   const isSingleColumn = useIsSingleColumn();
   const [darkMode, setDarkMode] = useDarkMode();
@@ -237,15 +241,15 @@ const Dashboard = () => {
     const success = await copy(jsonString, t('jsonCopied'));
     if (success) {
       setCopied(true);
-      const entry: HistoryEntry = {
-        id: Date.now(),
-        date: new Date().toLocaleString(),
-        json: jsonString,
-        favorite: false,
-        title: getTitleFromJson(jsonString),
-        editCount: 0,
-        copyCount: 0,
-      };
+        const entry: HistoryEntry = {
+          id: Date.now(),
+          date: Date.now(),
+          json: jsonString,
+          favorite: false,
+          title: getTitleFromJson(jsonString),
+          editCount: 0,
+          copyCount: 0,
+        };
       setHistory((prev) => [entry, ...prev].slice(0, 100));
       const opts = options as unknown as Record<string, unknown>;
       const sections = Object.keys(options).filter(
@@ -601,15 +605,15 @@ const Dashboard = () => {
    * Side effects: updates history state and logs analytics.
    */
   const importHistoryEntries = (entries: { json: string; title?: string }[]) => {
-    const mapped = entries.map(({ json, title }) => ({
-      id: Date.now() + Math.random(),
-      date: new Date().toLocaleString(),
-      json,
-      favorite: false,
-      title: title ?? getTitleFromJson(json),
-      editCount: 0,
-      copyCount: 0,
-    }));
+      const mapped = entries.map(({ json, title }) => ({
+        id: Date.now() + Math.random(),
+        date: Date.now(),
+        json,
+        favorite: false,
+        title: title ?? getTitleFromJson(json),
+        editCount: 0,
+        copyCount: 0,
+      }));
     setHistory((prev) => [...mapped, ...prev].slice(0, 100));
     trackEvent(trackingEnabled, AnalyticsEvent.HistoryImport, { type: 'bulk' });
   };

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -64,7 +64,11 @@ import {
 
 export interface HistoryEntry {
   id: number;
-  date: string;
+  /**
+   * Timestamp (ms since epoch) when the entry was created. Storing a numeric
+   * value avoids locale-dependent parsing issues.
+   */
+  date: number;
   json: string;
   favorite: boolean;
   title: string;
@@ -154,7 +158,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
           return b.copyCount - a.copyCount;
         case 'date':
         default:
-          return new Date(b.date).getTime() - new Date(a.date).getTime();
+          return b.date - a.date;
       }
     });
     return sorted;

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -14,15 +14,16 @@ import type { SoraOptions } from '@/lib/soraOptions';
 import { DEFAULT_OPTIONS } from '@/lib/defaultOptions';
 import { useSoraUserscript } from '@/hooks/use-sora-userscript';
 import { CURRENT_JSON, JSON_HISTORY } from '@/lib/storage-keys';
+import type { HistoryEntry } from '../HistoryPanel';
 
-let copyFn: ((entry: any) => void) | null = null;
+let copyFn: ((entry: HistoryEntry) => void) | null = null;
 let updateFn: ((opts: Partial<SoraOptions>) => void) | null = null;
 const mockUseDarkMode = jest.fn(() => [false, jest.fn()] as const);
 let sendFn: (() => void) | null = null;
 let resetFn: (() => void) | null = null;
 jest.mock('../HistoryPanel', () => ({
   __esModule: true,
-  default: ({ onCopy }: { onCopy: (entry: any) => void }) => {
+    default: ({ onCopy }: { onCopy: (entry: HistoryEntry) => void }) => {
     copyFn = onCopy;
     return null;
   },
@@ -233,15 +234,15 @@ describe('copyHistoryEntry', () => {
     render(<Dashboard />);
     await waitFor(() => expect(copyFn).not.toBeNull());
     await act(async () => {
-      copyFn?.({
-        id: 1,
-        date: 'd',
-        json: '{"a":1}',
-        favorite: false,
-        title: '',
-        editCount: 0,
-        copyCount: 0,
-      });
+        copyFn?.({
+          id: 1,
+          date: Date.now(),
+          json: '{"a":1}',
+          favorite: false,
+          title: '',
+          editCount: 0,
+          copyCount: 0,
+        });
       await Promise.resolve();
     });
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('{"a":1}');

--- a/src/components/__tests__/DashboardHistory.test.tsx
+++ b/src/components/__tests__/DashboardHistory.test.tsx
@@ -12,25 +12,26 @@ import { useTracking } from '@/hooks/use-tracking';
 import { useActionHistory } from '@/hooks/use-action-history';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics';
 import { JSON_HISTORY } from '@/lib/storage-keys';
+import type { HistoryEntry } from '../HistoryPanel';
 jest.mock('@/lib/validateOptions', () => ({
   __esModule: true,
   isValidOptions: jest.fn(() => true),
 }));
 
 let importFn: ((entries: { json: string; title?: string }[]) => void) | null = null;
-let copyFn: ((entry: any) => void) | null = null;
+let copyFn: ((entry: HistoryEntry) => void) | null = null;
 
 jest.mock('../HistoryPanel', () => ({
   __esModule: true,
-  default: ({
-    onImport,
-    onCopy,
-    onEdit,
-  }: {
-    onImport: (entries: { json: string; title?: string }[]) => void;
-    onCopy: (entry: any) => void;
-    onEdit: (entry: any) => void;
-  }) => {
+    default: ({
+      onImport,
+      onCopy,
+      onEdit,
+    }: {
+      onImport: (entries: { json: string; title?: string }[]) => void;
+      onCopy: (entry: HistoryEntry) => void;
+      onEdit: (entry: HistoryEntry) => void;
+    }) => {
     importFn = onImport;
     copyFn = onCopy;
     return null;
@@ -87,17 +88,17 @@ jest.mock('@/components/ui/sonner-toast', () => ({
   toast: { success: jest.fn(), error: jest.fn() },
 }));
 
-function createEntries(n: number) {
-  return Array.from({ length: n }, (_, i) => ({
-    id: i,
-    date: 'd',
-    json: '{}',
-    favorite: false,
-    title: `t${i}`,
-    editCount: 0,
-    copyCount: 0,
-  }));
-}
+  function createEntries(n: number) {
+    return Array.from({ length: n }, (_, i) => ({
+      id: i,
+      date: Date.now(),
+      json: '{}',
+      favorite: false,
+      title: `t${i}`,
+      editCount: 0,
+      copyCount: 0,
+    }));
+  }
 
 describe('Dashboard history limit', () => {
   beforeEach(() => {
@@ -148,15 +149,15 @@ describe('Dashboard history limit', () => {
   });
 
   test('increments copy counter', async () => {
-    const entry = {
-      id: 1,
-      date: 'd',
-      json: '{"prompt":"hi"}',
-      favorite: false,
-      title: 't1',
-      editCount: 0,
-      copyCount: 0,
-    };
+      const entry = {
+        id: 1,
+        date: Date.now(),
+        json: '{"prompt":"hi"}',
+        favorite: false,
+        title: 't1',
+        editCount: 0,
+        copyCount: 0,
+      };
     localStorage.setItem(JSON_HISTORY, JSON.stringify([entry]));
 
     render(<Dashboard />);

--- a/src/components/__tests__/HistoryPanel.test.tsx
+++ b/src/components/__tests__/HistoryPanel.test.tsx
@@ -101,7 +101,7 @@ jest.mock('@/components/ui/dropdown-menu', () => ({
 
 const sampleHistory = Array.from({ length: 20 }, (_, i) => ({
   id: i + 1,
-  date: 'd',
+  date: Date.now(),
   json: `{"prompt":"p${i}"}`,
   favorite: i % 2 === 0,
   title: `title${i}`,
@@ -316,35 +316,35 @@ describe('HistoryPanel basic actions', () => {
   });
 
   test('sorts history based on sort mode', () => {
-    const history = [
-      {
-        id: 1,
-        date: '2024-01-01',
-        json: '{"prompt":"b"}',
-        favorite: false,
-        title: 'Bravo',
-        editCount: 2,
-        copyCount: 1,
-      },
-      {
-        id: 2,
-        date: '2024-01-03',
-        json: '{"prompt":"a"}',
-        favorite: false,
-        title: 'Alpha',
-        editCount: 1,
-        copyCount: 3,
-      },
-      {
-        id: 3,
-        date: '2024-01-02',
-        json: '{"prompt":"c"}',
-        favorite: false,
-        title: 'Charlie',
-        editCount: 5,
-        copyCount: 2,
-      },
-    ];
+      const history = [
+        {
+          id: 1,
+          date: new Date('2024-01-01').getTime(),
+          json: '{"prompt":"b"}',
+          favorite: false,
+          title: 'Bravo',
+          editCount: 2,
+          copyCount: 1,
+        },
+        {
+          id: 2,
+          date: new Date('2024-01-03').getTime(),
+          json: '{"prompt":"a"}',
+          favorite: false,
+          title: 'Alpha',
+          editCount: 1,
+          copyCount: 3,
+        },
+        {
+          id: 3,
+          date: new Date('2024-01-02').getTime(),
+          json: '{"prompt":"c"}',
+          favorite: false,
+          title: 'Charlie',
+          editCount: 5,
+          copyCount: 2,
+        },
+      ];
     renderPanel({ history });
     const getTitles = () =>
       screen

--- a/src/components/history/HistoryItem.tsx
+++ b/src/components/history/HistoryItem.tsx
@@ -9,6 +9,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from '@/components/ui/tooltip';
+import { formatDateTime } from '@/lib/date';
 
 interface HistoryItemProps {
   entry: HistoryEntry;
@@ -38,9 +39,9 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
 
   return (
     <div className="border p-3 rounded-md space-y-2">
-      <div className="text-xs text-muted-foreground flex justify-between">
-        <span>{entry.date}</span>
-      </div>
+        <div className="text-xs text-muted-foreground flex justify-between">
+          <span>{formatDateTime(new Date(entry.date))}</span>
+        </div>
       <div className="space-y-1 text-xs text-muted-foreground">
         <div className="font-medium break-words text-foreground">
           {entry.title}


### PR DESCRIPTION
## Summary
- store history entry dates as numeric timestamps
- compare dates numerically to avoid locale parsing issues
- format stored timestamps for display

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1eaf959208325a962ccc9b81c0d9e